### PR TITLE
feat(test-runner): loosen expected_tools validation to use substring matching

### DIFF
--- a/src/holodeck/cli/main.py
+++ b/src/holodeck/cli/main.py
@@ -17,10 +17,16 @@ os.environ.setdefault(
     "SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS", "true"
 )
 
+from importlib.metadata import PackageNotFoundError, version
+
 import click
 from dotenv import load_dotenv
 
-__version__ = "0.1.0"
+try:
+    __version__ = version("holodeck-ai")
+except PackageNotFoundError:
+    # Package not installed, development mode
+    __version__ = "0.0.0.dev0"
 
 
 def _load_dotenv_files() -> None:


### PR DESCRIPTION
Change tool call validation from exact set equality to substring matching.
This allows expected tool names like "search" to match actual tool names
like "vectorstore-search", making test assertions more flexible when tools
have prefixes or suffixes.

- Update validate_tool_calls to check if expected names are substrings
- Allow extra tools beyond expected (no longer fails on superset)
- Add tests for substring matching scenarios