### PR TITLE
Fix PyPI release by removing local version identifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = { local_scheme = "no-local-version" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/holodeck"]


### PR DESCRIPTION
Configure hatch-vcs to use no-local-version scheme, preventing version strings like 0.1.4.dev0+g2055a70b6.d20251127 which PyPI rejects.