### PR TITLE
feat(config): add global MCP server merge into agent config (Phase 7)

### DIFF
--- a/specs/013-mcp-cli/tasks.md
+++ b/specs/013-mcp-cli/tasks.md
@@ -158,21 +158,21 @@
 
 ---
 
-## Phase 7: Config Merge Integration
+## Phase 7: Config Merge Integration ✅
 
 **Purpose**: Integrate global MCP servers into agent config loading
 
 ### Implementation for Config Merge
 
-- [ ] T033 Implement _merge_mcp_servers() method in src/holodeck/config/loader.py
-- [ ] T034 Extend merge_configs() to call _merge_mcp_servers() for global MCP server merging
-- [ ] T035 Add merge precedence logic (agent-level MCP tools override global with same name)
+- [x] T033 Implement _merge_mcp_servers() method in src/holodeck/config/loader.py
+- [x] T034 Extend merge_configs() to call _merge_mcp_servers() for global MCP server merging
+- [x] T035 Add merge precedence logic (agent-level MCP tools override global with same name)
 
 ### Tests for Config Merge
 
-- [ ] T035a [P] Add unit tests for _merge_mcp_servers() method in tests/unit/config/test_config_merge.py
-- [ ] T035b [P] Add unit tests for merge_configs() with MCP server merging in tests/unit/config/test_config_merge.py
-- [ ] T035c [P] Add unit tests for merge precedence logic (agent overrides global) in tests/unit/config/test_config_merge.py
+- [x] T035a [P] Add unit tests for _merge_mcp_servers() method in tests/unit/config/test_config_merge.py
+- [x] T035b [P] Add unit tests for merge_configs() with MCP server merging in tests/unit/config/test_config_merge.py
+- [x] T035c [P] Add unit tests for merge precedence logic (agent overrides global) in tests/unit/config/test_config_merge.py
 
 **Checkpoint**: Config merge integration complete and tested - global MCP servers merge into agent config at runtime
 


### PR DESCRIPTION
Resolves #162
Implement automatic merging of global MCP servers into agent configuration
at runtime. Agent-level tools take precedence over global servers with the
same name.

Changes:
- Add _merge_mcp_servers() method to ConfigLoader for merging global MCP
  servers into agent tools list
- Extend merge_configs() to call _merge_mcp_servers() when global config
  has MCP servers
- Add 11 unit tests for MCP server merging in test_loader.py
- Mark Phase 7 tasks as complete in tasks.md