### PR TITLE
feat(029): claude subagents, live chat panel, and per-backend docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,3 +211,10 @@ Always `source .venv/bin/activate` before Python commands.
 
 - Do NOT attribute Claude Code or include "Generated with Claude Code".
 - Conventional, focused on the change.
+
+## Active Technologies
+- Python 3.10+ + `claude-agent-sdk==0.1.44` (provides `AgentDefinition`, `ClaudeAgentOptions.agents`), Pydantic v2, PyYAML, Click (029-subagent-orchestration)
+- N/A (config-only feature; no persistent state) (029-subagent-orchestration)
+
+## Recent Changes
+- 029-subagent-orchestration: Added Python 3.10+ + `claude-agent-sdk==0.1.44` (provides `AgentDefinition`, `ClaudeAgentOptions.agents`), Pydantic v2, PyYAML, Click

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -81,15 +81,6 @@ Start an interactive multi-turn chat session with an agent.
       docstring_style: google
       show_source: true
 
-::: holodeck.cli.commands.chat.ChatSpinnerThread
-    options:
-      docstring_style: google
-      show_source: true
-      members:
-        - __init__
-        - run
-        - stop
-
 ::: holodeck.cli.commands.chat._run_chat_session
     options:
       docstring_style: google

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -70,7 +70,7 @@ All capabilities default to disabled (least-privilege).
       docstring_style: google
       show_source: true
 
-::: holodeck.models.claude_config.SubagentConfig
+::: holodeck.models.claude_config.SubagentSpec
     options:
       docstring_style: google
       show_source: true

--- a/docs/guides/agent-configuration.md
+++ b/docs/guides/agent-configuration.md
@@ -39,7 +39,7 @@ evaluations:                      # Optional: Quality metrics
 test_cases: []                    # Optional: Test scenarios
 ```
 
-> **Backend auto-selection**: HoloDeck automatically selects the execution backend based on the `provider` field. `anthropic` routes to the Claude Agent SDK backend; all other providers route to the Semantic Kernel backend.
+> **Backend auto-selection**: HoloDeck picks the execution backend from the `provider` field. `anthropic` routes to the [Claude Backend](claude-backend.md); everything else (`openai`, `azure_openai`, `ollama`) routes to the [Semantic Kernel Backend](semantic-kernel-backend.md). See those guides for backend-specific configuration.
 
 ## Agent Name
 
@@ -200,104 +200,9 @@ embedding_provider:
 
 ## Claude Agent SDK Settings
 
-When using `model.provider: anthropic`, you can configure Claude Agent SDK-specific capabilities via the `claude` section. All capabilities default to disabled (least-privilege).
+When using `model.provider: anthropic`, the agent.yaml accepts a top-level `claude:` section for backend-specific capabilities (permission modes, extended thinking, web search, subagents, bash, file_system, working_directory, max_turns, allowed_tools).
 
-### Permission Mode
-
-| Value | Description |
-|-------|-------------|
-| `manual` | Requires manual approval for all actions (default, safest) |
-| `acceptEdits` | Auto-approve file edits, manual approval for other actions |
-| `acceptAll` | Auto-approve all tool calls and actions |
-
-### Configuration Reference
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `permission_mode` | Enum | `manual` | Level of autonomous action |
-| `working_directory` | String | None | Scope file access to this path; subprocess cwd |
-| `max_turns` | Integer (>=1) | None (SDK default) | Maximum agent loop iterations |
-| `extended_thinking` | Object | None | Extended reasoning configuration |
-| `web_search` | Boolean | `false` | Enable built-in web search |
-| `bash` | Object | None | Shell command execution settings |
-| `file_system` | Object | None | File read/write/edit access |
-| `subagents` | Object | None | Parallel sub-agent execution |
-| `allowed_tools` | List[String] | None (all tools) | Explicit tool allowlist |
-
-### Extended Thinking
-
-Enable deep reasoning for complex tasks:
-
-```yaml
-claude:
-  extended_thinking:
-    enabled: true
-    budget_tokens: 10000  # 1,000 - 100,000
-```
-
-### Bash Access
-
-```yaml
-claude:
-  bash:
-    enabled: true
-    excluded_commands: ["rm", "shutdown"]  # Commands to block
-    allow_unsafe: false                    # Dangerous commands require explicit opt-in
-```
-
-### File System Access
-
-```yaml
-claude:
-  file_system:
-    read: true
-    write: true
-    edit: true
-```
-
-### Sub-agents
-
-```yaml
-claude:
-  subagents:
-    enabled: true
-    max_parallel: 4  # 1-16 parallel sub-agents
-```
-
-### Full Annotated Example
-
-```yaml
-claude:
-  permission_mode: acceptAll       # Auto-approve actions
-  working_directory: ./workspace   # Restrict file access
-  max_turns: 15                    # Limit agent loop iterations
-
-  extended_thinking:
-    enabled: true
-    budget_tokens: 20000           # Deep reasoning token budget
-
-  web_search: true                 # Enable web search
-
-  bash:
-    enabled: true
-    excluded_commands: ["rm -rf", "shutdown"]
-    allow_unsafe: false
-
-  file_system:
-    read: true
-    write: true
-    edit: true
-
-  subagents:
-    enabled: true
-    max_parallel: 8
-
-  allowed_tools:                   # Only expose these tools to the agent
-    - knowledge-base
-    - web-search
-```
-
-> **Note**: The `claude` section is ignored when using non-Anthropic providers.
+See [Claude Backend](claude-backend.md) for the full reference and examples. The `claude` block is ignored for non-Anthropic providers.
 
 ## Instructions
 

--- a/docs/guides/claude-backend.md
+++ b/docs/guides/claude-backend.md
@@ -1,0 +1,431 @@
+# Claude Backend
+
+The Claude backend runs your agent on top of the [Claude Agent SDK](https://docs.anthropic.com/en/api/agent-sdk) — Anthropic's first-class agent runtime. It is automatically selected when `model.provider: anthropic` is set in your agent configuration.
+
+This guide is for backend-specific behaviour: authentication, Claude Agent SDK capabilities (permission modes, extended thinking, web search, subagents, etc.), and the full configuration reference. For shared concepts like tools, observability, and vector stores, see the dedicated guides for each.
+
+## Quick start
+
+### Prerequisites
+
+- **Node.js 18+** — required by the Claude Agent SDK subprocess. Verify with `node --version`.
+- An Anthropic credential. The simplest is a Claude Code OAuth token (recommended for Claude Code users).
+
+### Minimal agent
+
+```yaml
+# agent.yaml
+name: my-claude-agent
+
+model:
+  provider: anthropic
+  name: claude-sonnet-4-20250514
+  auth_provider: oauth_token
+
+instructions:
+  inline: "You are a helpful assistant."
+```
+
+```bash
+# .env
+CLAUDE_CODE_OAUTH_TOKEN=your-oauth-token
+```
+
+Verify:
+
+```bash
+holodeck chat agent.yaml
+```
+
+## Advanced configuration
+
+All Claude-specific settings live under the top-level `claude:` block in `agent.yaml`. Every capability defaults to disabled (least-privilege).
+
+### Authentication providers
+
+The `auth_provider` field on `model` selects how HoloDeck authenticates with Anthropic. Defaults to `api_key` when omitted.
+
+| Method         | Env variables                                                              | Use case                                |
+|----------------|----------------------------------------------------------------------------|-----------------------------------------|
+| `api_key`      | `ANTHROPIC_API_KEY`                                                        | Direct API access (default)             |
+| `oauth_token`  | `CLAUDE_CODE_OAUTH_TOKEN`                                                  | Claude Code OAuth (recommended)         |
+| `bedrock`      | `AWS_REGION` (or `AWS_DEFAULT_REGION`) plus AWS credentials                | AWS Bedrock                             |
+| `vertex`       | `CLOUD_ML_REGION` plus `ANTHROPIC_VERTEX_PROJECT_ID` and Google credentials | Google Vertex AI                       |
+| `foundry`      | `ANTHROPIC_FOUNDRY_RESOURCE` or `ANTHROPIC_FOUNDRY_BASE_URL`               | Azure AI Foundry                        |
+
+**API key (default):**
+
+```yaml
+model:
+  provider: anthropic
+  name: claude-sonnet-4-20250514
+  auth_provider: api_key
+```
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+**OAuth token (recommended for Claude Code users):**
+
+```yaml
+model:
+  provider: anthropic
+  name: claude-sonnet-4-20250514
+  auth_provider: oauth_token
+```
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN="your-oauth-token"
+```
+
+**AWS Bedrock:**
+
+```yaml
+model:
+  provider: anthropic
+  name: claude-sonnet-4-20250514
+  auth_provider: bedrock
+```
+
+```bash
+export AWS_REGION=us-east-1
+# plus AWS credentials/profile (env vars, ~/.aws/credentials, or IAM role)
+```
+
+**Google Vertex AI:**
+
+```yaml
+model:
+  provider: anthropic
+  name: claude-sonnet-4-20250514
+  auth_provider: vertex
+```
+
+```bash
+export CLOUD_ML_REGION=us-east5
+export ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
+# plus Google credentials (GOOGLE_APPLICATION_CREDENTIALS or ADC)
+```
+
+**Azure AI Foundry:**
+
+```yaml
+model:
+  provider: anthropic
+  name: claude-sonnet-4-20250514
+  auth_provider: foundry
+```
+
+```bash
+export ANTHROPIC_FOUNDRY_RESOURCE=your-foundry-resource
+# or:
+export ANTHROPIC_FOUNDRY_BASE_URL=https://your-resource.services.ai.azure.com
+```
+
+Authentication is provided either via `ANTHROPIC_API_KEY` or the Azure credential chain.
+
+!!! note "Cloud routing is env-driven"
+    For `bedrock`, `vertex`, and `foundry`, HoloDeck sets the Claude Code subprocess flag (`CLAUDE_CODE_USE_BEDROCK=1`, `CLAUDE_CODE_USE_VERTEX=1`, `CLAUDE_CODE_USE_FOUNDRY=1`) based on `auth_provider`. `model.endpoint` is **not** consulted for these modes. Missing routing variables fail fast at startup with a configuration error.
+
+### Permission modes
+
+Controls how autonomously the agent can act:
+
+| Value          | Behaviour                                                          |
+|----------------|--------------------------------------------------------------------|
+| `manual`       | Manual approval for every action (default, safest)                 |
+| `acceptEdits`  | Auto-approve file edits; manual approval for other tool calls      |
+| `acceptAll`    | Auto-approve all tool calls and actions                            |
+
+```yaml
+claude:
+  permission_mode: acceptEdits
+```
+
+### Extended thinking
+
+Enable deep, internal reasoning before the agent responds:
+
+```yaml
+claude:
+  extended_thinking:
+    enabled: true
+    budget_tokens: 10000   # 1,000 - 100,000
+```
+
+`budget_tokens` caps how many tokens the agent can spend on hidden reasoning per turn.
+
+### Web search
+
+Built-in web search capability backed by the SDK:
+
+```yaml
+claude:
+  web_search: true
+```
+
+### Bash & file system scoping
+
+Both are off by default. Enable explicitly to grant access:
+
+```yaml
+claude:
+  bash:
+    enabled: true
+    excluded_commands: ["rm -rf", "shutdown"]
+    allow_unsafe: false              # dangerous commands require explicit opt-in
+
+  file_system:
+    read: true
+    write: true
+    edit: true
+```
+
+`working_directory` further scopes file access to a specific path (passed as the subprocess `cwd`):
+
+```yaml
+claude:
+  working_directory: ./workspace
+```
+
+### Subagents
+
+Define named subagents (a multi-agent team) under `claude.agents`. Each entry becomes an `AgentDefinition` registered with the SDK and is invocable by the parent via the `Task` tool.
+
+```yaml
+claude:
+  agents:
+    researcher:
+      description: Gathers raw information from the web and primary sources.
+      prompt: |
+        You are a meticulous researcher. Search the web for primary sources.
+        Cite every claim with a URL. Do not analyze — just gather facts.
+      tools: [WebSearch, WebFetch]
+      model: haiku
+    analyst:
+      description: Analyses data, identifies patterns, surfaces key insights.
+      prompt: |
+        You are a data analyst. Study the researcher's findings, identify
+        patterns and outliers, and summarise the key insights clearly.
+      tools: [Read]
+      model: sonnet
+    writer:
+      description: Produces a polished final report from analyst insights.
+      prompt: |
+        You are an expert technical writer. Use headers, bullets, and inline
+        citations. Do not conduct research yourself.
+      # No tools list → inherits all parent tools.
+      # No model → inherits parent model.
+```
+
+Per-subagent fields:
+
+| Field         | Type                                            | Required | Description                                                       |
+|---------------|-------------------------------------------------|----------|-------------------------------------------------------------------|
+| `description` | string                                          | yes      | Human-readable description used by the parent for routing         |
+| `prompt`      | string                                          | one of   | Inline system prompt for the subagent                             |
+| `prompt_file` | string                                          | one of   | Path to a file containing the prompt (mutually exclusive with `prompt`) |
+| `tools`       | list of strings                                 | no       | Allowlist of tool names; omit to inherit all parent tools         |
+| `model`       | `sonnet` \| `opus` \| `haiku` \| `inherit`      | no       | Model alias for this subagent; omit to inherit the parent's model |
+
+!!! warning "Subagent `model` must be a SDK alias"
+    Only `sonnet`, `opus`, `haiku`, or `inherit` are valid. Full model IDs like `claude-sonnet-4-20250514` are silently rejected by the Claude CLI — invalid values fail at config-load time with a clear error. Use `inherit` to track the parent's pinned full ID for version stability.
+
+### Working directory & max turns
+
+```yaml
+claude:
+  working_directory: ./workspace   # subprocess cwd; restricts file access
+  max_turns: 10                    # cap on agent loop iterations
+```
+
+### Allowed tools
+
+When set, only the listed tools are visible to the agent (in addition to any defined under the agent's top-level `tools:`):
+
+```yaml
+claude:
+  allowed_tools:
+    - knowledge-base
+    - web-search
+```
+
+### Embedding provider requirement
+
+Anthropic does not provide embedding models. When you combine `model.provider: anthropic` with **vectorstore** or **hierarchical_document** tools, you **must** define an `embedding_provider` at the agent level:
+
+```yaml
+embedding_provider:
+  provider: ollama
+  name: nomic-embed-text:latest
+  endpoint: http://localhost:11434
+
+# or:
+embedding_provider:
+  provider: openai
+  name: text-embedding-3-small
+```
+
+### Full annotated example
+
+```yaml
+# agent.yaml — full Claude-native agent
+name: research-assistant
+description: Research assistant powered by Claude
+
+model:
+  provider: anthropic
+  name: claude-sonnet-4-20250514
+  auth_provider: oauth_token
+  temperature: 0.3
+  max_tokens: 8000
+
+embedding_provider:
+  provider: ollama
+  name: nomic-embed-text:latest
+  endpoint: http://localhost:11434
+
+instructions:
+  inline: |
+    You are a research assistant.
+    Provide thorough, well-sourced answers.
+
+claude:
+  permission_mode: acceptEdits
+  working_directory: ./workspace
+  max_turns: 15
+
+  extended_thinking:
+    enabled: true
+    budget_tokens: 20000
+
+  web_search: true
+
+  bash:
+    enabled: true
+    excluded_commands: ["rm -rf", "shutdown"]
+    allow_unsafe: false
+
+  file_system:
+    read: true
+    write: true
+    edit: true
+
+  agents:
+    researcher:
+      description: Gathers raw information from the web.
+      prompt: "Search the web for primary sources. Cite every claim."
+      tools: [WebSearch, WebFetch]
+      model: haiku
+
+  allowed_tools:
+    - knowledge-base
+    - web-search
+
+tools:
+  - name: knowledge-base
+    type: vectorstore
+    description: Search the research knowledge base
+    source: ./data/research/
+```
+
+## Configuration reference
+
+### `model.*` fields
+
+| Field           | Type    | Required | Default     | Description                                                            |
+|-----------------|---------|----------|-------------|------------------------------------------------------------------------|
+| `provider`      | string  | yes      | -           | Must be `anthropic` to select the Claude backend                       |
+| `name`          | string  | yes      | -           | Anthropic model identifier (e.g. `claude-sonnet-4-20250514`)           |
+| `auth_provider` | enum    | no       | `api_key`   | One of `api_key`, `oauth_token`, `bedrock`, `vertex`, `foundry`        |
+| `temperature`   | float   | no       | `0.3`       | Randomness, `0.0`–`2.0`                                                |
+| `max_tokens`    | integer | no       | `1000`      | Maximum response tokens                                                |
+| `top_p`         | float   | no       | -           | Nucleus sampling, `0.0`–`1.0`                                          |
+| `api_key`       | string  | no       | -           | API key (when `auth_provider: api_key`); prefer `${ANTHROPIC_API_KEY}` |
+
+### `claude.*` fields
+
+| Field                | Type           | Default       | Description                                                              |
+|----------------------|----------------|---------------|--------------------------------------------------------------------------|
+| `permission_mode`    | enum           | `manual`      | `manual` \| `acceptEdits` \| `acceptAll`                                 |
+| `working_directory`  | string         | -             | Restrict file access; subprocess `cwd`                                   |
+| `max_turns`          | integer (≥1)   | SDK default   | Maximum agent loop iterations                                            |
+| `extended_thinking`  | object         | -             | `{ enabled: bool, budget_tokens: int }`                                  |
+| `web_search`         | boolean        | `false`       | Enable built-in web search                                               |
+| `bash`               | object         | -             | `{ enabled: bool, excluded_commands: [str], allow_unsafe: bool }`        |
+| `file_system`        | object         | -             | `{ read: bool, write: bool, edit: bool }`                                |
+| `agents`             | map<str, spec> | -             | Named subagents (see Subagents above)                                    |
+| `allowed_tools`      | list of strings | all tools    | Explicit tool allowlist                                                  |
+
+### Available models
+
+| Model                          | Description                                | Context window |
+|--------------------------------|--------------------------------------------|----------------|
+| `claude-sonnet-4-20250514`     | Best balance of speed and capability       | 200K tokens    |
+| `claude-opus-4-20250514`       | Most capable, best for complex tasks       | 200K tokens    |
+| `claude-3-5-sonnet-20241022`   | Previous-generation Sonnet                 | 200K tokens    |
+| `claude-3-5-haiku-20241022`    | Fast and cost-effective                    | 200K tokens    |
+
+Check [Anthropic's model documentation](https://docs.anthropic.com/en/docs/about-claude/models) for the latest list.
+
+### Anthropic environment variables
+
+| Variable                          | Auth provider           | Description                                       |
+|-----------------------------------|-------------------------|---------------------------------------------------|
+| `ANTHROPIC_API_KEY`               | `api_key`               | API authentication key                            |
+| `CLAUDE_CODE_OAUTH_TOKEN`         | `oauth_token`           | Claude Code OAuth token (recommended)             |
+| `AWS_REGION`                      | `bedrock`               | AWS Bedrock region                                |
+| `AWS_DEFAULT_REGION`              | `bedrock`               | Alternate AWS region variable                     |
+| `CLOUD_ML_REGION`                 | `vertex`                | Vertex region                                     |
+| `ANTHROPIC_VERTEX_PROJECT_ID`     | `vertex`                | Vertex project ID                                 |
+| `GCLOUD_PROJECT`                  | `vertex`                | Alternate Vertex project context                  |
+| `GOOGLE_CLOUD_PROJECT`            | `vertex`                | Alternate Vertex project context                  |
+| `GOOGLE_APPLICATION_CREDENTIALS`  | `vertex`                | Service-account credential file path              |
+| `ANTHROPIC_FOUNDRY_RESOURCE`      | `foundry`               | Foundry resource name                             |
+| `ANTHROPIC_FOUNDRY_BASE_URL`      | `foundry`               | Alternate Foundry base URL                        |
+
+## Troubleshooting
+
+### Cloud auth context missing
+
+**Error**: `AWS_REGION environment variable is not set for auth_provider: bedrock`
+**or**: `CLOUD_ML_REGION environment variable is not set for auth_provider: vertex`
+**or**: `Missing Foundry target for auth_provider: foundry`
+
+1. Confirm `model.provider: anthropic` and your selected `auth_provider`.
+2. Set the required routing variables (see the Authentication providers table above).
+3. `model.endpoint` is ignored for cloud auth modes — drop it.
+
+### Subagent not registering
+
+**Symptom**: The parent falls back to the `general-purpose` agent and your custom subagents (`researcher`, `analyst`, …) never appear.
+
+**Cause**: The Claude CLI silently drops `AgentDefinition`s whose `model` is outside `sonnet | opus | haiku | inherit`. Full model IDs are not accepted in the subagent slot.
+
+**Fix**: Use the SDK aliases in `claude.agents.<name>.model`, or omit `model` to inherit the parent's pinned model.
+
+### Embedding provider missing for Anthropic + vectorstore
+
+**Error**: HoloDeck refuses to start when `provider: anthropic` is combined with vectorstore/hierarchical_document tools but no `embedding_provider` is configured.
+
+**Fix**: Add an `embedding_provider` block (Ollama or OpenAI; see above).
+
+### Invalid API key
+
+**Error**: `AuthenticationError` or `Invalid API key`.
+
+1. Verify the key: `echo $ANTHROPIC_API_KEY`.
+2. Ensure no extra whitespace.
+3. For OAuth, regenerate via the Claude Code CLI.
+
+## Limitations
+
+- `holodeck serve` and container deployment do not currently support `provider: anthropic`. Both are planned in a future release. See [Agent Server](serve.md) and [Deployment](deployment.md) for the current SK-only support matrix.
+
+## Next steps
+
+- [Agent Configuration](agent-configuration.md) — full agent.yaml structure
+- [Tools](tools.md) — extending agent capabilities
+- [Observability](observability.md) — tracing and metrics
+- [Vector Stores](vector-stores.md) — semantic search configuration

--- a/docs/guides/llm-providers.md
+++ b/docs/guides/llm-providers.md
@@ -1,923 +1,109 @@
-# LLM Providers Guide
+# LLM Providers
 
-This guide explains how to configure LLM providers in HoloDeck for your AI agents.
+HoloDeck supports multiple LLM providers across two execution backends. Provider configuration can be defined at two levels:
 
-## Overview
+- **Global Configuration** (`config.yaml`): shared settings and credentials.
+- **Agent Configuration** (`agent.yaml`): per-agent model selection and overrides.
 
-HoloDeck supports multiple LLM providers, allowing you to choose the best model for your use case. Provider configuration can be defined at two levels:
+This page is an index. For setup, advanced features, and full configuration reference, follow the link to the matching backend.
 
-- **Global Configuration** (`config.yaml`): Shared settings and API credentials
-- **Agent Configuration** (`agent.yaml`): Per-agent model selection and overrides
+## Supported providers
 
-### Supported Providers
+| Provider       | Backend           | Description                                            |
+|----------------|-------------------|--------------------------------------------------------|
+| `anthropic`    | Claude Agent SDK  | Anthropic's Claude family (first-class)                |
+| `openai`       | Semantic Kernel   | OpenAI API (GPT-4o, GPT-4o-mini, etc.)                 |
+| `azure_openai` | Semantic Kernel   | Azure OpenAI Service (enterprise-deployed models)      |
+| `ollama`       | Semantic Kernel   | Local models via Ollama (Llama, Mistral, etc.)         |
 
-| Provider | Description | API Key Required |
-|----------|-------------|------------------|
-| `openai` | OpenAI API (GPT-4o, GPT-4o-mini, etc.) | Yes |
-| `azure_openai` | Azure OpenAI Service | Yes + Endpoint |
-| `anthropic` | Anthropic Claude models (native Claude Agent SDK) | Yes (multiple auth methods) |
-| `ollama` | Local models via Ollama | No (Endpoint required) |
+> **Backend auto-selection**: The `model.provider` field selects the backend automatically. `anthropic` routes to the Claude Agent SDK backend; everything else routes to the Semantic Kernel backend.
 
----
+## Choose a backend
 
-## Quick Start
+- **[Claude Backend](claude-backend.md)** — `provider: anthropic`. Quick start, authentication providers (api_key / oauth_token / bedrock / vertex / foundry), and Claude-specific capabilities like permission modes, extended thinking, web search, subagents, bash and file_system scoping.
+- **[Semantic Kernel Backend](semantic-kernel-backend.md)** — `provider: openai`, `azure_openai`, or `ollama`. Per-provider quick starts, the Azure deployment-name nuance, and Ollama context-size tuning.
 
-### Minimal Agent Configuration
-
-```yaml
-# agent.yaml
-name: my-agent
-
-model:
-  provider: openai
-  name: gpt-4o
-
-instructions:
-  inline: "You are a helpful assistant."
-```
-
-### Minimal Claude Agent
-
-```yaml
-# agent.yaml
-name: my-claude-agent
-
-model:
-  provider: anthropic
-  name: claude-sonnet-4-20250514
-  auth_provider: oauth_token  # Uses CLAUDE_CODE_OAUTH_TOKEN env var
-
-instructions:
-  inline: "You are a helpful assistant."
-```
-
-### With Global Configuration
-
-```yaml
-# config.yaml
-providers:
-  openai:
-    provider: openai
-    name: gpt-4o
-    api_key: ${OPENAI_API_KEY}
-```
-
-```yaml
-# agent.yaml
-name: my-agent
-
-model:
-  provider: openai
-  # Inherits name, api_key from config.yaml
-
-instructions:
-  inline: "You are a helpful assistant."
-```
-
----
-
-## Configuration Fields
+## Shared configuration fields
 
 All providers share these common fields:
 
-| Field | Type | Required | Default | Description |
-|-------|------|----------|---------|-------------|
-| `provider` | string | Yes | - | Provider identifier |
-| `name` | string | Yes | - | Model name/identifier |
-| `temperature` | float | No | 0.3 | Randomness (0.0-2.0) |
-| `max_tokens` | integer | No | 1000 | Maximum response tokens |
-| `top_p` | float | No | - | Nucleus sampling (0.0-1.0) |
-| `api_key` | string | No | - | API authentication key |
-| `endpoint` | string | Varies | - | API endpoint URL |
+| Field         | Type    | Required | Default | Description              |
+|---------------|---------|----------|---------|--------------------------|
+| `provider`    | string  | yes      | -       | Provider identifier      |
+| `name`        | string  | yes      | -       | Model name / identifier  |
+| `temperature` | float   | no       | `0.3`   | Randomness (`0.0`–`2.0`) |
+| `max_tokens`  | integer | no       | `1000`  | Maximum response tokens  |
+| `top_p`       | float   | no       | -       | Nucleus sampling         |
+| `api_key`     | string  | varies   | -       | API authentication key   |
+| `endpoint`    | string  | varies   | -       | API endpoint URL         |
 
 ### Temperature
 
 Controls response randomness:
 
-- **0.0**: Deterministic, focused responses
-- **0.3**: Default, balanced
-- **0.7**: More creative
-- **1.0+**: Highly creative/random
+- `0.0` — deterministic, focused.
+- `0.3` — default, balanced.
+- `0.7` — more creative.
+- `1.0+` — highly creative / random.
 
 ```yaml
 model:
-  temperature: 0.5  # Moderately creative
-```
-
-### Max Tokens
-
-Limits response length. Set based on your use case:
-
-```yaml
-model:
-  max_tokens: 2000  # Allow longer responses
-```
-
-### Top P (Nucleus Sampling)
-
-Alternative to temperature for controlling randomness. While both can be used simultaneously, it's recommended to adjust one or the other for more predictable results:
-
-```yaml
-model:
-  top_p: 0.9  # Consider top 90% probability tokens
-```
-
----
-
-## OpenAI
-
-OpenAI provides GPT-4o, GPT-4o-mini, and other models through their API.
-
-### Prerequisites
-
-1. Create an account at [platform.openai.com](https://platform.openai.com)
-2. Generate an API key in the [API Keys section](https://platform.openai.com/api-keys)
-3. Set up billing in your account
-
-### Configuration
-
-**Global Configuration (Recommended):**
-
-```yaml
-# config.yaml
-providers:
-  openai:
-    provider: openai
-    name: gpt-4o
-    temperature: 0.3
-    max_tokens: 2000
-    api_key: ${OPENAI_API_KEY}
-```
-
-**Agent Configuration:**
-
-```yaml
-# agent.yaml
-name: my-agent
-
-model:
-  provider: openai
-  name: gpt-4o
-  temperature: 0.7
-  max_tokens: 4000
-
-instructions:
-  inline: "You are a helpful assistant."
-```
-
-### Environment Variables
-
-```bash
-# .env
-OPENAI_API_KEY=sk-...
-```
-
-### Available Models
-
-| Model | Description | Context Window |
-|-------|-------------|----------------|
-| `gpt-4o` | Most capable, multimodal | 128K tokens |
-| `gpt-4o-mini` | Fast and cost-effective | 128K tokens |
-| `gpt-4-turbo` | Previous generation flagship | 128K tokens |
-| `gpt-3.5-turbo` | Fast, lower cost | 16K tokens |
-
-### Complete Example
-
-```yaml
-# config.yaml
-providers:
-  openai:
-    provider: openai
-    name: gpt-4o
-    api_key: ${OPENAI_API_KEY}
-
-  openai-fast:
-    provider: openai
-    name: gpt-4o-mini
-    api_key: ${OPENAI_API_KEY}
-```
-
-```yaml
-# agent.yaml
-name: support-agent
-description: Customer support with GPT-4o
-
-model:
-  provider: openai
-  name: gpt-4o
   temperature: 0.5
+```
+
+### Max tokens
+
+```yaml
+model:
   max_tokens: 2000
-
-instructions:
-  inline: |
-    You are a customer support specialist.
-    Be helpful, accurate, and professional.
 ```
 
----
+### Top P (nucleus sampling)
 
-## Azure OpenAI
+```yaml
+model:
+  top_p: 0.9
+```
 
-Azure OpenAI Service provides OpenAI models through Microsoft Azure with enterprise features.
+Use either `temperature` or `top_p`, not both, for predictable behaviour.
 
-### Prerequisites
+## Multi-provider setup
 
-1. Azure subscription with Azure OpenAI access
-2. Create an Azure OpenAI resource in the [Azure Portal](https://portal.azure.com)
-3. Deploy a model in Azure OpenAI Studio
-4. Note your endpoint URL and API key
-
-### Configuration
-
-Azure OpenAI requires both an `endpoint` and `api_key`:
-
-**Global Configuration (Recommended):**
+Configure multiple providers at the global level so different agents (or different evaluation models) can pick from the same set:
 
 ```yaml
 # config.yaml
 providers:
-  azure_openai:
-    provider: azure_openai
-    name: gpt-4o
-    endpoint: ${AZURE_OPENAI_ENDPOINT}
-    api_key: ${AZURE_OPENAI_API_KEY}
-    temperature: 0.3
-    max_tokens: 2000
-```
-
-**Agent Configuration:**
-
-```yaml
-# agent.yaml
-name: enterprise-agent
-
-model:
-  provider: azure_openai
-  name: gpt-4o  # Must match your Azure deployment name
-  endpoint: https://my-resource.openai.azure.com/
-  temperature: 0.5
-
-instructions:
-  inline: "You are an enterprise assistant."
-```
-
-### Environment Variables
-
-```bash
-# .env
-AZURE_OPENAI_ENDPOINT=https://your-resource-name.openai.azure.com/
-AZURE_OPENAI_API_KEY=your-api-key-here
-```
-
-### Endpoint Format
-
-The endpoint URL follows this pattern:
-
-```
-https://{resource-name}.openai.azure.com/
-```
-
-Find your endpoint in:
-
-1. Azure Portal > Your OpenAI Resource > Keys and Endpoint
-2. Azure OpenAI Studio > Deployments > Your Deployment
-
-### Understanding Azure Deployment Names
-
-> **Important**: In Azure OpenAI, the `name` field refers to your **deployment name**, not the base model name. This is different from OpenAI's API.
-
-When you deploy a model in Azure OpenAI Studio, you create a deployment with a custom name:
-
-1. **Base Model**: The underlying model (e.g., `gpt-4o`, `gpt-4o-mini`)
-2. **Deployment Name**: Your custom identifier (e.g., `my-gpt4o`, `prod-gpt4`)
-
-The `name` field in HoloDeck must match your **deployment name**:
-
-```yaml
-# If your Azure deployment is named "my-gpt4o-production"
-# backed by the gpt-4o base model:
-
-model:
-  provider: azure_openai
-  name: my-gpt4o-production  # Must match deployment name exactly
-  endpoint: https://my-resource.openai.azure.com/
-```
-
-**Common Mistake:**
-
-```yaml
-# WRONG - Using base model name
-model:
-  provider: azure_openai
-  name: gpt-4o  # This won't work unless your deployment is literally named "gpt-4o"
-
-# CORRECT - Using your deployment name
-model:
-  provider: azure_openai
-  name: my-gpt4o-deployment  # Your actual deployment name
-```
-
-> **Tip for OpenAI Users**: If you're transitioning from OpenAI to Azure, remember that Azure adds this extra layer of indirection. Your deployment name can be anything, but it must be specified exactly in the configuration.
-
-### Available Models
-
-Azure OpenAI offers the same models as OpenAI, deployed to your resource:
-
-| Model | Azure Deployment | Description |
-|-------|------------------|-------------|
-| GPT-4o | Deploy in Azure | Most capable |
-| GPT-4o-mini | Deploy in Azure | Cost-effective |
-| GPT-4 | Deploy in Azure | Previous flagship |
-| GPT-3.5-Turbo | Deploy in Azure | Fast, lower cost |
-
-### Complete Example
-
-```yaml
-# config.yaml
-providers:
-  azure_openai:
-    provider: azure_openai
-    name: gpt-4o-deployment
-    endpoint: ${AZURE_OPENAI_ENDPOINT}
-    api_key: ${AZURE_OPENAI_API_KEY}
-    temperature: 0.3
-    max_tokens: 2000
-```
-
-```yaml
-# agent.yaml
-name: enterprise-support
-description: Enterprise support agent on Azure
-
-model:
-  provider: azure_openai
-  name: gpt-4o-deployment
-  temperature: 0.5
-  max_tokens: 4000
-
-instructions:
-  file: prompts/enterprise-support.txt
-
-evaluations:
-  model:
-    provider: azure_openai
-    name: gpt-4o-deployment
-  metrics:
-    - metric: f1_score
-      threshold: 0.8
-```
-
----
-
-## Anthropic
-
-Anthropic provides the Claude family of models through the native Claude Agent SDK backend. Claude is a first-class citizen in HoloDeck with deep integration for agentic capabilities.
-
-### Prerequisites
-
-1. Create an account at [console.anthropic.com](https://console.anthropic.com) or obtain a Claude Code OAuth token
-2. **Node.js 18+** — required for the Claude Agent SDK subprocess. Check with `node --version`
-3. Set up authentication (see below)
-
-### Authentication Methods
-
-The `auth_provider` field on the model config selects how HoloDeck authenticates with Anthropic. Defaults to `api_key` if not specified.
-
-#### API Key (Default)
-
-```yaml
-model:
-  provider: anthropic
-  name: claude-sonnet-4-20250514
-  auth_provider: api_key  # Default, can be omitted
-```
-
-```bash
-export ANTHROPIC_API_KEY="sk-ant-..."
-```
-
-#### OAuth Token (Recommended)
-
-Recommended for Claude Code users. Uses the same OAuth token as the Claude Code CLI.
-
-```yaml
-model:
-  provider: anthropic
-  name: claude-sonnet-4-20250514
-  auth_provider: oauth_token
-```
-
-```bash
-export CLAUDE_CODE_OAUTH_TOKEN="your-oauth-token"
-```
-
-#### AWS Bedrock
-
-```yaml
-model:
-  provider: anthropic
-  name: claude-sonnet-4-20250514
-  auth_provider: bedrock
-```
-
-Requires AWS auth context and region. At minimum:
-
-```bash
-export AWS_REGION=us-east-1
-# or: export AWS_DEFAULT_REGION=us-east-1
-# plus AWS credentials/profile (for example via env vars, ~/.aws/credentials, or IAM role)
-```
-
-#### Google Vertex AI
-
-```yaml
-model:
-  provider: anthropic
-  name: claude-sonnet-4-20250514
-  auth_provider: vertex
-```
-
-Requires Vertex project and region context. Recommended:
-
-```bash
-export CLOUD_ML_REGION=us-east5
-export ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
-# plus Google credentials (for example GOOGLE_APPLICATION_CREDENTIALS or ADC)
-```
-
-#### Foundry
-
-```yaml
-model:
-  provider: anthropic
-  name: claude-sonnet-4-20250514
-  auth_provider: foundry
-```
-
-Requires a Foundry target via one of:
-
-```bash
-export ANTHROPIC_FOUNDRY_RESOURCE=your-foundry-resource
-# or
-export ANTHROPIC_FOUNDRY_BASE_URL=https://your-resource.services.ai.azure.com
-```
-
-Authentication can be provided via `ANTHROPIC_API_KEY` or Azure credential chain.
-
-### Cloud Auth Context (Bedrock/Vertex/Foundry)
-
-For `provider: anthropic`, cloud routing is driven by environment variables consumed by the Claude Code subprocess.
-
-- HoloDeck uses `auth_provider` to set the Claude Code mode flag:
-  - `bedrock` → `CLAUDE_CODE_USE_BEDROCK=1`
-  - `vertex` → `CLAUDE_CODE_USE_VERTEX=1`
-  - `foundry` → `CLAUDE_CODE_USE_FOUNDRY=1`
-- `model.endpoint` is **not** used for Anthropic cloud auth modes.
-- If required cloud routing variables are missing, HoloDeck fails fast at startup with a clear configuration error.
-
-### Configuration
-
-**Global Configuration (Recommended):**
-
-```yaml
-# config.yaml
-providers:
-  anthropic:
-    provider: anthropic
-    name: claude-sonnet-4-20250514
-    temperature: 0.3
-    max_tokens: 4000
-    api_key: ${ANTHROPIC_API_KEY}
-```
-
-**Agent Configuration:**
-
-```yaml
-# agent.yaml
-name: claude-agent
-
-model:
-  provider: anthropic
-  name: claude-sonnet-4-20250514
-  auth_provider: oauth_token
-  temperature: 0.5
-  max_tokens: 4000
-
-instructions:
-  inline: "You are Claude, a helpful AI assistant."
-```
-
-### Environment Variables
-
-```bash
-# .env — choose one authentication method
-
-# API Key (default)
-ANTHROPIC_API_KEY=sk-ant-...
-
-# OAuth Token (recommended for Claude Code users)
-CLAUDE_CODE_OAUTH_TOKEN=your-oauth-token
-
-# AWS Bedrock (auth_provider: bedrock)
-AWS_REGION=us-east-1
-# AWS_DEFAULT_REGION also supported
-
-# Google Vertex AI (auth_provider: vertex)
-CLOUD_ML_REGION=us-east5
-ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
-# Alternative project context vars: GCLOUD_PROJECT / GOOGLE_CLOUD_PROJECT
-
-# Azure AI Foundry (auth_provider: foundry)
-ANTHROPIC_FOUNDRY_RESOURCE=your-foundry-resource
-# or
-ANTHROPIC_FOUNDRY_BASE_URL=https://your-resource.services.ai.azure.com
-```
-
-### Available Models
-
-| Model | Description | Context Window |
-|-------|-------------|----------------|
-| `claude-sonnet-4-20250514` | Best balance of speed and capability | 200K tokens |
-| `claude-opus-4-20250514` | Most capable, best for complex tasks | 200K tokens |
-| `claude-3-5-sonnet-20241022` | Previous generation Sonnet | 200K tokens |
-| `claude-3-5-haiku-20241022` | Fast and cost-effective | 200K tokens |
-
-> **Note**: Model identifiers include version dates (e.g., `20250514`). Check [Anthropic's documentation](https://docs.anthropic.com/en/docs/about-claude/models) for the latest available models and their capabilities.
-
-### Claude Agent SDK Features
-
-The Claude backend supports advanced agentic capabilities configured via the `claude` section in `agent.yaml`. All capabilities default to disabled (least-privilege).
-
-**Extended Thinking** — Enable deep reasoning for complex tasks:
-
-```yaml
-claude:
-  extended_thinking:
-    enabled: true
-    budget_tokens: 10000  # 1,000 - 100,000
-```
-
-**Sub-agents** — Run parallel sub-agent tasks:
-
-```yaml
-claude:
-  subagents:
-    enabled: true
-    max_parallel: 8
-```
-
-**Web Search** — Built-in web search capability:
-
-```yaml
-claude:
-  web_search: true
-```
-
-**Bash & File System** — Shell and file access:
-
-```yaml
-claude:
-  bash:
-    enabled: true
-    excluded_commands: ["rm -rf"]
-  file_system:
-    read: true
-    write: true
-    edit: true
-```
-
-See the [Claude Agent SDK Settings](agent-configuration.md#claude-agent-sdk-settings) section in the Agent Configuration Guide for the full reference.
-
-### Embedding Provider Requirement
-
-!!! warning "Anthropic does not provide embedding models"
-    When using `model.provider: anthropic` with **vectorstore** or **hierarchical_document** tools, you **must** define an `embedding_provider` at the agent level. Anthropic cannot generate embeddings natively.
-
-```yaml
-# Required when using vectorstore/hierarchical_document tools with Anthropic
-embedding_provider:
-  provider: ollama
-  name: nomic-embed-text:latest
-  endpoint: http://localhost:11434
-
-# Or using OpenAI
-embedding_provider:
-  provider: openai
-  name: text-embedding-3-small
-```
-
-See [Embedding Provider](agent-configuration.md#embedding-provider) in the Agent Configuration Guide.
-
-### Complete Example
-
-```yaml
-# config.yaml
-providers:
-  anthropic:
-    provider: anthropic
-    name: claude-sonnet-4-20250514
-    api_key: ${ANTHROPIC_API_KEY}
-
-  anthropic-fast:
-    provider: anthropic
-    name: claude-3-5-haiku-20241022
-    api_key: ${ANTHROPIC_API_KEY}
-```
-
-```yaml
-# agent.yaml — full Claude-native agent
-name: research-assistant
-description: Research assistant powered by Claude
-
-model:
-  provider: anthropic
-  name: claude-sonnet-4-20250514
-  auth_provider: oauth_token
-  temperature: 0.3
-  max_tokens: 8000
-
-# Required for vectorstore tools with Anthropic
-embedding_provider:
-  provider: ollama
-  name: nomic-embed-text:latest
-  endpoint: http://localhost:11434
-
-instructions:
-  inline: |
-    You are a research assistant.
-    Provide thorough, well-sourced answers.
-    Be accurate and cite relevant information.
-
-# Claude Agent SDK settings
-claude:
-  permission_mode: acceptAll
-  max_turns: 10
-  extended_thinking:
-    enabled: true
-    budget_tokens: 10000
-  web_search: true
-
-tools:
-  - name: knowledge-base
-    type: vectorstore
-    description: Search the research knowledge base
-    source: ./data/research/
-```
-
----
-
-## Ollama
-
-Ollama enables running open-source LLMs locally on your machine. This is ideal for privacy-sensitive applications, offline deployments, and avoiding API costs.
-
-### Benefits of Ollama
-
-- **Privacy**: Data never leaves your machine
-- **No API Costs**: Run unlimited queries without usage fees
-- **Offline Support**: Works without internet connection
-- **Open-Source Models**: Access to Llama, Mistral, CodeLlama, and more
-
-### Prerequisites
-
-1. Install Ollama from [ollama.com](https://ollama.com)
-
-   **macOS/Linux:**
-   ```bash
-   curl -fsSL https://ollama.com/install.sh | sh
-   ```
-
-   **Windows:**
-   Download from [ollama.com/download](https://ollama.com/download)
-
-2. Pull a model:
-   ```bash
-   ollama pull llama3.2
-   ```
-
-3. Verify Ollama is running:
-   ```bash
-   ollama list
-   ```
-
-### Configuration
-
-Ollama requires an `endpoint` pointing to your local Ollama server:
-
-**Global Configuration (Recommended):**
-
-```yaml
-# config.yaml
-providers:
-  ollama:
-    provider: ollama
-    name: llama3.2
-    endpoint: http://localhost:11434
-    temperature: 0.7
-    max_tokens: 2000
-```
-
-**Agent Configuration:**
-
-```yaml
-# agent.yaml
-name: local-agent
-
-model:
-  provider: ollama
-  name: llama3.2
-  endpoint: http://localhost:11434
-  temperature: 0.5
-
-instructions:
-  inline: "You are a helpful local assistant."
-```
-
-### Environment Variables
-
-```bash
-# .env (optional - for custom endpoint)
-OLLAMA_ENDPOINT=http://localhost:11434
-```
-
-### Available Models
-
-Pull models with `ollama pull <model-name>`:
-
-| Model | Command | Description | Size |
-|-------|---------|-------------|------|
-| GPT-OSS (20B) | `ollama pull gpt-oss:20b` | Recommended completion model | 40GB |
-| Nomic Embed Text | `ollama pull nomic-embed-text:latest` | Recommended embedding model | 274MB |
-| Llama 3.2 | `ollama pull llama3.2` | Meta's latest, general purpose | 2GB |
-| Llama 3.2 (3B) | `ollama pull llama3.2:3b` | Larger Llama variant | 5GB |
-| Mistral | `ollama pull mistral` | Fast and capable | 4GB |
-| CodeLlama | `ollama pull codellama` | Optimized for code | 4GB |
-| Phi-3 | `ollama pull phi3` | Microsoft's compact model | 2GB |
-| Gemma 2 | `ollama pull gemma2` | Google's open model | 5GB |
-
-> **Tip**: Run `ollama list` to see your installed models.
-
-### Running Ollama as a Service
-
-For production use, run Ollama as a background service:
-
-**Start Ollama server:**
-```bash
-ollama serve
-```
-
-**Or with Docker:**
-```bash
-docker run -d \
-  --name ollama \
-  -p 11434:11434 \
-  -v ollama-data:/root/.ollama \
-  ollama/ollama
-```
-
-### Context Size Configuration
-
-For agent workloads, we recommend configuring a context size of at least **16k tokens**. By default, Ollama models may use smaller context windows which can limit agent capabilities.
-
-**Create a custom model with extended context:**
-
-```bash
-# Create a Modelfile with extended context
-cat <<EOF > Modelfile
-FROM gpt-oss:20b
-PARAMETER num_ctx 16384
-EOF
-
-# Create the custom model
-ollama create gpt-oss:20b-16k -f Modelfile
-```
-
-**For larger context needs (32k):**
-
-```bash
-cat <<EOF > Modelfile
-FROM gpt-oss:20b
-PARAMETER num_ctx 32768
-EOF
-
-ollama create gpt-oss:20b-32k -f Modelfile
-```
-
-**Use the custom model in your configuration:**
-
-```yaml
-model:
-  provider: ollama
-  name: gpt-oss:20b-16k  # or gpt-oss:20b-32k for larger context
-  endpoint: http://localhost:11434
-```
-
-> **Note**: Larger context sizes require more memory. A 32k context with a 20B parameter model may require 48GB+ RAM or a GPU with 16GB+ VRAM.
-
-### Complete Example
-
-```yaml
-# config.yaml
-providers:
-  ollama:
-    provider: ollama
-    name: llama3.2
-    endpoint: ${OLLAMA_ENDPOINT}
-    temperature: 0.7
-
-  ollama-code:
-    provider: ollama
-    name: codellama
-    endpoint: ${OLLAMA_ENDPOINT}
-    temperature: 0.2
-```
-
-```yaml
-# agent.yaml
-name: local-assistant
-description: Privacy-focused local assistant
-
-model:
-  provider: ollama
-  name: llama3.2
-  temperature: 0.5
-  max_tokens: 4000
-
-instructions:
-  inline: |
-    You are a helpful assistant running locally.
-    All data stays on this machine for privacy.
-```
-
-### Troubleshooting Ollama
-
-**Error:** `endpoint is required for ollama provider`
-
-**Solution:** Always include the endpoint:
-```yaml
-model:
-  provider: ollama
-  name: llama3.2
-  endpoint: http://localhost:11434
-```
-
-**Error:** `Connection refused`
-
-**Solutions:**
-1. Verify Ollama is running: `ollama list`
-2. Start the server: `ollama serve`
-3. Check the endpoint URL matches your setup
-
-**Error:** `Model not found`
-
-**Solution:** Pull the model first:
-```bash
-ollama pull llama3.2
-```
-
----
-
-## Multi-Provider Setup
-
-Configure multiple providers to use different models for different purposes:
-
-```yaml
-# config.yaml
-providers:
-  # Primary provider for agents
   openai:
     provider: openai
     name: gpt-4o
     api_key: ${OPENAI_API_KEY}
     temperature: 0.3
 
-  # Fast provider for evaluations
   openai-fast:
     provider: openai
     name: gpt-4o-mini
     api_key: ${OPENAI_API_KEY}
     temperature: 0.0
 
-  # Enterprise provider
   azure:
     provider: azure_openai
     name: gpt-4o-deployment
     endpoint: ${AZURE_OPENAI_ENDPOINT}
     api_key: ${AZURE_OPENAI_API_KEY}
 
-  # Alternative provider
   anthropic:
     provider: anthropic
     name: claude-sonnet-4-20250514
     api_key: ${ANTHROPIC_API_KEY}
 
-  # Local provider (no API costs, privacy-focused)
   ollama:
     provider: ollama
     name: llama3.2
     endpoint: ${OLLAMA_ENDPOINT}
 ```
 
-Use different providers in your agent:
+Use them in an agent:
 
 ```yaml
 # agent.yaml
@@ -930,49 +116,46 @@ model:
 evaluations:
   model:
     provider: openai
-    name: gpt-4o-mini  # Use faster model for evaluations
+    name: gpt-4o-mini   # cheaper / faster eval model
   metrics:
     - metric: f1_score
       threshold: 0.8
 ```
 
----
+## Security best practices
 
-## Security Best Practices
-
-### Never Commit API Keys
+### Never commit API keys
 
 ```yaml
-# WRONG - Never do this
+# WRONG
 providers:
   openai:
-    api_key: sk-abc123...  # Exposed secret!
+    api_key: sk-abc123...
 
-# CORRECT - Use environment variables
+# CORRECT
 providers:
   openai:
     api_key: ${OPENAI_API_KEY}
 ```
 
-### Use .env Files
+### Use `.env` files
 
-Create a `.env` file (add to `.gitignore`):
+Add `.env` to `.gitignore`:
 
 ```bash
-# .env - DO NOT COMMIT
+# .env — DO NOT COMMIT
 OPENAI_API_KEY=sk-...
 AZURE_OPENAI_ENDPOINT=https://...
 AZURE_OPENAI_API_KEY=...
 ANTHROPIC_API_KEY=sk-ant-...
+CLAUDE_CODE_OAUTH_TOKEN=...
 OLLAMA_ENDPOINT=http://localhost:11434
 ```
 
-### Create Example Files
-
-Commit a template for other developers:
+Commit a template (`.env.example`) for collaborators:
 
 ```bash
-# .env.example - Safe to commit
+# .env.example — Safe to commit
 OPENAI_API_KEY=your-openai-api-key-here
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
 AZURE_OPENAI_API_KEY=your-azure-api-key-here
@@ -980,109 +163,12 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 OLLAMA_ENDPOINT=http://localhost:11434
 ```
 
----
+## Next steps
 
-## Troubleshooting
-
-### Invalid API Key
-
-**Error:** `AuthenticationError` or `Invalid API key`
-
-**Solutions:**
-
-1. Verify your API key is correct
-2. Check environment variable is set: `echo $OPENAI_API_KEY`
-3. Ensure no extra whitespace in the key
-4. Regenerate the API key if needed
-
-### Anthropic Cloud Auth Context Missing
-
-**Error:** `AWS_REGION environment variable is not set for auth_provider: bedrock`
-**or:** `CLOUD_ML_REGION environment variable is not set for auth_provider: vertex`
-**or:** `Missing Foundry target for auth_provider: foundry`
-
-**Solutions:**
-
-1. Confirm `model.provider: anthropic` and the selected `auth_provider` are correct.
-2. Set the required routing env vars for your auth mode:
-   - Bedrock: `AWS_REGION`
-   - Vertex: `CLOUD_ML_REGION` plus project context (`ANTHROPIC_VERTEX_PROJECT_ID` recommended)
-   - Foundry: `ANTHROPIC_FOUNDRY_RESOURCE` or `ANTHROPIC_FOUNDRY_BASE_URL`
-3. Remember: `model.endpoint` is ignored for Anthropic cloud auth.
-
-### Azure Endpoint Issues
-
-**Error:** `endpoint is required for azure_openai provider`
-
-**Solution:** Include the endpoint in your configuration:
-
-```yaml
-model:
-  provider: azure_openai
-  name: my-deployment
-  endpoint: https://my-resource.openai.azure.com/
-```
-
-### Model Not Found
-
-**Error:** `Model not found` or `Deployment not found`
-
-**Solutions:**
-
-- **OpenAI**: Check the model name is valid (e.g., `gpt-4o`, not `gpt4o`)
-- **Azure**: Ensure `name` matches your deployment name exactly
-- **Anthropic**: Use full model identifier (e.g., `claude-sonnet-4-20250514`)
-
-### Rate Limits
-
-**Error:** `Rate limit exceeded`
-
-**Solutions:**
-
-1. Implement retry logic with exponential backoff
-2. Reduce `max_tokens` to use fewer tokens
-3. Use a faster/cheaper model for testing
-4. Upgrade your API plan
-
-### Temperature Out of Range
-
-**Error:** `temperature must be between 0.0 and 2.0`
-
-**Solution:** Use a value between 0.0 and 2.0:
-
-```yaml
-model:
-  temperature: 0.7  # Valid
-```
-
----
-
-## Environment Variable Reference
-
-| Variable | Provider | Description |
-|----------|----------|-------------|
-| `OPENAI_API_KEY` | OpenAI | API authentication key |
-| `AZURE_OPENAI_ENDPOINT` | Azure OpenAI | Resource endpoint URL |
-| `AZURE_OPENAI_API_KEY` | Azure OpenAI | API authentication key |
-| `ANTHROPIC_API_KEY` | Anthropic | API authentication key (`auth_provider: api_key`) |
-| `CLAUDE_CODE_OAUTH_TOKEN` | Anthropic | OAuth token (`auth_provider: oauth_token`, recommended) |
-| `AWS_REGION` | Anthropic Bedrock | AWS Bedrock region (`auth_provider: bedrock`) |
-| `AWS_DEFAULT_REGION` | Anthropic Bedrock | Alternate AWS region variable |
-| `CLOUD_ML_REGION` | Anthropic Vertex | Vertex region (`auth_provider: vertex`) |
-| `ANTHROPIC_VERTEX_PROJECT_ID` | Anthropic Vertex | Vertex project ID (`auth_provider: vertex`) |
-| `GCLOUD_PROJECT` | Anthropic Vertex | Alternate Vertex project context |
-| `GOOGLE_CLOUD_PROJECT` | Anthropic Vertex | Alternate Vertex project context |
-| `GOOGLE_APPLICATION_CREDENTIALS` | Anthropic Vertex | Service account credential file path (also accepted for project context) |
-| `ANTHROPIC_FOUNDRY_RESOURCE` | Anthropic Foundry | Foundry resource name (`auth_provider: foundry`) |
-| `ANTHROPIC_FOUNDRY_BASE_URL` | Anthropic Foundry | Alternate Foundry base URL (`auth_provider: foundry`) |
-| `OLLAMA_ENDPOINT` | Ollama | Server endpoint (default: `http://localhost:11434`) |
-
----
-
-## Next Steps
-
-- See [Agent Configuration](agent-configuration.md) for complete agent setup
-- See [Global Configuration](global-config.md) for shared provider settings and credentials
-- See [Evaluations Guide](evaluations.md) for configuring evaluation models (consider using faster models like `gpt-4o-mini` for cost-effective evaluations)
-- See [Tools Guide](tools.md) for extending agent capabilities
-- See [Vector Stores Guide](vector-stores.md) for semantic search configuration
+- [Claude Backend](claude-backend.md) — Claude-specific setup and capabilities.
+- [Semantic Kernel Backend](semantic-kernel-backend.md) — OpenAI / Azure / Ollama setup.
+- [Agent Configuration](agent-configuration.md) — full `agent.yaml` structure.
+- [Global Configuration](global-config.md) — shared provider settings and credentials.
+- [Evaluations](evaluations.md) — configuring evaluation models.
+- [Tools](tools.md) — extending agent capabilities.
+- [Vector Stores](vector-stores.md) — semantic search configuration.

--- a/docs/guides/semantic-kernel-backend.md
+++ b/docs/guides/semantic-kernel-backend.md
@@ -1,0 +1,414 @@
+# Semantic Kernel Backend
+
+The Semantic Kernel (SK) backend powers HoloDeck agents that run against OpenAI, Azure OpenAI, or local Ollama models. It is automatically selected for any `model.provider` other than `anthropic`.
+
+This guide is for backend-specific behaviour: per-provider setup, deployment-name mechanics, local-model nuances, and the full configuration reference. For shared concepts like tools, observability, and vector stores, see the dedicated guides for each.
+
+## Quick start
+
+OpenAI is the most common entry point. Set an API key and point an agent at it:
+
+```yaml
+# agent.yaml
+name: my-agent
+
+model:
+  provider: openai
+  name: gpt-4o
+  temperature: 0.5
+  max_tokens: 2000
+
+instructions:
+  inline: "You are a helpful assistant."
+```
+
+```bash
+# .env
+OPENAI_API_KEY=sk-...
+```
+
+Verify:
+
+```bash
+holodeck chat agent.yaml
+```
+
+For Azure OpenAI or Ollama, see the per-provider sections below.
+
+## Advanced configuration
+
+The SK backend doesn't expose a separate top-level config block — all backend behaviour is driven by the `model` settings of the active provider plus the provider's own infrastructure.
+
+### Provider: OpenAI
+
+OpenAI provides GPT-4o, GPT-4o-mini, and other models through their hosted API.
+
+**Prerequisites:**
+
+1. Create an account at [platform.openai.com](https://platform.openai.com).
+2. Generate an API key in the [API Keys section](https://platform.openai.com/api-keys).
+3. Set up billing.
+
+**Configuration:**
+
+```yaml
+# config.yaml
+providers:
+  openai:
+    provider: openai
+    name: gpt-4o
+    temperature: 0.3
+    max_tokens: 2000
+    api_key: ${OPENAI_API_KEY}
+```
+
+```yaml
+# agent.yaml
+name: my-agent
+
+model:
+  provider: openai
+  name: gpt-4o
+  temperature: 0.7
+  max_tokens: 4000
+
+instructions:
+  inline: "You are a helpful assistant."
+```
+
+**Environment variables:**
+
+```bash
+OPENAI_API_KEY=sk-...
+```
+
+**Available models:**
+
+| Model           | Description                       | Context window |
+|-----------------|-----------------------------------|----------------|
+| `gpt-4o`        | Most capable, multimodal          | 128K tokens    |
+| `gpt-4o-mini`   | Fast and cost-effective           | 128K tokens    |
+| `gpt-4-turbo`   | Previous-generation flagship      | 128K tokens    |
+| `gpt-3.5-turbo` | Fast, lower cost                  | 16K tokens     |
+
+### Provider: Azure OpenAI
+
+Azure OpenAI Service provides OpenAI models via Microsoft Azure with enterprise features.
+
+**Prerequisites:**
+
+1. Azure subscription with Azure OpenAI access.
+2. Create an Azure OpenAI resource in the [Azure Portal](https://portal.azure.com).
+3. Deploy a model in Azure OpenAI Studio.
+4. Note the endpoint URL and API key.
+
+**Configuration:**
+
+Both `endpoint` and `api_key` are required:
+
+```yaml
+# config.yaml
+providers:
+  azure_openai:
+    provider: azure_openai
+    name: my-gpt4o-deployment    # see "Deployment names" below
+    endpoint: ${AZURE_OPENAI_ENDPOINT}
+    api_key: ${AZURE_OPENAI_API_KEY}
+    temperature: 0.3
+    max_tokens: 2000
+```
+
+```yaml
+# agent.yaml
+name: enterprise-agent
+
+model:
+  provider: azure_openai
+  name: my-gpt4o-deployment
+  endpoint: https://my-resource.openai.azure.com/
+
+instructions:
+  inline: "You are an enterprise assistant."
+```
+
+**Environment variables:**
+
+```bash
+AZURE_OPENAI_ENDPOINT=https://your-resource-name.openai.azure.com/
+AZURE_OPENAI_API_KEY=your-api-key-here
+```
+
+**Endpoint format:**
+
+```
+https://{resource-name}.openai.azure.com/
+```
+
+Find your endpoint in: Azure Portal → Your OpenAI Resource → Keys and Endpoint, or Azure OpenAI Studio → Deployments → Your Deployment.
+
+#### Deployment names
+
+!!! warning "`name` refers to the deployment, not the base model"
+    In Azure OpenAI, the `name` field must match your **deployment name**, not the base model. This is different from OpenAI's API.
+
+When you deploy a model in Azure OpenAI Studio, you create a deployment with a custom name:
+
+- **Base model**: `gpt-4o`, `gpt-4o-mini`, etc.
+- **Deployment name**: your custom identifier (e.g. `my-gpt4o`, `prod-gpt4`).
+
+```yaml
+# If your deployment is "my-gpt4o-production" backed by gpt-4o:
+model:
+  provider: azure_openai
+  name: my-gpt4o-production
+  endpoint: https://my-resource.openai.azure.com/
+```
+
+Common mistake:
+
+```yaml
+# WRONG — using the base model name
+model:
+  provider: azure_openai
+  name: gpt-4o    # only works if the deployment is literally named "gpt-4o"
+
+# CORRECT — using your deployment name
+model:
+  provider: azure_openai
+  name: my-gpt4o-deployment
+```
+
+### Provider: Ollama
+
+Ollama runs open-source LLMs locally — ideal for privacy-sensitive workloads, offline use, and avoiding API costs.
+
+**Prerequisites:**
+
+1. Install Ollama from [ollama.com](https://ollama.com):
+
+   ```bash
+   # macOS / Linux
+   curl -fsSL https://ollama.com/install.sh | sh
+   ```
+
+2. Pull a model:
+
+   ```bash
+   ollama pull llama3.2
+   ```
+
+3. Verify it's running:
+
+   ```bash
+   ollama list
+   ```
+
+**Configuration:**
+
+Ollama requires an `endpoint` pointing to your local server:
+
+```yaml
+# config.yaml
+providers:
+  ollama:
+    provider: ollama
+    name: llama3.2
+    endpoint: http://localhost:11434
+    temperature: 0.7
+    max_tokens: 2000
+```
+
+```yaml
+# agent.yaml
+name: local-agent
+
+model:
+  provider: ollama
+  name: llama3.2
+  endpoint: http://localhost:11434
+
+instructions:
+  inline: "You are a helpful local assistant."
+```
+
+**Environment variables:**
+
+```bash
+OLLAMA_ENDPOINT=http://localhost:11434
+```
+
+**Available models** (pull with `ollama pull <model>`):
+
+| Model            | Command                                     | Description              | Size   |
+|------------------|---------------------------------------------|--------------------------|--------|
+| GPT-OSS (20B)    | `ollama pull gpt-oss:20b`                   | Recommended completion   | 40 GB  |
+| Nomic Embed Text | `ollama pull nomic-embed-text:latest`       | Recommended embeddings   | 274 MB |
+| Llama 3.2        | `ollama pull llama3.2`                      | Meta's latest, general   | 2 GB   |
+| Llama 3.2 (3B)   | `ollama pull llama3.2:3b`                   | Larger Llama variant     | 5 GB   |
+| Mistral          | `ollama pull mistral`                       | Fast and capable         | 4 GB   |
+| CodeLlama        | `ollama pull codellama`                     | Optimised for code       | 4 GB   |
+| Phi-3            | `ollama pull phi3`                          | Microsoft compact model  | 2 GB   |
+| Gemma 2          | `ollama pull gemma2`                        | Google's open model      | 5 GB   |
+
+#### Running Ollama as a service
+
+```bash
+ollama serve
+```
+
+Or with Docker:
+
+```bash
+docker run -d \
+  --name ollama \
+  -p 11434:11434 \
+  -v ollama-data:/root/.ollama \
+  ollama/ollama
+```
+
+#### Context size
+
+For agent workloads, configure a context size of at least **16k tokens**. Default Ollama context windows can be small enough to clip tool outputs.
+
+Create a custom model with extended context:
+
+```bash
+cat <<EOF > Modelfile
+FROM gpt-oss:20b
+PARAMETER num_ctx 16384
+EOF
+
+ollama create gpt-oss:20b-16k -f Modelfile
+```
+
+For 32k:
+
+```bash
+cat <<EOF > Modelfile
+FROM gpt-oss:20b
+PARAMETER num_ctx 32768
+EOF
+
+ollama create gpt-oss:20b-32k -f Modelfile
+```
+
+Use it:
+
+```yaml
+model:
+  provider: ollama
+  name: gpt-oss:20b-16k
+  endpoint: http://localhost:11434
+```
+
+!!! note "Memory pressure scales with context"
+    A 32k context with a 20B-parameter model typically requires 48 GB+ RAM or a GPU with 16 GB+ VRAM.
+
+### Backend behaviour vs Claude
+
+The SK backend is automatically selected when `model.provider` is anything other than `anthropic`. There is no top-level `claude:` block — capabilities like permission modes, extended thinking, web search, and subagents are Claude-only and are documented in the [Claude Backend](claude-backend.md) guide.
+
+## Configuration reference
+
+### `model.*` fields per provider
+
+All providers share these fields:
+
+| Field         | Type    | Required | Default | Description                                |
+|---------------|---------|----------|---------|--------------------------------------------|
+| `provider`    | string  | yes      | -       | `openai`, `azure_openai`, or `ollama`      |
+| `name`        | string  | yes      | -       | Model name (deployment name for Azure)     |
+| `temperature` | float   | no       | `0.3`   | Randomness, `0.0`–`2.0`                    |
+| `max_tokens`  | integer | no       | `1000`  | Maximum response tokens                    |
+| `top_p`       | float   | no       | -       | Nucleus sampling, `0.0`–`1.0`              |
+| `api_key`     | string  | varies   | -       | API key (required for OpenAI / Azure)      |
+| `endpoint`    | string  | varies   | -       | Endpoint URL (required for Azure / Ollama) |
+
+Per-provider requirements:
+
+| Provider       | `api_key` | `endpoint` | Notes                                                      |
+|----------------|-----------|------------|------------------------------------------------------------|
+| `openai`       | required  | -          | -                                                          |
+| `azure_openai` | required  | required   | `name` must match the deployment name, not the base model  |
+| `ollama`       | -         | required   | Default endpoint `http://localhost:11434`                  |
+
+### Provider-specific environment variables
+
+| Variable                  | Provider     | Description                                          |
+|---------------------------|--------------|------------------------------------------------------|
+| `OPENAI_API_KEY`          | OpenAI       | API authentication key                               |
+| `AZURE_OPENAI_ENDPOINT`   | Azure OpenAI | Resource endpoint URL                                |
+| `AZURE_OPENAI_API_KEY`    | Azure OpenAI | API authentication key                               |
+| `OLLAMA_ENDPOINT`         | Ollama       | Server endpoint (default `http://localhost:11434`)   |
+
+## Limitations & roadmap
+
+The SK backend currently powers `holodeck serve` and `holodeck deploy build`; the Claude backend does not yet support those commands.
+
+- [Agent Server](serve.md): SK-only.
+- [Deployment](deployment.md): SK-only (containerisation).
+
+Both will gain Claude support in a future release.
+
+## Troubleshooting
+
+### Invalid API key
+
+**Error**: `AuthenticationError` or `Invalid API key`.
+
+1. Verify the key: `echo $OPENAI_API_KEY` (or the Azure / Ollama equivalent).
+2. Ensure no extra whitespace.
+3. Regenerate the API key if needed.
+
+### Azure endpoint missing
+
+**Error**: `endpoint is required for azure_openai provider`.
+
+```yaml
+model:
+  provider: azure_openai
+  name: my-deployment
+  endpoint: https://my-resource.openai.azure.com/
+```
+
+### Model / deployment not found
+
+- **OpenAI**: check the model identifier (e.g. `gpt-4o`, not `gpt4o`).
+- **Azure**: ensure `name` matches the deployment name exactly.
+- **Ollama**: pull first with `ollama pull <model>`.
+
+### Ollama: connection refused
+
+1. Verify the daemon: `ollama list`.
+2. Start the server: `ollama serve`.
+3. Confirm the `endpoint` URL.
+
+### Ollama: model not found
+
+```bash
+ollama pull llama3.2
+```
+
+### Rate limits
+
+**Error**: `Rate limit exceeded` (OpenAI / Azure).
+
+1. Implement retry with exponential backoff.
+2. Reduce `max_tokens`.
+3. Use a faster / cheaper model.
+4. Upgrade the API plan.
+
+### Temperature out of range
+
+```yaml
+model:
+  temperature: 0.7   # must be 0.0 – 2.0
+```
+
+## Next steps
+
+- [Agent Configuration](agent-configuration.md) — full agent.yaml structure
+- [Tools](tools.md) — extending agent capabilities
+- [Observability](observability.md) — tracing and metrics
+- [Vector Stores](vector-stores.md) — semantic search configuration
+- [Agent Server](serve.md) and [Deployment](deployment.md) — running SK agents as services

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,8 @@ nav:
   - Guides:
     - Agent Configuration: guides/agent-configuration.md
     - LLM Providers: guides/llm-providers.md
+    - Claude Backend: guides/claude-backend.md
+    - Semantic Kernel Backend: guides/semantic-kernel-backend.md
     - Tools: guides/tools.md
     - MCP CLI: guides/mcp-cli.md
     - Vector Stores: guides/vector-stores.md

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -217,6 +217,25 @@
           "type": ["array", "null"],
           "items": { "type": "string" },
           "description": "Explicit tool allowlist (null = all configured tools)"
+        },
+        "effort": {
+          "type": ["string", "null"],
+          "enum": ["low", "medium", "high", "max", null],
+          "description": "Thinking effort level (low | medium | high | max)"
+        },
+        "max_budget_usd": {
+          "type": ["number", "null"],
+          "exclusiveMinimum": 0,
+          "description": "Hard cap on session spend in USD. Must be > 0."
+        },
+        "fallback_model": {
+          "type": ["string", "null"],
+          "description": "Model used when the primary model is unavailable"
+        },
+        "disallowed_tools": {
+          "type": ["array", "null"],
+          "items": { "type": "string" },
+          "description": "Tools that must never be used; takes precedence over allowed_tools"
         }
       },
       "description": "Claude Agent SDK-specific settings. All capabilities default to disabled (least-privilege)."

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -155,24 +155,37 @@
       },
       "description": "File read/write/edit access settings"
     },
-    "SubagentConfig": {
+    "SubagentSpec": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["description"],
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable parallel sub-agent execution"
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable description used by the parent agent for routing decisions. Required by the SDK."
         },
-        "max_parallel": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 16,
-          "default": 4,
-          "description": "Maximum parallel sub-agents (1-16)"
+        "prompt": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "Inline system prompt for the subagent. Mutually exclusive with prompt_file. Either prompt or prompt_file is required."
+        },
+        "prompt_file": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "Path to a file containing the subagent's system prompt. Resolved relative to the agent.yaml directory. Mutually exclusive with prompt. File contents are inlined at config-load time."
+        },
+        "tools": {
+          "type": ["array", "null"],
+          "items": { "type": "string" },
+          "description": "Allowlist of tool names. When null/omitted, the subagent inherits all parent tools. Unknown entries produce a warning at load time, not an error."
+        },
+        "model": {
+          "type": ["string", "null"],
+          "description": "Model override for this subagent. Passed through to the SDK verbatim (e.g. 'sonnet', 'haiku', 'inherit', or a full model id). The SDK is the source of truth for valid values."
         }
       },
-      "description": "Parallel sub-agent execution settings"
+      "description": "A single subagent definition for multi-agent orchestration."
     },
     "ClaudeConfig": {
       "type": "object",
@@ -209,9 +222,10 @@
           "$ref": "#/$defs/FileSystemConfig",
           "description": "File read/write/edit access settings"
         },
-        "subagents": {
-          "$ref": "#/$defs/SubagentConfig",
-          "description": "Parallel sub-agent execution settings"
+        "agents": {
+          "type": ["object", "null"],
+          "additionalProperties": { "$ref": "#/$defs/SubagentSpec" },
+          "description": "Named subagent definitions. Each entry becomes an AgentDefinition on ClaudeAgentOptions.agents. Subagents share parent MCP server registrations and use their `tools` allowlist to scope MCP tool access (`mcp__<server>__<tool>`). Per-subagent MCP server registration is NOT supported by the SDK."
         },
         "allowed_tools": {
           "type": ["array", "null"],

--- a/specs/026-sdk-config-additions/spec.md
+++ b/specs/026-sdk-config-additions/spec.md
@@ -74,10 +74,11 @@ A user wants to prevent the agent from ever using certain tools, regardless of o
 
 ### Edge Cases
 
-- What happens when `effort` is set alongside `extended_thinking.budget_tokens`? Both are passed to the SDK; the SDK determines precedence. Document this interaction.
+- What happens when `effort` is set alongside `extended_thinking.budget_tokens`? The SDK exposes `effort` and `thinking` (which carries `budget_tokens`) as independent parameters and does not publicly document precedence between them. To avoid ambiguity, HoloDeck MUST raise a validation warning when both are set on the same agent, instructing the user to pick one. (See FR-009.)
 - What happens when `max_budget_usd` is set to a very small value (e.g., 0.01)? The agent may fail on the first turn. The system should surface the SDK's budget-exhausted error clearly.
 - What happens when `fallback_model` is set to the same value as the primary model? Passed through as-is; the SDK handles this case.
 - What happens when a tool appears in both `allowed_tools` and `disallowed_tools`? Passed through as-is; the SDK's precedence rules apply (disallowed wins).
+- What happens when `disallowed_tools` is set to an empty list (`[]`)? Equivalent to omitting the field — the SDK's default is an empty list, not `None`.
 
 ## Requirements *(mandatory)*
 
@@ -88,9 +89,10 @@ A user wants to prevent the agent from ever using certain tools, regardless of o
 - **FR-003**: System MUST accept a `fallback_model` field on `ClaudeConfig` as a string.
 - **FR-004**: System MUST accept a `disallowed_tools` field on `ClaudeConfig` as a list of strings.
 - **FR-005**: System MUST pass all four fields through to the Claude SDK options when present.
-- **FR-006**: System MUST NOT pass any of the four fields when they are not set (preserve SDK defaults).
+- **FR-006**: System MUST NOT pass any of the four fields when they are not set (preserve SDK defaults). Note: `disallowed_tools`'s SDK default is an empty list (`[]`), so passing `[]` is equivalent to omitting it; the implementation MAY pass either form.
 - **FR-007**: System MUST reject invalid `effort` values at config validation time with a clear error message.
 - **FR-008**: System MUST reject non-positive `max_budget_usd` values at config validation time.
+- **FR-009**: System MUST raise a validation warning when both `effort` and `extended_thinking` are configured on the same agent, since the SDK does not publicly document precedence between `effort` and `thinking.budget_tokens` and the combination is ambiguous.
 
 ### Key Entities
 
@@ -108,6 +110,8 @@ A user wants to prevent the agent from ever using certain tools, regardless of o
 
 ## Assumptions
 
-- The Claude Agent SDK's Python client (`ClaudeAgentOptions`) already supports `fallback_model`, `effort`, `disallowed_tools`, and `max_budget_usd` as parameters. If any are not yet available in the installed SDK version, the implementation should be gated behind a version check or documented as requiring a minimum SDK version.
-- The `effort` field in the SDK accepts string literals ("low", "medium", "high", "max"), not numeric values.
-- The `disallowed_tools` list uses the same tool naming convention as `allowed_tools` (e.g., "Bash", "Write", "mcp__server__tool").
+- The Claude Agent SDK's Python client (`ClaudeAgentOptions`) already supports `fallback_model`, `effort`, `disallowed_tools`, and `max_budget_usd` as parameters (verified against `claude_agent_sdk/types.py`: `max_budget_usd: float | None`, `disallowed_tools: list[str]` defaulting to `[]`, `fallback_model: str | None`, `effort: Literal["low", "medium", "high", "max"] | None`).
+- The `effort` field in the SDK accepts the four string literals `low | medium | high | max`, not numeric values, and not arbitrary strings.
+- The `fallback_model` field accepts any string (no SDK-side literal restriction), so values like `haiku` or full model IDs like `claude-haiku-4-5` are both valid. HoloDeck SHOULD pass the value through unchanged.
+- The `disallowed_tools` list uses the same tool naming convention as `allowed_tools` (e.g., `Bash`, `Write`, `mcp__server__tool`).
+- The SDK's `effort` and `thinking` parameters are independent — neither's docstring describes precedence over the other — so HoloDeck treats simultaneous use as a configuration ambiguity (see FR-009).

--- a/specs/029-subagent-orchestration/contracts/subagent-spec.schema.json
+++ b/specs/029-subagent-orchestration/contracts/subagent-spec.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://holodeck.dev/schemas/029/subagent-spec.schema.json",
+  "title": "SubagentSpec",
+  "description": "JSON schema fragment to merge into schemas/agent.schema.json. Adds a SubagentSpec $def and an `agents` property under ClaudeConfig. Strict (additionalProperties: false) — typos are caught at config-load time.",
+  "$defs": {
+    "SubagentSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description"],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable description used by the parent agent for routing decisions. Required by the SDK."
+        },
+        "prompt": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "Inline system prompt for the subagent. Mutually exclusive with prompt_file. Either prompt or prompt_file is required."
+        },
+        "prompt_file": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "description": "Path to a file containing the subagent's system prompt. Resolved relative to the agent.yaml directory. Mutually exclusive with prompt. File contents are inlined at config-load time."
+        },
+        "tools": {
+          "type": ["array", "null"],
+          "items": { "type": "string" },
+          "description": "Allowlist of tool names. May include built-in SDK tools (Read, Write, WebSearch, ...), parent-registered MCP tools as `mcp__<server>__<tool>`, or HoloDeck-bridged tool names. When null/omitted, the subagent inherits all parent tools. Unknown entries produce a warning at load time, not an error."
+        },
+        "model": {
+          "type": ["string", "null"],
+          "enum": ["sonnet", "opus", "haiku", "inherit", null],
+          "description": "Model override for this subagent. Restricted to the SDK's literal set. Any other value is rejected at config-load time."
+        }
+      }
+    }
+  },
+  "validationOwnership": {
+    "description": "JSON Schema declares structural shape only. The mutual-exclusion rule (exactly one of prompt/prompt_file) and the at-least-one rule are enforced by the Pydantic SubagentSpec model validator at config-load time. JSON Schema's oneOf does not handle nullable fields cleanly (explicit-null counts as 'present'), so encoding the constraint here would produce false negatives. See research.md §7."
+  },
+  "patches": {
+    "description": "Apply these patches to schemas/agent.schema.json.",
+    "ClaudeConfig.properties.agents": {
+      "type": ["object", "null"],
+      "additionalProperties": { "$ref": "#/$defs/SubagentSpec" },
+      "description": "Named subagent definitions. Each entry becomes an AgentDefinition on ClaudeAgentOptions.agents. Subagents share parent MCP server registrations and use their `tools` allowlist to scope MCP tool access (`mcp__<server>__<tool>`). Per-subagent MCP server registration is NOT supported by the SDK."
+    }
+  }
+}

--- a/specs/029-subagent-orchestration/data-model.md
+++ b/specs/029-subagent-orchestration/data-model.md
@@ -1,0 +1,174 @@
+# Data Model: Subagent Definitions & Multi-Agent Orchestration
+
+**Spec**: 029-subagent-orchestration
+**Phase**: 1 (Design)
+**Date**: 2026-04-29
+
+This feature is configuration-only. No new persistence, no new runtime
+state. The data model below describes Pydantic v2 models added to
+`src/holodeck/models/claude_config.py` and how they translate to the
+Claude Agent SDK's `AgentDefinition`.
+
+---
+
+## Entities
+
+### 1. `SubagentSpec` (new)
+
+A single subagent definition. Lives next to existing config models in
+`claude_config.py`. Strict (`extra="forbid"`).
+
+| Field | Type | Required | Default | Validation |
+|---|---|---|---|---|
+| `description` | `str` | yes | — | Non-empty after strip. The SDK uses this for routing decisions. |
+| `prompt` | `str \| None` | conditionally | `None` | Mutually exclusive with `prompt_file`. At least one of `prompt` / `prompt_file` MUST be set. Non-empty after strip. |
+| `prompt_file` | `str \| None` | conditionally | `None` | Mutually exclusive with `prompt`. Path resolved relative to `agent_base_dir`; file MUST exist at validation time. Inlined into `prompt` after load. |
+| `tools` | `list[str] \| None` | no | `None` | When omitted (`None`), subagent inherits all parent tools. When provided, only those tools are available; entries should match a known built-in (see static set below), an MCP tool name (`mcp__<server>__<tool>`), or a HoloDeck-bridged tool — unknown entries produce a `UserWarning` at config-load time (not error). |
+| `model` | `Literal["sonnet", "opus", "haiku", "inherit"] \| None` | no | `None` | Restricted to the SDK's literal set. Any other value produces a `ValidationError` at config-load time. |
+
+**Validation rules** (implemented as `@model_validator(mode="after")`):
+
+1. **Mutual exclusion**: if both `prompt` and `prompt_file` are set →
+   `ValidationError("prompt and prompt_file are mutually exclusive")`.
+2. **At-least-one**: if neither is set → `ValidationError("subagent
+   requires either prompt or prompt_file")`.
+3. **prompt_file resolution**: if `prompt_file` is set, resolve relative
+   to `agent_base_dir.get()`; if the path doesn't exist →
+   `ValidationError("prompt_file not found: {path}")`. If it exists,
+   read the file and store the contents in `prompt`; clear `prompt_file`
+   so downstream code only ever sees `prompt`.
+4. **description non-empty**: `description.strip() == ""` →
+   `ValidationError`.
+5. **Tool-name typo warnings** (load time): for each entry in `tools`,
+   emit a `UserWarning` if the entry is **not** in the known-built-ins
+   set, **not** prefixed with `mcp__`, and **not** a HoloDeck-bridged
+   tool name resolvable from the parent agent's top-level `tools` field.
+   The known-built-ins set is a module constant in `claude_config.py`:
+   `{"Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch",
+   "WebFetch", "Task", "TodoWrite", "NotebookEdit"}`. The warning
+   message includes the offending name and the three accepted patterns.
+
+**State transitions**: none. Immutable after construction.
+
+**Maps to**: `claude_agent_sdk.types.AgentDefinition` 1-to-1, with the
+following correspondence:
+
+| `SubagentSpec` | `AgentDefinition` |
+|---|---|
+| `description` | `description` |
+| `prompt` (after `prompt_file` inlining) | `prompt` |
+| `tools` | `tools` |
+| `model` | `model` |
+
+---
+
+### 2. `ClaudeConfig.agents` (new field on existing model)
+
+A new optional field on the existing `ClaudeConfig` model:
+
+```python
+agents: dict[str, SubagentSpec] | None = Field(
+    default=None,
+    description=(
+        "Named subagent definitions. Each entry becomes an AgentDefinition "
+        "on ClaudeAgentOptions.agents. Subagents share parent MCP servers "
+        "and use their `tools` allowlist to scope MCP tool access."
+    ),
+)
+```
+
+**Validation rules**:
+
+1. **Empty-map normalization** (`@model_validator(mode="after")` on
+   `ClaudeConfig`): if `agents == {}` → set `agents = None`.
+2. **Legacy-block migration error** (`@model_validator(mode="before")` on
+   `ClaudeConfig`): if the input dict contains a `subagents` key, raise
+   `ValidationError` with the exact message: *"`claude.subagents` is no
+   longer supported; remove this block. Subagent forwarding is gated
+   solely by the presence of `claude.agents`. To cap HoloDeck-side test
+   concurrency, set `execution.parallel_test_cases` instead."* This runs
+   before the `extra="forbid"` check so the user gets a targeted error
+   rather than a generic "extra fields not permitted".
+
+**Translation to SDK** (in
+`src/holodeck/lib/backends/claude_backend.py:build_options()`):
+
+```python
+if claude and claude.agents:
+    opts_kwargs["agents"] = {
+        name: AgentDefinition(
+            description=spec.description,
+            prompt=spec.prompt,           # already inlined
+            tools=spec.tools,             # None → inherit
+            model=spec.model,             # None → inherit
+        )
+        for name, spec in claude.agents.items()
+    }
+```
+
+The presence of `claude.agents` (after empty-map normalization) is the
+sole gate. There is no separate `subagents.enabled` check.
+
+Tool-name typo warnings are emitted at config-load time by the
+`SubagentSpec` model validator (rule #5 above), not in `build_options()`.
+This satisfies the spec edge-case requirement that warnings fire at
+"config load time", and keeps `build_options()` focused on translation.
+
+---
+
+### 3. `SubagentConfig` (deleted)
+
+The previously-existing `SubagentConfig` model and `ClaudeConfig.subagents`
+field are removed. See research §4 for rationale. Migration: any
+`agent.yaml` referencing `claude.subagents` produces a clear
+`ValidationError` directing users at `claude.agents` and
+`execution.parallel_test_cases`. Tests in
+`tests/unit/models/test_claude_config.py` that exercised
+`SubagentConfig` are removed; new tests verify the migration error
+fires correctly.
+
+---
+
+## Relationships
+
+```
+ClaudeConfig
+└── agents : dict[str, SubagentSpec] | None   (new — sole gate)
+
+SubagentSpec  →  claude_agent_sdk.types.AgentDefinition  (1-to-1, lossless,
+                                                          translated in
+                                                          build_options())
+```
+
+No cross-entity foreign keys; the dict key (subagent name) is opaque to
+the SDK and used only as the `agents` map key on `ClaudeAgentOptions`.
+
+---
+
+## Invariants
+
+- `SubagentSpec.prompt` is always non-empty after construction (loader
+  has inlined `prompt_file` contents).
+- `SubagentSpec.prompt_file` is always `None` after construction.
+- `ClaudeConfig.agents` is either `None` or a non-empty dict (empty maps
+  normalized to `None`).
+- `ClaudeConfig` has no `subagents` field. Any input dict containing a
+  `subagents` key is rejected at validation time with a migration error.
+
+---
+
+## Backwards compatibility
+
+- Existing `agent.yaml` files without a `claude.agents` and without a
+  `claude.subagents` section behave identically. No new required fields
+  are added at the top level.
+- **Breaking change**: `claude.subagents` (with `enabled` and
+  `max_parallel`) is removed. Any `agent.yaml` still using this block
+  fails to load with a clear migration error. Per `git log` and a sweep
+  of `sample/`, no shipped sample agent.yaml uses the field; the recent
+  feature commits (`9c1dc8c`, `65e292e`) added it but did not publish
+  user-facing examples that depend on it. Custom user configs require a
+  one-line removal.
+- Schema additions (`SubagentSpec` `$def`, `agents` property) are purely
+  additive. The schema also drops `SubagentConfig` `$def` and the
+  `subagents` property — also a breaking change with the same rationale.

--- a/specs/029-subagent-orchestration/plan.md
+++ b/specs/029-subagent-orchestration/plan.md
@@ -1,0 +1,167 @@
+# Implementation Plan: Subagent Definitions & Multi-Agent Orchestration
+
+**Branch**: `feature/029-claude-subagents` | **Date**: 2026-04-29 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/029-subagent-orchestration/spec.md`
+**Spec ID**: 029-subagent-orchestration
+**Dependencies**: 027-mcp-http-sse-transport (parent agent's MCP servers; subagents inherit access via their `tools` allowlist)
+
+## Summary
+
+Expose the Claude Agent SDK's multi-agent orchestration via YAML. Add a new
+`claude.agents` map of named subagent specs (`description`, `prompt` |
+`prompt_file`, `tools`, `model`) and translate each entry 1-to-1 into a
+`claude_agent_sdk.types.AgentDefinition` on `ClaudeAgentOptions.agents`. No
+per-subagent MCP server registration — subagents share the parent's
+registrations and use their `tools` allowlist (including `mcp__<server>__<tool>`
+identifiers) for capability scoping.
+
+**Removal**: the existing `claude.subagents` block (`enabled`, `max_parallel`)
+is deleted entirely. Both fields were vestigial — `enabled` is redundant
+with `agents` presence, and `max_parallel` was never a real SDK control
+(the SDK manages subagent dispatch internally) and only duplicates what
+`execution.parallel_test_cases` already does at the test-runner level. The
+presence of `claude.agents` is the only gate. HoloDeck-side test
+concurrency continues to be controlled exclusively by
+`execution.parallel_test_cases`.
+
+The implementation is config-only: a new `SubagentSpec` Pydantic model, a
+schema fragment, validators (prompt_file resolution, mutual-exclusion,
+model literal, tool-name typo warnings), one `agents=` kwarg on
+`ClaudeAgentOptions`, deletion of `SubagentConfig` + `ClaudeConfig.subagents`
++ the corresponding schema `$def`, and migration of any existing tests
+that referenced them.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+
+**Primary Dependencies**: `claude-agent-sdk==0.1.44` (provides `AgentDefinition`, `ClaudeAgentOptions.agents`), Pydantic v2, PyYAML, Click
+**Storage**: N/A (config-only feature; no persistent state)
+**Testing**: pytest with `-n auto`; markers `@pytest.mark.unit` and `@pytest.mark.integration`
+**Target Platform**: Linux/macOS dev workstations and CI runners (HoloDeck CLI)
+**Project Type**: Single project (HoloDeck monolith with backend abstraction)
+**Performance Goals**: No runtime hot path. Config load and validation must complete in <50ms for an agent.yaml with up to ~16 subagents (typical: 3–5).
+**Constraints**:
+- `AgentDefinition` exposes exactly 4 fields (`description`, `prompt`, `tools`, `model`); HoloDeck must not invent extras.
+- `model` literal set is `{sonnet, opus, haiku, inherit}` — full model IDs are rejected by the SDK type.
+- `prompt_file` paths must resolve relative to the agent.yaml directory via the existing `agent_base_dir` `ContextVar` (see `src/holodeck/config/context.py:22`).
+- HoloDeck cannot intercede in SDK-internal subagent dispatch. The presence of `claude.agents` is the sole gate for forwarding subagent definitions.
+- `claude.subagents` is deleted; loading an `agent.yaml` that still contains it produces a clear Pydantic `ValidationError` (since `ClaudeConfig` uses `extra="forbid"`).
+
+**Scale/Scope**: Up to ~16 subagent specs per agent (typical: 3–5); single-agent YAML files; thousands of test cases per run.
+
+### Concrete integration points (from codebase survey)
+
+- `src/holodeck/models/claude_config.py:63-70,115-118` — **delete** `SubagentConfig` and the `ClaudeConfig.subagents` field. Add new `SubagentSpec` model and `ClaudeConfig.agents: dict[str, SubagentSpec] | None`.
+- `src/holodeck/lib/backends/claude_backend.py:248-356` — `build_options()`. Populate `opts_kwargs["agents"]` from `claude.agents` when non-empty. No `subagents.enabled` check.
+- `schemas/agent.schema.json:158-215` — **delete** `SubagentConfig` `$def` and the `subagents` property under `ClaudeConfig`. Add `SubagentSpec` `$def` and an `agents` property under `ClaudeConfig`.
+- `src/holodeck/config/loader.py:775-783` — already sets `agent_base_dir`; reuse for `prompt_file` resolution at validation time. No other changes.
+- `src/holodeck/lib/test_runner/executor.py:820-828` — **no changes**. The existing `execution.parallel_test_cases` semaphore is the only HoloDeck-side concurrency control.
+- `tests/unit/models/test_claude_config.py:158-196,248-255` — remove the existing `SubagentConfig` test cases; add `SubagentSpec` and `ClaudeConfig.agents` tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Reference: `.specify/memory/constitution.md` v1.0.1.
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. No-Code-First Agent Definition | ✅ Pass | The whole feature is YAML-driven. Users define subagent teams entirely via `claude.agents` without writing Python. |
+| II. MCP for API Integrations | ✅ Pass | No new API integrations. Subagents reuse parent-level MCP server registrations; `tools` allowlist references `mcp__<server>__<tool>` identifiers. The spec explicitly forbids per-subagent MCP server registration (FR-009). |
+| III. Test-First with Multimodal Support | ✅ Pass | Plan delivers unit tests for `SubagentSpec` validation and contract tests on `build_options()`'s `agents` kwarg (SC-002, SC-003, SC-004). Tests for the deleted `subagents` block are removed (SC-005). No multimodal surface area changes. |
+| IV. OpenTelemetry-Native Observability | ✅ Pass | Subagent dispatch is instrumented by the Claude SDK itself; no new HoloDeck spans required. The OTel bridge (`otel_bridge.py`) continues to forward env vars unchanged. |
+| V. Evaluation Flexibility with Model Overrides | ✅ Pass | Per-subagent `model` override aligns with this principle by extending model selection granularity from "global / per-run / per-metric" to "per-subagent" within a single agent run. |
+
+**Architecture constraints**: Config-only change. No new engine, no cross-engine
+contract changes. Backend abstraction (`AgentBackend` / `AgentSession`) is
+untouched — only the Claude backend's options builder gains a new field, and
+the model layer loses one redundant block.
+
+**Code quality / testing discipline**: Adheres to existing conventions
+(`extra="forbid"` Pydantic, Black/Ruff/MyPy strict, pytest markers, AAA tests).
+No coverage regression expected — replaced tests cover an equal-or-greater
+surface.
+
+**Backwards compatibility note**: Removing `claude.subagents` is a breaking
+config change. Acceptable because (a) `extra="forbid"` will produce a clear
+error message, (b) the field is freshly introduced (recent commits 9c1dc8c
+and 65e292e) and not yet load-bearing in shipped agent.yaml configs, and
+(c) the migration is a one-line removal. We add a custom validator that
+detects the legacy `subagents` key and emits a more helpful error than the
+generic Pydantic "extra fields not permitted" — pointing users at the
+`claude.agents`-only model.
+
+**Result**: ✅ All gates pass. No Complexity Tracking entries needed.
+
+### Post-Phase-1 re-evaluation
+
+After producing `research.md`, `data-model.md`, `contracts/subagent-spec.schema.json`, and `quickstart.md`, the design surface is:
+
+- One new Pydantic model (`SubagentSpec`), one new optional field (`ClaudeConfig.agents`), three new validators on `SubagentSpec` (mutual-exclusion + prompt_file resolution, tool-name typo warnings, model literal — the last enforced by Pydantic's `Literal` type), one new validator on `ClaudeConfig` (legacy `subagents` key migration error).
+- One deleted Pydantic model (`SubagentConfig`) and one deleted field (`ClaudeConfig.subagents`).
+- One new translation block in `build_options()` (≤ 8 lines).
+- One additive JSON schema fragment (`SubagentSpec` `$def` + `agents` property).
+- One subtractive JSON schema change (delete `SubagentConfig` `$def` + `subagents` property).
+- Test-runner executor: **no changes**.
+- Two unit test files updated (one extended with new cases, one with the deleted-block cases removed).
+
+No new engines, no cross-engine contract changes, no new dependencies. All five constitution principles continue to hold; gate result remains ✅.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/029-subagent-orchestration/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── subagent-spec.schema.json   # JSON schema fragment for SubagentSpec
+├── checklists/          # Existing
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+Only the files below change. No new packages or modules. Test-runner executor
+is unchanged.
+
+```text
+src/holodeck/
+├── models/
+│   └── claude_config.py                  # -SubagentConfig; -ClaudeConfig.subagents;
+│                                         # +SubagentSpec; +ClaudeConfig.agents;
+│                                         # +legacy-key validator
+├── lib/
+│   └── backends/
+│       └── claude_backend.py             # +translate ClaudeConfig.agents → ClaudeAgentOptions.agents
+└── config/
+    └── loader.py                         # (no changes — agent_base_dir already set)
+
+schemas/
+└── agent.schema.json                     # -SubagentConfig $def; -subagents property;
+                                          # +SubagentSpec $def; +agents property
+
+tests/
+└── unit/
+    ├── models/
+    │   └── test_claude_config.py         # remove SubagentConfig cases;
+    │                                     # add SubagentSpec + ClaudeConfig.agents cases
+    └── backends/
+        └── test_claude_backend_options.py  # +AgentDefinition translation cases
+
+sample/                                   # +one example agent.yaml under sample/<scenario>/claude/
+                                          #  showing claude.agents with 2-3 subagents (US1 demo)
+```
+
+**Structure Decision**: Single-project layout (`src/holodeck/`) preserved. No
+new top-level directories. The change is a focused vertical slice: models →
+schema → backend translation → tests/sample.
+
+## Complexity Tracking
+
+> Fill ONLY if Constitution Check has violations that must be justified.
+
+No violations. Table intentionally empty.

--- a/specs/029-subagent-orchestration/quickstart.md
+++ b/specs/029-subagent-orchestration/quickstart.md
@@ -1,0 +1,188 @@
+# Quickstart: Multi-Agent Teams in YAML
+
+**Spec**: 029-subagent-orchestration
+**Audience**: HoloDeck users defining a multi-agent team in `agent.yaml`.
+
+This quickstart shows how to define a parent agent with three specialized
+subagents — a researcher, a data analyst, and a report writer — entirely
+in YAML. The parent automatically delegates to subagents based on their
+`description` fields; you don't write any routing code.
+
+---
+
+## 1. Minimal example
+
+```yaml
+name: research-team
+instructions: |
+  You are a research coordinator. Delegate research, analysis, and writing
+  to your subagents. Synthesize their findings into a final answer.
+
+model:
+  provider: anthropic
+  name: claude-opus-4-7
+
+claude:
+  permission_mode: acceptEdits
+  web_search: true
+
+  agents:
+    researcher:
+      description: Gathers raw information from the web and primary sources.
+      prompt: |
+        You are a meticulous researcher. Search the web for primary sources.
+        Cite every claim with a URL. Do not analyze — just gather facts.
+      tools: [WebSearch, WebFetch]
+      model: haiku
+
+    analyst:
+      description: Analyzes data and identifies patterns and outliers.
+      prompt_file: ./prompts/analyst.md
+      tools: [Read]
+      model: sonnet
+
+    writer:
+      description: Produces a polished final report from analyzed findings.
+      prompt: |
+        You are an expert technical writer. Produce a clear, well-structured
+        report. Use headers, bullets, and inline citations.
+      # No tools list → inherits all parent tools.
+      # No model → inherits parent model.
+```
+
+---
+
+## 2. Field reference
+
+Each entry under `claude.agents.<name>` accepts these fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `description` | yes | Used by the parent agent for routing. Be specific about what the subagent does and when to invoke it. |
+| `prompt` | one of | Inline system prompt. |
+| `prompt_file` | one of | Path to a `.md` or `.txt` file containing the prompt, resolved relative to the agent.yaml directory. |
+| `tools` | no | List of tool names this subagent may use. Built-ins (`WebSearch`, `Read`, `Write`, `Bash`, …), MCP tools (`mcp__<server>__<tool>`), or HoloDeck-bridged names are valid. Omit to inherit all parent tools. |
+| `model` | no | One of `sonnet`, `opus`, `haiku`, `inherit`. Omit to inherit the parent's model. |
+
+> **Note on `tools`**: subagents share the parent's MCP server
+> registrations. To restrict an MCP tool to one subagent, name it on that
+> subagent's `tools` list and leave it off the others. The Claude SDK
+> enforces the allowlist at runtime.
+
+---
+
+## 3. Restricting MCP tool access per subagent
+
+```yaml
+claude:
+  agents:
+    db_analyst:
+      description: Runs SQL queries against the production read-replica.
+      prompt: You are a SQL expert. Use mcp__db__query to answer questions.
+      tools: [mcp__db__query, mcp__db__describe]
+
+    researcher:
+      description: Searches the web. Cannot touch the database.
+      prompt: You are a web researcher.
+      tools: [WebSearch, WebFetch]
+      # ↑ no mcp__db__* — DB tools are unreachable from this subagent.
+```
+
+Both subagents share the same parent-level `mcp_servers.db` registration,
+but the SDK only exposes the tools each one explicitly enumerates.
+
+---
+
+## 4. Capping HoloDeck-side concurrency
+
+Use the existing top-level `execution.parallel_test_cases` field — it
+caps the test runner's per-test-case semaphore. There is no
+subagent-specific knob, because HoloDeck cannot intercede in the
+SDK's internal subagent dispatch (the SDK manages that itself).
+
+```yaml
+execution:
+  parallel_test_cases: 2   # at most 2 concurrent agent sessions
+
+claude:
+  agents:
+    # ...
+```
+
+> **Note (migration)**: earlier prereleases offered a
+> `claude.subagents` block with `enabled` and `max_parallel`. That
+> block is removed in spec 029 — both fields were redundant. If your
+> YAML still has `claude.subagents`, delete it. Loading produces a
+> clear validation error pointing here.
+
+---
+
+## 5. Validation walkthrough
+
+The following YAML triggers each validation error so you know what to
+expect:
+
+| Misconfiguration | Result at config-load time |
+|---|---|
+| Missing `description` | `ValidationError: subagent requires description` |
+| Both `prompt` and `prompt_file` set | `ValidationError: prompt and prompt_file are mutually exclusive` |
+| Neither `prompt` nor `prompt_file` set | `ValidationError: subagent requires either prompt or prompt_file` |
+| `prompt_file: ./does-not-exist.md` | `ValidationError: prompt_file not found` |
+| `model: claude-3-5-sonnet-20241022` | `ValidationError: model must be one of sonnet, opus, haiku, inherit` |
+| `tools: [WebSerach]` (typo) | **Warning** at load time (not an error) — typos in tool names produce a warning so unknown built-ins/MCP tools aren't blocked. |
+| `claude.subagents:` block present | `ValidationError: claude.subagents is no longer supported; remove this block. Subagent forwarding is gated solely by the presence of claude.agents. To cap HoloDeck-side test concurrency, set execution.parallel_test_cases instead.` |
+
+---
+
+## 6. Verifying the wiring
+
+A quick sanity check after editing your YAML — both `holodeck chat` and
+`holodeck test` load and validate the YAML before they do anything else,
+so either one will surface validation errors and warnings:
+
+```bash
+holodeck chat path/to/agent.yaml                  # exercise the team interactively
+holodeck test path/to/agent.yaml                  # run test cases (honors execution.parallel_test_cases)
+```
+
+If your test suite includes a "smoke" case at the top, `holodeck test`
+gives you fast YAML validation followed by a single end-to-end exercise.
+
+---
+
+## 7. Common patterns
+
+**Specialized small models for narrow tasks**:
+
+```yaml
+claude:
+  agents:
+    classifier:
+      description: Routes questions to one of: technical, billing, general.
+      prompt: Classify the user's question. Respond with one word only.
+      model: haiku
+      tools: []      # no tools needed — pure reasoning
+```
+
+**File-based prompts for long instructions**:
+
+```yaml
+claude:
+  agents:
+    legal_reviewer:
+      description: Reviews contracts for risk per the firm's playbook.
+      prompt_file: ./prompts/legal-reviewer.md     # versioned alongside agent.yaml
+      tools: [Read, mcp__contract_db__search]
+```
+
+**Inherit-everything subagent for chained reasoning**:
+
+```yaml
+claude:
+  agents:
+    reflector:
+      description: Reviews the parent's draft answer for gaps and suggests revisions.
+      prompt: You are a critical reviewer. Find gaps in reasoning.
+      # tools omitted → inherits parent tools
+      # model omitted → inherits parent model
+```

--- a/specs/029-subagent-orchestration/research.md
+++ b/specs/029-subagent-orchestration/research.md
@@ -1,0 +1,240 @@
+# Research: Subagent Definitions & Multi-Agent Orchestration
+
+**Spec**: 029-subagent-orchestration
+**Phase**: 0 (Outline & Research)
+**Date**: 2026-04-29
+
+The Technical Context section of `plan.md` had no `NEEDS CLARIFICATION`
+markers — every unknown was resolvable against the installed SDK and the
+existing codebase. The decisions below document the design choices that
+flow into Phase 1.
+
+---
+
+## 1. SDK surface for subagent definitions
+
+**Decision**: Translate each YAML `claude.agents.<name>` entry into one
+`claude_agent_sdk.types.AgentDefinition` and assemble them into the
+`agents: dict[str, AgentDefinition] | None` field of `ClaudeAgentOptions`.
+
+**Rationale**: Verified against the installed SDK (`claude-agent-sdk==0.1.44`):
+
+```python
+@dataclass
+class AgentDefinition:
+    description: str
+    prompt: str
+    tools: list[str] | None = None
+    model: Literal["sonnet", "opus", "haiku", "inherit"] | None = None
+```
+
+`ClaudeAgentOptions` exposes `agents` as a top-level dataclass field. The
+spec's Assumptions section already locks this in; this research step
+confirmed it empirically.
+
+**Alternatives considered**:
+
+- *A separate Pydantic model per subagent type* (researcher, analyst, …) —
+  rejected: the SDK doesn't differentiate, and HoloDeck's value is
+  configuration not code generation.
+- *Keep the existing `subagents` config and overload it with definitions* —
+  rejected: `SubagentConfig` semantically describes HoloDeck-side
+  concurrency. Mixing it with SDK-side specs would be confusing and lock
+  out the future possibility of supporting both knobs together.
+
+---
+
+## 2. `prompt_file` resolution
+
+**Decision**: Resolve `prompt_file` paths relative to the agent.yaml
+directory using the existing `agent_base_dir` `ContextVar`
+(`src/holodeck/config/context.py:22`). Read the file at config-load time
+and inline the contents into the resulting `SubagentSpec.prompt`.
+
+**Rationale**:
+
+- The loader already sets `agent_base_dir` for the duration of YAML loading
+  (`src/holodeck/config/loader.py:775-783`).
+- The same pattern is already used for hierarchical-document tools
+  (`src/holodeck/config/schema.py:104-106`). Reusing it keeps the
+  resolution rules consistent and avoids a second context mechanism.
+- Inlining at load time means the SDK never sees `prompt_file`; it always
+  receives a non-empty `prompt` (matching FR-006).
+
+**Alternatives considered**:
+
+- *Lazy file read inside `build_options()`* — rejected: errors would
+  surface at session start instead of config validation, breaking SC-004.
+- *CWD-relative resolution* — rejected: fails when the user runs `holodeck`
+  from a different directory. The agent.yaml directory is the only stable
+  anchor.
+
+**Edge cases covered**:
+
+- `prompt_file` does not exist → `ValidationError` at load time (SC-004).
+- Both `prompt` and `prompt_file` set → `ValidationError` (FR-006).
+- Neither set → `ValidationError` (FR-006; SDK requires non-empty prompt).
+
+---
+
+## 3. Tool list validation strategy
+
+**Decision**: At config-load time (`@model_validator(mode="after")` on
+`SubagentSpec`), validate that each entry in a subagent's `tools` list
+matches one of three patterns:
+
+1. A name in a static set of known SDK built-in tools, kept as a module
+   constant in `claude_config.py`:
+   `{"Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch",
+   "WebFetch", "Task", "TodoWrite", "NotebookEdit"}`. (This list is
+   advisory and may lag SDK upgrades — that's acceptable because the
+   penalty for a stale entry is a warning, not a hard error.)
+2. A string starting with `mcp__` (parent-registered MCP tool — the
+   actual server presence is verified later by the SDK at runtime).
+3. A name listed in the parent agent's top-level `tools` field
+   (HoloDeck-bridged tools from `tool_adapters.py`).
+
+Unknown entries produce a `UserWarning` at config-load time, mirroring
+the existing `_warn_effort_with_extended_thinking` validator on
+`ClaudeConfig`. This satisfies the spec edge case verbatim ("Validation
+warning at config load time") and catches typos like `WebSerach` or
+`mcp__db_query` (single underscore) before any session starts.
+
+**Rationale**: Earlier draft deferred this to `build_options()` (session
+start). Verification surfaced the timing mismatch with the spec, which
+explicitly promises load-time. Implementing the check in the model
+validator keeps everything in `claude_config.py` and matches the
+load-time guarantee. The static built-in set is small and SDK-stable;
+when the SDK adds a new tool, HoloDeck users get a one-release lag of
+spurious warnings — acceptable tradeoff vs. blocking valid configs.
+
+**Alternatives considered**:
+
+- *No validation* — rejected: doesn't help users catch typos.
+- *Hard error on unknown* — rejected: too brittle; fails on legitimate
+  built-ins not yet in HoloDeck's allowlist.
+- *Defer to `build_options()`* — rejected at verification time: violates
+  the spec's "config load time" promise and means warnings are tied to
+  session start rather than `holodeck` config-validation paths.
+
+---
+
+## 4. Removal of `claude.subagents` block
+
+**Decision**: Delete the entire `claude.subagents` block (`SubagentConfig`
+model and `ClaudeConfig.subagents` field) instead of trying to give it
+meaningful semantics under spec 029. The presence of `claude.agents`
+becomes the sole gate for forwarding subagent definitions to the SDK.
+HoloDeck-side test concurrency continues to be controlled exclusively by
+the existing top-level `execution.parallel_test_cases`.
+
+**Rationale**: Verification surfaced that both fields in the block are
+vestigial under the new design:
+
+- **`max_parallel` is not a real SDK control.** The Claude Agent SDK
+  manages subagent dispatch internally — HoloDeck has no API to
+  intercede. The earlier framing as "HoloDeck-side concurrency cap"
+  amounted to clamping the test-runner semaphore via
+  `min(execution.parallel_test_cases, max_parallel)`, which is pure
+  duplication: a user who wants a lower cap can just set
+  `execution.parallel_test_cases` lower in the same agent YAML. There
+  is no scenario where `max_parallel` provides functionality
+  `parallel_test_cases` doesn't already cover.
+
+- **`enabled` is redundant with `agents` presence.** If a user defines
+  `claude.agents`, they want subagent forwarding; if they don't, they
+  don't. There is no third state. A separate boolean gate adds
+  ceremony without value.
+
+- **Avoids the bool|None tri-state hack.** With `enabled` removed, we no
+  longer need the `bool | None` workaround the previous research draft
+  introduced to satisfy FR-011 + FR-012. Both FRs are now obsolete and
+  removed from the spec.
+
+The deletion is acceptable because the `claude.subagents` block is
+recently introduced (commits `9c1dc8c` and `65e292e`) and not yet
+load-bearing in production agent.yaml configs. To make migration crisp,
+we add a `@model_validator(mode="before")` on `ClaudeConfig` that
+detects a legacy `subagents` key and raises a `ValidationError` with a
+specific message: *"`claude.subagents` is no longer supported; remove
+this block. Subagent forwarding is gated solely by the presence of
+`claude.agents`. To cap HoloDeck-side test concurrency, set
+`execution.parallel_test_cases` instead."* This is friendlier than the
+generic Pydantic "extra fields not permitted" that `extra="forbid"`
+would otherwise produce.
+
+**Alternatives considered**:
+
+- *Keep `subagents.enabled` only, drop `max_parallel`* — rejected:
+  `enabled` is still redundant with `agents` presence. Half-measure.
+- *Keep both with deprecation warnings (gradual sunset)* — rejected:
+  the block is too new to warrant a deprecation cycle. A clean delete
+  with a clear migration error is simpler and less code.
+- *Keep `max_parallel` for backward-compat with shipped configs* —
+  rejected: per `git log`, no shipped agent.yaml under `sample/` uses
+  the field, and the user explicitly directed deletion. The migration
+  cost is one-line removal in any custom configs.
+
+**Verification**: SC-005 (revised) — loading an `agent.yaml` containing
+`claude.subagents` produces a clear `ValidationError` pointing the user
+at `claude.agents` and `execution.parallel_test_cases`.
+
+---
+
+## 5. Empty `agents` map handling
+
+**Decision**: Treat `claude.agents: {}` (empty map) and a missing `agents`
+field as equivalent: do not pass `agents` to the SDK at all. Per the spec:
+
+> What happens when subagent definitions are empty (no agents listed)?
+> Treated the same as not having the `agents` section at all.
+
+Implemented by storing `agents` as `dict[str, SubagentSpec] | None` on
+`ClaudeConfig`, with a `model_validator` that normalizes `{}` to `None`.
+
+**Rationale**: Avoids passing an empty dict to the SDK, which would
+suppress the "no subagents configured" code path in the SDK.
+
+---
+
+## 6. Schema strategy
+
+**Decision**: Add a `SubagentSpec` `$def` to `schemas/agent.schema.json`
+mirroring the Pydantic model's structural shape (closed object,
+`additionalProperties: false`), and add `agents` as an optional property
+of `ClaudeConfig` typed as `{"type": "object",
+"additionalProperties": {"$ref": "#/$defs/SubagentSpec"}}`. The schema
+declares field types and the `model` enum, but **does not** encode the
+prompt/prompt_file mutual-exclusion rule — Pydantic owns that.
+
+**Rationale**: HoloDeck's schema is the user-facing contract for IDE
+autocompletion and pre-Pydantic validation. Mirroring the model keeps
+the two in lockstep. Closed-object enforcement catches typos early. The
+mutual-exclusion rule was originally drafted in the schema as a
+`oneOf`/`allOf` block, but verification surfaced that JSON Schema treats
+explicit-null as "present", so a config like `prompt: null, prompt_file:
+"x.md"` would fail the `oneOf` even though the user's intent is
+unambiguous. Pydantic's `model_validator` evaluates field truthiness
+correctly and is already the authoritative validator. Keeping the rule
+in one place (Pydantic) avoids divergence.
+
+**Alternatives considered**:
+
+- *Encode mutual exclusion via JSON Schema `oneOf`* — rejected at
+  verification time: nullable-field semantics make the constraint produce
+  false negatives; users get confusing schema errors instead of the clear
+  Pydantic message.
+- *Tighten `prompt` / `prompt_file` to `"string"` only (no null)* —
+  rejected: would force YAML users to omit the field rather than write
+  explicit null, a change in user-facing surface area for a small win.
+- *Auto-generate the schema from the Pydantic model* — out of scope; the
+  rest of the schema is hand-written and divergence would be jarring.
+- *Encode `claude.subagents` as a deprecated/ignored block in the
+  schema* — rejected: spec 029 deletes it outright (research §4).
+
+---
+
+## Open items
+
+None. All FRs and edge cases in the spec map to a concrete decision above.
+Phase 1 (data-model.md, contracts/, quickstart.md) can proceed.

--- a/specs/029-subagent-orchestration/spec.md
+++ b/specs/029-subagent-orchestration/spec.md
@@ -41,22 +41,7 @@ A user wants a subagent to only see a subset of the parent agent's tools, includ
 
 ---
 
-### User Story 3 - Limit HoloDeck-Side Subagent Concurrency (Priority: P3)
-
-A user wants to cap how many HoloDeck-driven invocations of a multi-agent configuration run in parallel (e.g., during evaluation runs or batch test execution). They set `max_parallel` on the existing `subagents` config so the HoloDeck test runner throttles its own dispatch.
-
-**Why this priority**: Resource management still matters for batch/test workflows. **However**, `max_parallel` does **not** control the SDK's internal subagent dispatch — once the parent agent starts orchestrating subagents via the Task tool, the SDK manages concurrency itself, and HoloDeck cannot intercede. This story therefore scopes `max_parallel` to HoloDeck-side concurrency only (e.g., the test runner's semaphore), not to the SDK.
-
-**Independent Test**: Set `claude.subagents.max_parallel: 2` alongside subagent definitions, dispatch three test cases that each invoke the agent, and verify HoloDeck holds at most two concurrent agent sessions open at any time.
-
-**Acceptance Scenarios**:
-
-1. **Given** `claude.subagents.max_parallel: 2` and three concurrent test cases targeting an agent with subagent definitions, **When** the test runner executes them, **Then** at most two test cases hold an agent session simultaneously.
-2. **Given** `claude.subagents.enabled: false` and subagent definitions present, **When** the config is loaded, **Then** a validation warning is raised that subagent definitions exist but subagents are disabled.
-
----
-
-### User Story 4 - Define Subagent with Custom System Prompt (Priority: P1)
+### User Story 3 - Define Subagent with Custom System Prompt (Priority: P1)
 
 A user wants each subagent to have specialized instructions. They provide a `prompt` field (inline text or file path) for each subagent definition, giving each subagent a distinct personality and expertise area.
 
@@ -75,7 +60,6 @@ A user wants each subagent to have specialized instructions. They provide a `pro
 ### Edge Cases
 
 - What happens when a subagent definition references a model not available to the user's API key? The SDK surfaces the error at runtime; HoloDeck should propagate it clearly.
-- What happens when `claude.agents` is defined but `claude.subagents.enabled` is not set? Default to enabled if agent definitions are present.
 - What happens when a subagent's tool list references tools not defined in the parent's tool configuration? Validation warning at config load time -- the tools may be built-in SDK tools (Read, Write, etc.), MCP-provided tools (`mcp__<server>__<tool>`), or the user may have made a mistake.
 - What happens when subagent definitions are empty (no agents listed)? Treated the same as not having the `agents` section at all.
 - What happens when a subagent's `prompt_file` path doesn't exist? A validation error is raised at config load time.
@@ -95,15 +79,13 @@ A user wants each subagent to have specialized instructions. They provide a `pro
 - **FR-007**: When `tools` is omitted from a subagent, the subagent MUST inherit all tools from the parent agent (achieved by passing `tools=None` to the SDK).
 - **FR-008**: System MUST validate `model` against the SDK-allowed set `{sonnet, opus, haiku, inherit}` and surface a clear error for any other value.
 - **FR-009**: System MUST allow subagent `tools` lists to reference parent-registered MCP tools by their fully qualified names (`mcp__<server>__<tool>`), so subagents share the parent's MCP server registrations but only see the tools enumerated in their `tools` list. Per-subagent MCP server registration is **not supported** by the SDK and MUST NOT be modeled in YAML.
-- **FR-010**: The existing `subagents.max_parallel` field, when set, MUST cap HoloDeck-side concurrent agent-session dispatch (e.g., test runner / batch execution). It MUST NOT be claimed to control SDK-internal subagent dispatch — the SDK manages that concurrency itself.
-- **FR-011**: System MUST default `subagents.enabled` to `true` when `claude.agents` definitions are present, unless explicitly set to `false`.
-- **FR-012**: System MUST raise a validation warning when `subagents.enabled: false` but agent definitions are present.
+- **FR-010**: System MUST treat the presence of one or more entries in `claude.agents` as the only gate for forwarding subagent definitions to the SDK. There is no separate `subagents.enabled` flag; HoloDeck does not throttle SDK-internal subagent dispatch (the SDK manages that itself), and HoloDeck-side test concurrency continues to be controlled exclusively by the existing top-level `execution.parallel_test_cases`.
+- **FR-011**: System MUST remove the existing `claude.subagents` config block (`enabled`, `max_parallel`) entirely. The block has no remaining semantics under spec 029 — `enabled` is redundant with `agents` presence, and `max_parallel` was never a meaningful SDK control. Removal is acceptable because the block is freshly introduced and not yet load-bearing in shipped configs.
 
 ### Key Entities
 
 - **SubagentDefinition**: A named subagent specification with `description`, `prompt`/`prompt_file`, `tools`, and `model`. (Note: no per-subagent MCP servers — the SDK does not support that.)
 - **ClaudeConfig.agents**: A dictionary mapping subagent names to their definitions; translated 1-to-1 to `ClaudeAgentOptions.agents` on the SDK side.
-- **SubagentConfig**: Existing config (`enabled`, `max_parallel`); `enabled` gates whether YAML-defined `agents` are forwarded to the SDK, and `max_parallel` is a HoloDeck-side concurrency cap (not an SDK concurrency control).
 
 ## Success Criteria *(mandatory)*
 
@@ -113,7 +95,7 @@ A user wants each subagent to have specialized instructions. They provide a `pro
 - **SC-002**: Subagent definitions are correctly translated to SDK `AgentDefinition` objects, verified by unit tests asserting on the four fields (`description`, `prompt`, `tools`, `model`) of the built options.
 - **SC-003**: Subagents with restricted `tools` lists (including MCP tool names) only see those tools, verified by unit tests asserting on each `AgentDefinition.tools` value.
 - **SC-004**: Invalid subagent configurations (missing description, both prompt and prompt_file set, neither prompt nor prompt_file set, nonexistent prompt_file, model outside the allowed literal set) produce clear validation errors at config load time.
-- **SC-005**: HoloDeck-side test runner / batch execution honors `max_parallel` as a session-dispatch cap, verified by an integration test that asserts on the maximum number of simultaneously open agent sessions.
+- **SC-005**: The `claude.subagents` config block is removed; loading an `agent.yaml` that still contains `claude.subagents` produces a clear validation error pointing users at the new model (presence of `claude.agents` is the only gate).
 
 ## Assumptions
 
@@ -122,4 +104,4 @@ A user wants each subagent to have specialized instructions. They provide a `pro
 - Subagent definitions are static (defined at config load time) -- dynamic subagent creation at runtime is out of scope.
 - The `model` field on subagent definitions is restricted to the SDK's literal set `{sonnet, opus, haiku, inherit}`; full model IDs are not accepted by the SDK type.
 - All MCP servers are registered at the parent (top-level `ClaudeAgentOptions.mcp_servers`); subagents share that registration and use their `tools` allowlist to scope which MCP tools they can call (`mcp__<server>__<tool>`).
-- The SDK manages subagent-dispatch concurrency internally; HoloDeck does not control how many subagents the SDK runs in parallel during a single agent session. `max_parallel` only constrains HoloDeck-driven concurrent agent sessions (e.g., test runner).
+- The SDK manages subagent-dispatch concurrency internally; HoloDeck does not and cannot control how many subagents the SDK runs in parallel during a single agent session. HoloDeck-side test concurrency is controlled exclusively by `execution.parallel_test_cases`; no separate subagent-specific knob is provided.

--- a/specs/029-subagent-orchestration/spec.md
+++ b/specs/029-subagent-orchestration/spec.md
@@ -5,7 +5,7 @@
 **Created**: 2026-03-28
 **Status**: Draft
 **Input**: Enable users to define full subagent specifications in YAML and wire them into the Claude SDK's agent orchestration system, allowing multi-agent teams to be configured without code.
-**Dependencies**: 026-sdk-config-additions (fallback_model per subagent), 027-mcp-http-sse-transport (subagents may use HTTP/SSE MCP servers)
+**Dependencies**: 027-mcp-http-sse-transport (parent agent may use HTTP/SSE MCP servers; subagents inherit access to those servers via their `tools` allowlist)
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -26,32 +26,32 @@ A user wants to create a research agent that delegates to specialized subagents:
 
 ---
 
-### User Story 2 - Configure Subagent with Custom MCP Servers (Priority: P2)
+### User Story 2 - Restrict Subagent Tool Access (Priority: P2)
 
-A user wants a subagent to have access to MCP servers that the parent agent doesn't use. For example, a "Database Analyst" subagent connects to a database MCP server while the parent agent has no database access.
+A user wants a subagent to only see a subset of the parent agent's tools, including a subset of MCP-provided tools. For example, a "Database Analyst" subagent receives the database MCP server's tools (e.g., `mcp__db__query`) while a "Researcher" subagent does not — even though both subagents share the same MCP server registration on the parent.
 
-**Why this priority**: MCP isolation per subagent is a key security and capability pattern -- subagents should only access the resources they need.
+**Why this priority**: Tool-level isolation is the core security and capability boundary the SDK provides for subagents. The SDK does **not** support per-subagent MCP server registration — all MCP servers register at the parent level, and isolation is enforced via each subagent's `tools` allowlist.
 
-**Independent Test**: Define a subagent with its own `mcp_servers` section, initialize the agent, and verify the subagent's SDK definition includes the MCP server config.
+**Independent Test**: Define two subagents whose `tools` lists name different MCP tool identifiers (`mcp__<server>__<tool>`); initialize the agent and verify each subagent's `AgentDefinition.tools` contains only the named entries.
 
 **Acceptance Scenarios**:
 
-1. **Given** a subagent definition with `mcp_servers` containing a database MCP server (STDIO or HTTP/SSE), **When** the agent is initialized, **Then** the subagent's SDK definition includes the MCP server configuration.
-2. **Given** a subagent with MCP servers and the parent agent with different MCP servers, **When** both are initialized, **Then** each has only its own configured MCP servers.
+1. **Given** a parent agent with an MCP server registered and a subagent definition whose `tools` list includes `mcp__db__query`, **When** the agent is initialized, **Then** the subagent's `AgentDefinition.tools` contains `mcp__db__query` and the SDK enforces that only those tools are usable from the subagent.
+2. **Given** two subagents sharing one parent-level MCP server but with different `tools` lists, **When** both are initialized, **Then** each subagent only has access to the tool names it explicitly enumerates.
 
 ---
 
-### User Story 3 - Control Parallel Subagent Execution (Priority: P2)
+### User Story 3 - Limit HoloDeck-Side Subagent Concurrency (Priority: P3)
 
-A user wants to limit how many subagents run concurrently to control resource usage. They set `max_parallel` on the existing `subagents` config to cap concurrency.
+A user wants to cap how many HoloDeck-driven invocations of a multi-agent configuration run in parallel (e.g., during evaluation runs or batch test execution). They set `max_parallel` on the existing `subagents` config so the HoloDeck test runner throttles its own dispatch.
 
-**Why this priority**: Resource management is important for production but the existing `SubagentConfig.max_parallel` field already exists -- this story ensures it works with the new subagent definitions.
+**Why this priority**: Resource management still matters for batch/test workflows. **However**, `max_parallel` does **not** control the SDK's internal subagent dispatch — once the parent agent starts orchestrating subagents via the Task tool, the SDK manages concurrency itself, and HoloDeck cannot intercede. This story therefore scopes `max_parallel` to HoloDeck-side concurrency only (e.g., the test runner's semaphore), not to the SDK.
 
-**Independent Test**: Set `claude.subagents.max_parallel: 2` alongside subagent definitions, initialize the agent, and verify the SDK options reflect the concurrency limit.
+**Independent Test**: Set `claude.subagents.max_parallel: 2` alongside subagent definitions, dispatch three test cases that each invoke the agent, and verify HoloDeck holds at most two concurrent agent sessions open at any time.
 
 **Acceptance Scenarios**:
 
-1. **Given** `claude.subagents.max_parallel: 2` and three subagent definitions, **When** the agent is initialized, **Then** the SDK is configured to run at most 2 subagents concurrently.
+1. **Given** `claude.subagents.max_parallel: 2` and three concurrent test cases targeting an agent with subagent definitions, **When** the test runner executes them, **Then** at most two test cases hold an agent session simultaneously.
 2. **Given** `claude.subagents.enabled: false` and subagent definitions present, **When** the config is loaded, **Then** a validation warning is raised that subagent definitions exist but subagents are disabled.
 
 ---
@@ -76,45 +76,50 @@ A user wants each subagent to have specialized instructions. They provide a `pro
 
 - What happens when a subagent definition references a model not available to the user's API key? The SDK surfaces the error at runtime; HoloDeck should propagate it clearly.
 - What happens when `claude.agents` is defined but `claude.subagents.enabled` is not set? Default to enabled if agent definitions are present.
-- What happens when a subagent's tool list references tools not defined in the parent's tool configuration? Validation warning at config load time -- the tools may be built-in SDK tools (Read, Write, etc.) or the user may have made a mistake.
+- What happens when a subagent's tool list references tools not defined in the parent's tool configuration? Validation warning at config load time -- the tools may be built-in SDK tools (Read, Write, etc.), MCP-provided tools (`mcp__<server>__<tool>`), or the user may have made a mistake.
 - What happens when subagent definitions are empty (no agents listed)? Treated the same as not having the `agents` section at all.
 - What happens when a subagent's `prompt_file` path doesn't exist? A validation error is raised at config load time.
+- What happens when neither `prompt` nor `prompt_file` is provided? A validation error is raised at config load time -- the SDK requires a non-empty prompt on every `AgentDefinition`.
+- What happens when a subagent's `model` value is outside `{sonnet, opus, haiku, inherit}`? A validation error is raised at config load time -- the SDK's `AgentDefinition.model` only accepts those four literal values.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
 - **FR-001**: System MUST accept an `agents` section under `claude` in agent YAML containing named subagent definitions.
-- **FR-002**: Each subagent definition MUST support: `description` (string, required), `prompt` (inline string, optional), `prompt_file` (file path, optional), `tools` (list of tool names, optional), `model` (string, optional), and `mcp_servers` (list of MCP configs, optional).
-- **FR-003**: System MUST translate each subagent definition into the Claude SDK's `AgentDefinition` format.
+- **FR-002**: Each subagent definition MUST support: `description` (string, required), `prompt` (inline string, required-if-no-`prompt_file`), `prompt_file` (file path, required-if-no-`prompt`), `tools` (list of tool names, optional), and `model` (string, optional, restricted to `sonnet | opus | haiku | inherit`).
+- **FR-003**: System MUST translate each subagent definition into the Claude SDK's `AgentDefinition` dataclass with exactly its four supported fields: `description`, `prompt`, `tools`, `model`.
 - **FR-004**: System MUST validate that each subagent has a `description` field (required by the SDK for routing decisions).
 - **FR-005**: System MUST resolve `prompt_file` paths relative to the agent YAML directory and load file contents as the prompt.
-- **FR-006**: System MUST validate that `prompt` and `prompt_file` are not both specified on the same subagent (mutually exclusive).
-- **FR-007**: When `tools` is omitted from a subagent, the subagent MUST inherit all tools from the parent agent.
-- **FR-008**: System MUST translate subagent `mcp_servers` using the same MCP bridge logic as the parent (supporting STDIO, SSE, and HTTP transports).
-- **FR-009**: The existing `subagents.max_parallel` field MUST be passed to the SDK to control concurrency.
-- **FR-010**: System MUST default `subagents.enabled` to `true` when `claude.agents` definitions are present, unless explicitly set to `false`.
-- **FR-011**: System MUST raise a validation warning when `subagents.enabled: false` but agent definitions are present.
+- **FR-006**: System MUST validate that `prompt` and `prompt_file` are not both specified on the same subagent (mutually exclusive) and that at least one of them is set (the SDK requires a non-empty prompt on every `AgentDefinition`).
+- **FR-007**: When `tools` is omitted from a subagent, the subagent MUST inherit all tools from the parent agent (achieved by passing `tools=None` to the SDK).
+- **FR-008**: System MUST validate `model` against the SDK-allowed set `{sonnet, opus, haiku, inherit}` and surface a clear error for any other value.
+- **FR-009**: System MUST allow subagent `tools` lists to reference parent-registered MCP tools by their fully qualified names (`mcp__<server>__<tool>`), so subagents share the parent's MCP server registrations but only see the tools enumerated in their `tools` list. Per-subagent MCP server registration is **not supported** by the SDK and MUST NOT be modeled in YAML.
+- **FR-010**: The existing `subagents.max_parallel` field, when set, MUST cap HoloDeck-side concurrent agent-session dispatch (e.g., test runner / batch execution). It MUST NOT be claimed to control SDK-internal subagent dispatch — the SDK manages that concurrency itself.
+- **FR-011**: System MUST default `subagents.enabled` to `true` when `claude.agents` definitions are present, unless explicitly set to `false`.
+- **FR-012**: System MUST raise a validation warning when `subagents.enabled: false` but agent definitions are present.
 
 ### Key Entities
 
-- **SubagentDefinition**: A named subagent specification with description, prompt, tools, model, and MCP servers.
-- **ClaudeConfig.agents**: A dictionary mapping subagent names to their definitions.
-- **SubagentConfig**: Existing config extended to interact with the new agent definitions.
+- **SubagentDefinition**: A named subagent specification with `description`, `prompt`/`prompt_file`, `tools`, and `model`. (Note: no per-subagent MCP servers — the SDK does not support that.)
+- **ClaudeConfig.agents**: A dictionary mapping subagent names to their definitions; translated 1-to-1 to `ClaudeAgentOptions.agents` on the SDK side.
+- **SubagentConfig**: Existing config (`enabled`, `max_parallel`); `enabled` gates whether YAML-defined `agents` are forwarded to the SDK, and `max_parallel` is a HoloDeck-side concurrency cap (not an SDK concurrency control).
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
 - **SC-001**: Users can define multi-agent teams entirely in YAML with distinct prompts, models, and tool access per subagent.
-- **SC-002**: Subagent definitions are correctly translated to SDK `AgentDefinition` objects, verified by unit tests asserting on the built options.
-- **SC-003**: Subagents with custom MCP servers receive only their configured servers, not the parent's.
-- **SC-004**: Invalid subagent configurations (missing description, both prompt and prompt_file set, nonexistent prompt_file) produce clear validation errors at config load time.
-- **SC-005**: The concurrency limit (`max_parallel`) is respected by the SDK when multiple subagents are active.
+- **SC-002**: Subagent definitions are correctly translated to SDK `AgentDefinition` objects, verified by unit tests asserting on the four fields (`description`, `prompt`, `tools`, `model`) of the built options.
+- **SC-003**: Subagents with restricted `tools` lists (including MCP tool names) only see those tools, verified by unit tests asserting on each `AgentDefinition.tools` value.
+- **SC-004**: Invalid subagent configurations (missing description, both prompt and prompt_file set, neither prompt nor prompt_file set, nonexistent prompt_file, model outside the allowed literal set) produce clear validation errors at config load time.
+- **SC-005**: HoloDeck-side test runner / batch execution honors `max_parallel` as a session-dispatch cap, verified by an integration test that asserts on the maximum number of simultaneously open agent sessions.
 
 ## Assumptions
 
-- The Claude Agent SDK's `AgentDefinition` type supports `description`, `prompt`, `tools`, `model`, `skills`, `memory`, and `mcpServers` fields.
+- The Claude Agent SDK's `AgentDefinition` dataclass exposes exactly four fields: `description: str` (required), `prompt: str` (required), `tools: list[str] | None`, `model: Literal["sonnet", "opus", "haiku", "inherit"] | None`. There are **no** `skills`, `memory`, `mcp_servers`, or `fallback_model` fields on `AgentDefinition`; these are top-level `ClaudeAgentOptions` concerns or are not exposed by the SDK at all.
 - The parent agent automatically delegates to subagents based on their `description` fields -- no explicit routing logic is needed in HoloDeck.
 - Subagent definitions are static (defined at config load time) -- dynamic subagent creation at runtime is out of scope.
-- The `model` field on subagent definitions accepts the same values as the SDK (e.g., "sonnet", "opus", "haiku", "inherit").
+- The `model` field on subagent definitions is restricted to the SDK's literal set `{sonnet, opus, haiku, inherit}`; full model IDs are not accepted by the SDK type.
+- All MCP servers are registered at the parent (top-level `ClaudeAgentOptions.mcp_servers`); subagents share that registration and use their `tools` allowlist to scope which MCP tools they can call (`mcp__<server>__<tool>`).
+- The SDK manages subagent-dispatch concurrency internally; HoloDeck does not control how many subagents the SDK runs in parallel during a single agent session. `max_parallel` only constrains HoloDeck-driven concurrent agent sessions (e.g., test runner).

--- a/specs/029-subagent-orchestration/tasks-us1.md
+++ b/specs/029-subagent-orchestration/tasks-us1.md
@@ -1,0 +1,207 @@
+---
+
+description: "Per-user-story tasks for US1 (P1): Define a Multi-Agent Research Team"
+---
+
+# Tasks (US1): Subagent Definitions & Multi-Agent Orchestration — User Story 1
+
+**Spec ID**: 029-subagent-orchestration
+**Branch**: `feature/029-claude-subagents`
+**Input**: Design documents from `/specs/029-subagent-orchestration/`
+**Prerequisites**: plan.md, spec.md (US1 + FR-001..FR-011 + SC-001..SC-005), data-model.md, research.md §1/§5/§6, contracts/subagent-spec.schema.json
+
+**Scope**: This file delivers **only User Story 1 (P1) — Define a Multi-Agent Research Team** as the MVP increment. US2 (per-subagent MCP tool scoping) and US3 (`prompt`/`prompt_file` mutual-exclusion + file resolution) live in their own per-story tasks files.
+
+US1 specifically covers:
+- Three named subagents (researcher / analyst / writer) round-trip from `claude.agents` YAML to SDK `AgentDefinition` objects.
+- Per-subagent `model: haiku | sonnet | opus | inherit` override.
+- Per-subagent `tools: [...]` allowlist.
+- Omitted `tools` → subagent inherits all parent tools (None passed to SDK).
+
+Foundational phase establishes the `SubagentSpec` model + `ClaudeConfig.agents` field skeleton and removes the legacy `claude.subagents` block. The legacy removal MUST land in foundational (not US1) because `ClaudeConfig` uses `extra="forbid"`, so the new `agents` field cannot be added next to a leftover `subagents` field without breaking config load, and US1's tests would otherwise fail before they could exercise the new translation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on other [P] tasks in the same phase).
+- **[US1]**: Tagged on tasks scoped to User Story 1. Setup / Foundational / Polish tasks are NOT tagged with a story.
+- File paths are absolute or repository-relative.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the working environment is ready. No new dependencies are introduced by this feature (`claude-agent-sdk==0.1.44` already installed; `AgentDefinition` and `ClaudeAgentOptions.agents` are available).
+
+- [ ] T001 Verify `claude-agent-sdk==0.1.44` is installed and `AgentDefinition` import works by running `source .venv/bin/activate && python -c "from claude_agent_sdk.types import AgentDefinition; from claude_agent_sdk import ClaudeAgentOptions; print(AgentDefinition.__dataclass_fields__.keys()); print('agents' in ClaudeAgentOptions.__dataclass_fields__)"`. Expect the four fields `description, prompt, tools, model` and `True` for `agents`. (Sanity gate per plan.md "Concrete integration points".)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Stand up the SDK-translation surface and the validation surface needed by US1, US2, and US3. Foundational tests are authored FIRST and verified FAILING before implementation per the project's TDD discipline (constitution principle III).
+
+**Foundational scope** (shared with US2 and US3 — skip whichever tasks have landed on the branch):
+- Delete legacy `SubagentConfig` + `ClaudeConfig.subagents` (FR-011, SC-005).
+- Add `SubagentSpec` model skeleton + `description` non-empty validator + `ClaudeConfig.agents` field + empty-map normalizer (FR-001, FR-002, FR-004, FR-008, FR-010).
+- Add legacy-key migration validator + targeted error message (SC-005, FR-011).
+- Add `build_options()` translation block (FR-001, FR-003, FR-007, FR-010, SC-002). **Shared with US2** — US2's T005 covers the same edit; first owner to land wins, the other deletes their copy.
+- Sync `schemas/agent.schema.json` to the new shape.
+- Remove legacy tests; add migration-error and translation tests.
+
+**CRITICAL**: No US1 (Phase 3) work begins until Phase 2 is complete.
+
+### Foundational tests (write FIRST — must FAIL before T009–T015)
+
+- [ ] T002 [P] Add unit test `test_legacy_subagents_block_rejected` in `tests/unit/models/test_claude_config.py` that constructs `ClaudeConfig(**{"subagents": {"enabled": True}})` and asserts the resulting `ValidationError` message contains the substring `"claude.subagents is no longer supported"` and mentions both `claude.agents` and `execution.parallel_test_cases`. Verify it FAILS at this point (validator not yet added). Traces to SC-005, FR-011.
+- [ ] T003 [P] Add unit test `test_claude_config_agents_empty_map_normalized_to_none` in `tests/unit/models/test_claude_config.py` asserting `ClaudeConfig(agents={}).agents is None`. Verify it FAILS (field/validator not yet added). Traces to FR-010, edge case "empty agents map", research.md §5.
+- [ ] T004 [P] Add a foundational translation test `test_build_options_no_agents_omits_field` in the existing `tests/unit/lib/backends/test_claude_backend.py` asserting that when `claude.agents is None`, `ClaudeAgentOptions.agents` is `None` (or absent from `opts_kwargs`). Verify it FAILS or passes trivially today (translation block not yet added). Traces to FR-010.
+
+### Foundational implementation
+
+- [ ] T005 Delete the `SubagentConfig` Pydantic model (lines ~63-70) and the `ClaudeConfig.subagents` field (lines ~115-118) from `src/holodeck/models/claude_config.py`. Also remove `SubagentConfig` from any module-level `__all__` if present. Traces to FR-011, plan.md "Concrete integration points" line 1.
+- [ ] T006 Add the new `SubagentSpec` Pydantic model in `src/holodeck/models/claude_config.py` next to the other Claude config models, with `model_config = ConfigDict(extra="forbid")` and these fields per data-model.md §1: `description: str`, `prompt: str | None = None`, `prompt_file: str | None = None`, `tools: list[str] | None = None`, `model: Literal["sonnet", "opus", "haiku", "inherit"] | None = None`. **Do not** add `prompt`/`prompt_file` mutual-exclusion / file-resolution validators yet — those belong to US3. Do add a `description.strip() != ""` check (data-model.md rule 4) since US1 acceptance scenario 1 asserts on `description`. Traces to FR-001, FR-002, FR-004, FR-008.
+- [ ] T007 Add the `agents: dict[str, SubagentSpec] | None = None` field to `ClaudeConfig` in `src/holodeck/models/claude_config.py` with the description text from data-model.md §2. Add a `@model_validator(mode="after")` that normalizes `agents == {}` → `agents = None` (research.md §5 / data-model.md rule 1). Confirm T003 now PASSES. Traces to FR-001, FR-010, edge-case "empty agents map".
+- [ ] T008 Add a `@model_validator(mode="before")` on `ClaudeConfig` in `src/holodeck/models/claude_config.py` that detects a legacy `subagents` key in the input dict and raises `ValueError` with the exact message from data-model.md §2 rule 2 (\"`claude.subagents` is no longer supported; remove this block. Subagent forwarding is gated solely by the presence of `claude.agents`. To cap HoloDeck-side test concurrency, set `execution.parallel_test_cases` instead.\"). Confirm T002 now PASSES. Traces to FR-011, SC-005.
+- [ ] T009 In `src/holodeck/lib/backends/claude_backend.py` `build_options()` (around lines 346-355, immediately after the existing `if claude.disallowed_tools:` block), add the SDK translation block from data-model.md §2:
+
+  ```python
+  if claude.agents:
+      opts_kwargs["agents"] = {
+          name: AgentDefinition(
+              description=spec.description,
+              prompt=spec.prompt,
+              tools=spec.tools,
+              model=spec.model,
+          )
+          for name, spec in claude.agents.items()
+      }
+  ```
+
+  Add `AgentDefinition` to the existing `from claude_agent_sdk.types import (...)` block at `src/holodeck/lib/backends/claude_backend.py:24-29` (alongside `HookContext`, `HookEvent`, `McpSdkServerConfig`, `SyncHookJSONOutput`). Confirm T004 now PASSES. **Shared with US2.T005** — first owner wins. Traces to FR-001, FR-003, FR-007, FR-010, US1 acceptance scenarios 1–4, SC-002.
+- [ ] T010 [P] Update `schemas/agent.schema.json`: delete the `SubagentConfig` `$def` (lines ~158-176) and the `subagents` property under `ClaudeConfig.properties` (lines ~212-215). Add a new `SubagentSpec` `$def` and an `agents` property under `ClaudeConfig.properties` per `specs/029-subagent-orchestration/contracts/subagent-spec.schema.json` (the `$defs.SubagentSpec` block and the `patches.ClaudeConfig.properties.agents` block). Traces to FR-001, FR-002, FR-008, SC-005, research.md §6.
+- [ ] T011 [P] Remove the legacy `TestSubagentConfig` test class (lines ~158-196) and the `test_with_subagents` case + the `subagents=...` line in `test_with_all_fields` (around lines 211, 248-255, 269) from `tests/unit/models/test_claude_config.py`. Also remove the `SubagentConfig` import. Traces to plan.md "Concrete integration points" final line; SC-005.
+
+**Checkpoint**: `ClaudeConfig` accepts an `agents` map of `SubagentSpec`s, rejects the legacy `subagents` block with a targeted error, the SDK translation block populates `ClaudeAgentOptions.agents`, and the schema mirrors the model. US1 acceptance-scenario tests can now proceed.
+
+---
+
+## Phase 3: User Story 1 — Define a Multi-Agent Research Team (Priority: P1) MVP
+
+**Story Goal**: A user can declare three named subagents (researcher, analyst, writer) under `claude.agents` in YAML — each with its own `description`, inline `prompt`, optional `tools` list, and optional `model` literal — and have all three round-trip into `ClaudeAgentOptions.agents` as `AgentDefinition` objects when the agent is initialized.
+
+**Independent Test**: Run the new unit tests in `tests/unit/lib/backends/test_claude_backend.py` (added in this phase) — they construct an `Agent` with a `claude.agents` map of three subagents and assert that `build_options(...)` returns a `ClaudeAgentOptions` whose `agents` dict has three entries, each an `AgentDefinition` with the expected `description`, `prompt`, `tools`, and `model` values, plus the four US1 acceptance scenarios (round-trip, model override, tools allowlist, tools omitted → None).
+
+### Tests for User Story 1 (write FIRST — must FAIL before T016/T017)
+
+> Foundational tests T002–T004 cover `ClaudeAgentOptions.agents` baseline (None/empty), legacy migration error, and empty-map normalization. The US1 tests below cover the four acceptance scenarios on top of that scaffolding.
+
+- [ ] T012 [P] [US1] Add unit test `test_subagent_spec_round_trip_minimal` in `tests/unit/models/test_claude_config.py`: construct a `SubagentSpec(description="x", prompt="y")` and assert `description == "x"`, `prompt == "y"`, `tools is None`, `model is None`. Verify it PASSES once T006 has landed (round-trip on the model itself, not the SDK translation). Traces to FR-001, FR-002, US1 acceptance scenario 1.
+- [ ] T013 [P] [US1] Add unit test `test_subagent_spec_model_literal_accepts_allowed` (parametrized over `["sonnet", "opus", "haiku", "inherit"]`) and `test_subagent_spec_model_literal_rejects_other` (parametrized over `["claude-3-5-sonnet-20241022", "gpt-4", "haiku-3"]` expecting `ValidationError`) in `tests/unit/models/test_claude_config.py`. Traces to FR-008, US1 acceptance scenario 2, edge case "model outside allowed set".
+- [ ] T014 [P] [US1] Add the four SDK-translation tests to the existing `tests/unit/lib/backends/test_claude_backend.py` (do NOT create a new file — match the existing layout convention used by every other backend test in that directory). All marked `@pytest.mark.unit`:
+  - `test_build_options_translates_three_named_subagents`: three entries (researcher / analyst / writer) round-trip 1-to-1 into `AgentDefinition` objects with matching `description` and `prompt`. Traces to US1 acceptance scenario 1, SC-002.
+  - `test_build_options_subagent_model_override_haiku`: a subagent with `model="haiku"` produces `AgentDefinition(model="haiku")` on the SDK side. Traces to US1 acceptance scenario 2, SC-002.
+  - `test_build_options_subagent_tools_allowlist`: a subagent with `tools=["WebSearch", "WebFetch"]` produces `AgentDefinition(tools=["WebSearch", "WebFetch"])`. Traces to US1 acceptance scenario 3, SC-003.
+  - `test_build_options_subagent_tools_omitted_inherits_all`: a subagent with no `tools` field produces `AgentDefinition(tools=None)`. Traces to US1 acceptance scenario 4, FR-007.
+
+  All four tests must construct `Agent` via the project's existing helpers/fixtures (mirror the patterns in `tests/unit/lib/backends/test_claude_backend.py`) and call `build_options(...)`. **Verify all four tests FAIL** before T016/T017 if the foundational T009 translation block has not yet been merged on this branch.
+
+### Implementation for User Story 1
+
+- [ ] T015 [US1] **No-op verification**: confirm the foundational translation block (T009) is in place. If T009 was deferred (e.g., parallel branch), implement it here. The translation logic is identical; T009 is the canonical home.
+- [ ] T016 [US1] If any of T012/T013/T014 fail because of missing model fields or translation gaps, surface the diff and fix it inside the foundational tasks (T006/T009) rather than adding US1-specific code. US1 should be a pure-test slice on top of the foundational scaffolding.
+- [ ] T017 [US1] Run T012/T013/T014 to green: `source .venv/bin/activate && pytest tests/unit/models/test_claude_config.py tests/unit/lib/backends/test_claude_backend.py -n auto -v`. Confirm all four US1 backend cases plus the two US1 model cases pass.
+
+**Checkpoint**: User Story 1 is fully functional and independently testable. A user can write a `claude.agents` block with three named subagents, optional per-subagent `model` literal, and optional `tools` allowlist; the SDK receives matching `AgentDefinition` objects.
+
+---
+
+## Phase N: Polish & Cross-Cutting Concerns
+
+**Purpose**: Ship-quality polish for the US1 increment. Keep this phase narrow — extended validators (mutual exclusion, prompt_file resolution, tool-name typo warnings) belong to US3 / US2 task files, not here.
+
+- [ ] T018 [P] Run `make format && make lint && make type-check` from the repo root and resolve any issues introduced by T005–T014. Traces to constitution principle (code quality).
+- [ ] T019 [P] Add a US1 sample agent.yaml under `sample/research/claude/research-team.yaml` (or the closest existing scenario directory) demonstrating two or three subagents per the `quickstart.md §1` minimal example, **without** `prompt_file` (US3 territory) and **without** MCP-scoped tools (US2 territory) — keep it pure US1: inline `prompt`, optional `model`, optional `tools` allowlist, one subagent that omits `tools` to demonstrate inheritance. Traces to SC-001, plan.md project-structure tree (sample/ entry).
+- [ ] T020 Verify the full project test suite still passes: `source .venv/bin/activate && make test-unit`. Confirm no regressions in the broader `tests/unit/models/` or `tests/unit/lib/backends/` trees from the legacy-block deletion. Traces to constitution principle (test discipline).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — T001 can run immediately.
+- **Phase 2 (Foundational)**: Depends on Phase 1. **Blocks Phase 3.** TDD-ordered: tests T002–T004 are authored first and verified failing; then implementation T005–T011 lands; foundational tests must be green before Phase 3 begins.
+- **Phase 3 (US1)**: Depends on Phase 2. T012–T014 are pure tests (model + translation); T015–T017 verify-and-run.
+- **Phase N (Polish)**: Depends on Phase 3 completion. T020 should run last (after T018 fixes any lint/type issues).
+
+### Within Phase 2 (Foundational)
+
+- Tests first: T002, T003, T004 are `[P]` — author in parallel, all verified FAILING.
+- Implementation in order: T005 → T006 → T007 → T008 are sequential (all in `claude_config.py`, same file). T009 (translation in `claude_backend.py`) can run in parallel with T010 (`agent.schema.json`) and T011 (test cleanup) — all marked `[P]`.
+- T002 turns green after T008. T003 turns green after T007. T004 turns green after T009.
+
+### Within Phase 3 (US1)
+
+- T012, T013, T014 are all `[P]` — different test files / functions; T012 and T013 share `test_claude_config.py` so coordinate on merge.
+- T015 is a no-op verification IF foundational T009 has landed; otherwise it is the canonical implementation site.
+- T017 depends on T012–T014.
+
+### Cross-File Dependencies a Developer Should Know
+
+- `src/holodeck/models/claude_config.py` is touched by T005, T006, T007, T008 — strictly sequential edits to the same file.
+- `tests/unit/models/test_claude_config.py` is touched by T002, T003, T011, T012, T013 — these can be authored in parallel only if developers coordinate around merge conflicts (different test classes / functions). Recommend serializing if a single dev is working alone.
+- `src/holodeck/lib/backends/claude_backend.py` (T009, T015) and `tests/unit/lib/backends/test_claude_backend.py` (T004, T014) depend on `SubagentSpec` and `ClaudeConfig.agents` existing — i.e. T006 and T007 must be merged first.
+- The legacy-block deletion (T005, T010, T011) must land **before** T009 ships any agent.yaml fixture, because `extra="forbid"` on `ClaudeConfig` would otherwise reject any fixture that exercises the new `agents` key alongside a leftover `subagents` field.
+- **US2 overlap**: foundational T009 (translation) is shared with US2's T005. First owner to land wins; the other deletes their copy at PR review.
+
+---
+
+## Parallel Execution Example: User Story 1
+
+Once Phase 2 is green, the three US1 test-authoring tasks can be picked up in parallel:
+
+```bash
+# Author all three US1 test tasks in parallel — different files / different test functions:
+T012 [US1] tests/unit/models/test_claude_config.py::test_subagent_spec_round_trip_minimal
+T013 [US1] tests/unit/models/test_claude_config.py::test_subagent_spec_model_literal_*
+T014 [US1] tests/unit/lib/backends/test_claude_backend.py  (four new translation tests)
+
+# Run them to confirm they all PASS once foundational T006/T007/T009 are merged:
+source .venv/bin/activate && pytest \
+  tests/unit/models/test_claude_config.py::TestSubagentSpec \
+  tests/unit/lib/backends/test_claude_backend.py \
+  -n auto -v
+```
+
+If any of T012–T014 fail, fix the foundational task they depend on (T006 for model fields, T009 for translation) — do NOT add US1-specific code outside the foundational scaffolding.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. **Phase 1: Setup** — T001 sanity-check the SDK surface.
+2. **Phase 2: Foundational (TDD)** — Author T002–T004 first (foundational tests, all FAILING). Then land T005–T011 in topological order. Verify T002–T004 turn green at T008/T007/T009 respectively.
+3. **Phase 3: User Story 1** — Author T012–T014 (acceptance-scenario tests). They should pass immediately if Phase 2 is sound. T015–T017 are verification.
+4. **STOP and VALIDATE**: A user can hand-write the quickstart.md §1 YAML example and `holodeck chat` it without errors; all four US1 acceptance scenarios are covered by passing unit tests.
+5. **Phase N: Polish** — T018 (format/lint/type), T019 (sample), T020 (full suite).
+6. **Ship**.
+
+### Out-of-Scope for US1 (deliberately deferred)
+
+- Mutual exclusion of `prompt`/`prompt_file` and file resolution → **US3** (separate tasks file).
+- Tool-name typo warnings (`UserWarning` for unknown built-ins / non-`mcp__` / non-bridged names) → **US2** (per data-model.md rule 5).
+- Per-subagent MCP tool scoping demos and tests → **US2**.
+
+If a developer is tempted to "just add the mutual-exclusion validator while editing `SubagentSpec`" during T006, **don't** — it changes the test surface and risks landing US3 work in the US1 PR. Keep the slice surgical.
+
+---
+
+## Notes
+
+- Every task above traces to a concrete spec FR / SC / acceptance scenario or to a plan.md integration point. No invented scope.
+- `[P]` is reserved for tasks in different files with no ordering dependency.
+- TDD discipline applies to every phase: Foundational tests (T002–T004) and US1 tests (T012–T014) are authored before implementation and verified FAILING (or passing trivially) at the time they're written.
+- Commit after each task or at the natural Phase 2 / Phase 3 / Phase N checkpoints.
+- Do not delete pre-existing dead code while editing `claude_config.py` or `claude_backend.py` — clean up only the symbols this feature removes (`SubagentConfig`, `ClaudeConfig.subagents`).

--- a/specs/029-subagent-orchestration/tasks-us2.md
+++ b/specs/029-subagent-orchestration/tasks-us2.md
@@ -1,0 +1,183 @@
+---
+description: "Per-user-story tasks for US2 (Restrict Subagent Tool Access) — spec 029-subagent-orchestration"
+---
+
+# Tasks: Subagent Orchestration — User Story 2 (Restrict Subagent Tool Access)
+
+**Input**: Design documents from `/specs/029-subagent-orchestration/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/subagent-spec.schema.json, quickstart.md
+**Scope**: This file covers **only User Story 2 (P2)** — subagent `tools`-allowlist scoping, with emphasis on MCP tool isolation and the load-time tool-name typo warning. Foundational tasks below overlap with US1 (shared scaffolding) and are listed here so this file is self-contained.
+
+**Tests**: Tests are REQUIRED for this feature. Spec SC-003 mandates per-`AgentDefinition.tools` assertions, and the data-model rule #5 (typo warning) is observable only via `pytest.warns(UserWarning)`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: `US2` for tasks unique to this story; Setup/Foundational/Polish carry no story tag
+- All file paths are absolute or repo-relative
+
+## Path Conventions
+
+Single-project layout per `plan.md`:
+
+- Source: `src/holodeck/`
+- Tests: `tests/unit/`
+- Schema: `schemas/agent.schema.json`
+- Samples: `sample/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Ensure the dev environment can run the targeted unit tests for this feature.
+
+- [ ] T001 Verify the working tree is on `feature/029-claude-subagents` and that `make init && source .venv/bin/activate` produces a green `pytest tests/unit/models/test_claude_config.py tests/unit/lib/backends/test_claude_backend.py -n auto` baseline. No code changes.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the `SubagentSpec` model surface, the `ClaudeConfig.agents` field, and the SDK translation block that US2 validates against. **Shared with US1's Foundational** — every task in this phase is canonically owned by US1's foundational pass (US1.T002–T011). If US1's Foundational PR is already merged on `feature/029-claude-subagents`, skip Phase 2 entirely and jump to Phase 3. This phase is reproduced here only so US2 is self-contained as a deliverable slice.
+
+**TDD note**: foundational tests are authored first per US1.T002–T004; this file does not duplicate them. If US2 is being delivered standalone, run `pytest tests/unit/models/test_claude_config.py tests/unit/lib/backends/test_claude_backend.py -n auto` after every implementation task to verify the foundational test surface from US1 stays green.
+
+**CRITICAL**: No US2 (Phase 3) work can begin until this phase is complete.
+
+- [ ] T002 Add `SubagentSpec` Pydantic v2 model to `src/holodeck/models/claude_config.py` with `extra="forbid"` and the five fields per `data-model.md` §1: `description: str`, `prompt: str | None = None`, `prompt_file: str | None = None`, `tools: list[str] | None = None`, `model: Literal["sonnet", "opus", "haiku", "inherit"] | None = None`. (Skeleton only; the typo-warning validator is added in Phase 3 / T010.) **Shared with US1.T006** — first owner wins.
+- [ ] T003 Add `agents: dict[str, SubagentSpec] | None = None` field to the existing `ClaudeConfig` model in `src/holodeck/models/claude_config.py`, with the `description` text from `data-model.md` §2. **Shared with US1.T007**.
+- [ ] T004 Add the empty-map normalization `@model_validator(mode="after")` on `ClaudeConfig` (`if self.agents == {}: self.agents = None`) per `research.md` §5. **Shared with US1.T007**.
+- [ ] T005 In `src/holodeck/lib/backends/claude_backend.py` (`build_options()`, around lines 346-355), add the translation block from `data-model.md` §2: when `claude.agents` is non-empty, populate `opts_kwargs["agents"]` with `AgentDefinition(description=..., prompt=..., tools=spec.tools, model=spec.model)` per entry. Add `AgentDefinition` to the existing `from claude_agent_sdk.types import (...)` block at lines 24-29. The `tools` field passes through 1:1 — the SDK enforces the allowlist at runtime (FR-009). **Shared with US1.T009** — if US1's Foundational has landed, this is a no-op verification; otherwise this is the canonical implementation site for both stories.
+- [ ] T006 [P] Add the `SubagentSpec` `$def` and `ClaudeConfig.properties.agents` property to `schemas/agent.schema.json` per `contracts/subagent-spec.schema.json`. Closed object (`additionalProperties: false`). The `tools` field is `{"type": ["array", "null"], "items": {"type": "string"}}`. **Shared with US1.T010**.
+
+**Checkpoint**: Foundation ready — US2 work can begin. Running `pytest tests/unit/models/test_claude_config.py -n auto` should still pass (no behavior change yet from US2's perspective).
+
+---
+
+## Phase 3: User Story 2 — Restrict Subagent Tool Access (Priority: P2)
+
+**Story Goal**: Each subagent's `tools` allowlist scopes which built-in or MCP tools it can call. Two subagents on the same parent share parent-level MCP server registrations but see disjoint tool sets when their `tools` lists name disjoint entries. Unknown tool-name entries (typos) surface as `UserWarning` at config-load time, not as hard errors.
+
+**Independent Test (per spec.md)**: Define two subagents whose `tools` lists name different MCP tool identifiers (`mcp__<server>__<tool>`); initialize the agent and verify each subagent's `AgentDefinition.tools` contains only the named entries (SC-003).
+
+**Traceability**: FR-009, FR-007 (omitted `tools` → inherit), SC-003, data-model.md rule #5, research.md §3, quickstart.md §3.
+
+### Tests for User Story 2 (write FIRST, ensure they FAIL before implementation) ⚠️
+
+- [ ] T007 [P] [US2] Add a `KNOWN_BUILTIN_TOOLS` import-or-attribute test to `tests/unit/models/test_claude_config.py` asserting the constant in `claude_config.py` equals `{"Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch", "WebFetch", "Task", "TodoWrite", "NotebookEdit"}` (data-model.md rule #5; research.md §3).
+- [ ] T008 [P] [US2] Add `pytest.warns(UserWarning)` tests in `tests/unit/models/test_claude_config.py` covering rule #5 of `SubagentSpec`:
+  - **No warning** for entries in the built-ins set (e.g. `["Read", "WebSearch"]`).
+  - **No warning** for entries prefixed with `mcp__` (e.g. `["mcp__db__query", "mcp__db__describe"]`).
+  - **Warning** for an unknown bare name (e.g. `["WebSerach"]` — typo of WebSearch); assert the warning message includes the offending name and references the three accepted patterns.
+  - **No warning** when `tools` is `None` (omitted) — confirms FR-007 inheritance path is silent.
+  - **No warning** when `tools` is `[]` (explicit empty list — pure-reasoning subagent per quickstart §7).
+- [ ] T009 [P] [US2] Add unit tests in `tests/unit/lib/backends/test_claude_backend.py` exercising `build_options()` translation for SC-003:
+  - **AC-1**: parent agent with one MCP server registered + a subagent `db_analyst` whose `tools=["mcp__db__query", "mcp__db__describe"]` → `opts.agents["db_analyst"].tools == ["mcp__db__query", "mcp__db__describe"]`. Verify the value is a list (not `None`) and matches exactly.
+  - **AC-2 (disjoint isolation)**: same parent, two subagents `db_analyst` (`tools=["mcp__db__query"]`) and `researcher` (`tools=["WebSearch", "WebFetch"]`) → `opts.agents["db_analyst"].tools == ["mcp__db__query"]` AND `opts.agents["researcher"].tools == ["WebSearch", "WebFetch"]` AND `"mcp__db__query" not in opts.agents["researcher"].tools`.
+  - **FR-007 inheritance**: subagent with `tools` omitted → `opts.agents[name].tools is None` (signals SDK to inherit parent tools).
+  - **Pure-reasoning**: subagent with `tools=[]` → `opts.agents[name].tools == []` (preserved verbatim, not normalized to `None`).
+
+### Implementation for User Story 2
+
+- [ ] T010 [US2] Add the `KNOWN_BUILTIN_TOOLS: frozenset[str]` module-level constant to `src/holodeck/models/claude_config.py` per data-model.md rule #5 / research.md §3: `frozenset({"Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch", "WebFetch", "Task", "TodoWrite", "NotebookEdit"})`.
+- [ ] T011 [US2] Implement the tool-name typo warning validator on `SubagentSpec` in `src/holodeck/models/claude_config.py` as a `@model_validator(mode="after")`. Pattern after `_warn_effort_with_extended_thinking` (research.md §3 cites this as the reference). For each entry in `self.tools or []`:
+  - skip if entry is in `KNOWN_BUILTIN_TOOLS`,
+  - skip if entry starts with `mcp__`,
+  - otherwise emit `warnings.warn(f"Subagent tool '{entry}' does not match a known built-in (one of {sorted(KNOWN_BUILTIN_TOOLS)}), an MCP tool name (mcp__<server>__<tool>), or a HoloDeck-bridged tool. This may be a typo.", UserWarning, stacklevel=2)`.
+  - **Note**: cross-checking against the parent agent's top-level `tools` field (HoloDeck-bridged tools, the third accepted pattern in research.md §3) is **deferred** — the model validator runs in isolation and does not have parent-`Agent`-level context. Document this limitation in a comment; the warning message still names all three accepted patterns so users understand bridged names are also valid.
+- [ ] T012 [US2] Verify the translation block from T005 already preserves the three states needed by T009: `None` (inherit), `[]` (pure reasoning), and a populated list (allowlist). No additional code expected — this is a verify-and-confirm task. If T009 tests fail because of unintended normalization, fix `build_options()` to pass `tools=spec.tools` verbatim.
+- [ ] T013 [US2] Run `pytest tests/unit/models/test_claude_config.py tests/unit/lib/backends/test_claude_backend.py -n auto` and confirm T007–T009 now pass.
+
+### Optional sample addition
+
+- [ ] T014 [P] [US2] Add a sample `agent.yaml` at `sample/subagents-mcp-isolation/claude/agent.yaml` mirroring `quickstart.md` §3 (the `db_analyst` / `researcher` disjoint-MCP-tools pattern). Include a stub `mcp_servers.db` registration so the sample is loadable. Optional but recommended for demoability of SC-003.
+
+**Checkpoint**: User Story 2 is fully functional and independently testable. SC-003 (per-`AgentDefinition.tools` value verification) and the load-time typo-warning behavior are both observable via the unit suite.
+
+---
+
+## Phase N: Polish & Cross-Cutting
+
+**Purpose**: Lint, type-check, and quickstart validation specific to US2's surface area.
+
+- [ ] T015 [P] Run `make format` and `make lint` against `src/holodeck/models/claude_config.py` and `src/holodeck/lib/backends/claude_backend.py`. Address any Black/Ruff/Bandit findings.
+- [ ] T016 [P] Run `make type-check` and confirm MyPy is clean for the touched files. The `KNOWN_BUILTIN_TOOLS` constant must be typed `frozenset[str]`; the validator's `warnings.warn` call must satisfy MyPy strict.
+- [ ] T017 Manually walk `quickstart.md` §3 (Restricting MCP tool access per subagent) end-to-end: load a YAML matching the snippet, confirm each subagent's resulting `AgentDefinition.tools` matches the YAML's enumeration. Use `holodeck chat` or a small Python harness; this is the human-loop check on top of T009.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup. **Shared with US1** — if US1's foundational tasks (model + field + translation site + schema) are already merged on the branch, Phase 2 here is a no-op confirmation. Otherwise, the Phase 2 tasks below MUST land before any Phase 3 work begins.
+- **User Story 2 (Phase 3)**: Depends on Phase 2 only. Independent of US1's prompt/prompt_file/model validation work.
+- **Polish (Phase N)**: Depends on Phase 3 completion.
+
+### Cross-File Dependencies a Developer Should Know
+
+- T002, T003, T004, T010, T011 all touch `src/holodeck/models/claude_config.py` — they are **sequential**, not parallel.
+- T005 and T012 both touch `src/holodeck/lib/backends/claude_backend.py` — sequential.
+- T007, T008 both touch `tests/unit/models/test_claude_config.py` — can be drafted in one editor session; mark as parallel-safe only if split across two distinct test classes/functions.
+- T009 lives in `tests/unit/lib/backends/test_claude_backend.py` (existing file) — independent of the test_claude_config.py edits and can run [P] with T007/T008.
+- T006 (schema) is independent of the `.py` edits and can run [P] with the model work.
+- T014 (sample YAML) is independent of every other task and can run [P] at any point after T002–T005.
+
+### Within User Story 2
+
+- All test tasks (T007, T008, T009) MUST be written and FAIL before T010–T012.
+- T010 (constant) before T011 (validator that consumes it).
+- T011 (validator) before T013 (test run) — since T008 asserts the warning behavior implemented in T011.
+- T012 (translation verify) before T013.
+
+---
+
+## Parallel Execution Example: User Story 2
+
+```bash
+# Once Phase 2 is complete, launch all US2 tests together (different files):
+Task: "T007 KNOWN_BUILTIN_TOOLS constant test in tests/unit/models/test_claude_config.py"
+Task: "T008 SubagentSpec typo-warning tests in tests/unit/models/test_claude_config.py"   # same file as T007 — coordinate
+Task: "T009 build_options() AgentDefinition.tools translation tests in tests/unit/lib/backends/test_claude_backend.py"
+
+# Sample addition can run in parallel with the test/code work:
+Task: "T014 sample/subagents-mcp-isolation/claude/agent.yaml"
+
+# Polish tasks (after Phase 3) — file-independent:
+Task: "T015 make format && make lint"
+Task: "T016 make type-check"
+```
+
+---
+
+## Implementation Strategy
+
+### Recommended order (US2-only, single developer)
+
+1. Confirm Phase 1 / T001 baseline is green.
+2. Land Phase 2 (T002–T006) as one commit — model + field + translation skeleton + schema fragment. Confirm existing tests still pass.
+3. Write the three test groups (T007, T008, T009). Confirm they FAIL.
+4. Implement T010 → T011 → T012. Re-run the suite (T013).
+5. Optional: T014 (sample YAML).
+6. Polish: T015–T017.
+
+### Parallel-team strategy
+
+- One developer takes Phase 2 (foundational) — coordinated with US1's foundational owner, since the work overlaps.
+- Once Phase 2 lands, US2 is a single self-contained slice of code (≤ 30 lines added to `claude_config.py`, ≤ 8 lines added to `claude_backend.py`) and is best owned by one developer end-to-end.
+
+### Stopping points
+
+- After T013: US2 is **mergeable** as an independent slice covering SC-003 + load-time typo warnings.
+- After T014: US2 has a runnable demo sample.
+- After T017: US2 is **release-ready** (lint, types, quickstart walked).
+
+---
+
+## Notes
+
+- Every task above traces directly to a spec FR (FR-007, FR-009), success criterion (SC-003), data-model rule (rule #5), or research decision (§3). No invented scope.
+- The Claude SDK enforces the `tools` allowlist at runtime; HoloDeck's job is purely (a) translation 1:1 and (b) load-time warnings for likely typos. Do not add runtime enforcement code.
+- Cross-checking unknown tool names against the parent's HoloDeck-bridged tool list is intentionally deferred — it requires `Agent`-level context the `SubagentSpec` validator does not have. The warning message names the third accepted pattern so users understand bridged names are valid.
+- **Migration**: this file does not own the `claude.subagents` legacy-block migration error (research §4 / SC-005). That belongs to US1's foundational work — do not duplicate it here.
+- Commit after each task or logical group; do not bundle Phase 2 with Phase 3 in a single commit.

--- a/specs/029-subagent-orchestration/tasks-us3.md
+++ b/specs/029-subagent-orchestration/tasks-us3.md
@@ -1,0 +1,203 @@
+# Tasks: Subagent Definitions & Multi-Agent Orchestration — User Story 3
+
+**Spec**: 029-subagent-orchestration
+**User Story**: US3 — Define Subagent with Custom System Prompt (Priority: P1)
+**Input**: Design documents from `/specs/029-subagent-orchestration/`
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/subagent-spec.schema.json, quickstart.md
+**Scope**: This file delivers ONLY US3. The Phase 2 (Foundational) tasks here are the minimum SubagentSpec/ClaudeConfig.agents scaffolding US3 needs to be testable; US1 and US2 reuse them but are out of scope here.
+
+**Tests**: Included. SC-004 explicitly mandates validation-error tests at config-load time; without them, US3's acceptance scenarios cannot be verified.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: `[US3]` only on User Story 3 tasks. Setup / Foundational / Polish carry no story tag.
+- All paths absolute from repo root `/Users/justinbarias/Documents/Git/python/agentlab/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the working tree and tooling baseline before any model edits.
+
+- [ ] T001 Verify branch is `feature/029-claude-subagents` and working tree is clean; run `make install-dev` if `.venv/` is missing so `pytest`, `mypy`, `ruff`, and `black` are available.
+- [ ] T002 [P] Confirm `claude-agent-sdk==0.1.44` is installed in `.venv/` (it provides `AgentDefinition`); run `python -c "from claude_agent_sdk.types import AgentDefinition; print(AgentDefinition)"` to fail-fast if missing.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites — shared with US1/US2)
+
+**Purpose**: Stand up the `SubagentSpec` model skeleton, the `ClaudeConfig.agents` field with empty-map normalization, the `description` validator, and the legacy `claude.subagents` migration validator so US3's prompt-sourcing rules have a model to attach to AND so SC-005 holds regardless of which story ships first. These tasks are NOT US3-unique — US1 and US2 build on the same scaffolding — and so are tagged as foundational, not `[US3]`.
+
+**TDD-ordered**: foundational tests (T003a, T003b, T003c) are authored FIRST and verified FAILING before implementation tasks (T004–T009).
+
+**CRITICAL**: No US3 (Phase 3) work can begin until this phase is complete.
+
+### Foundational tests (write FIRST — must FAIL before T004–T009)
+
+- [ ] T003a [P] Add `test_subagent_description_required_non_empty` in `tests/unit/models/test_claude_config.py` asserting `SubagentSpec(description="", prompt="x")` and `SubagentSpec(description="   ", prompt="x")` both raise `ValidationError("subagent requires description")`. Verify it FAILS today (model not yet added). (FR-004, SC-004)
+- [ ] T003b [P] Add `test_legacy_subagents_block_rejected` in `tests/unit/models/test_claude_config.py` asserting `ClaudeConfig(**{"subagents": {"enabled": True}})` raises `ValidationError` whose message contains `"claude.subagents is no longer supported"` and references both `claude.agents` and `execution.parallel_test_cases`. Verify it FAILS. **Shared with US1.T002** — first owner wins. (FR-011, SC-005)
+- [ ] T003c [P] Add `test_claude_config_agents_empty_map_normalized_to_none` in `tests/unit/models/test_claude_config.py` asserting `ClaudeConfig(agents={}).agents is None`. Verify it FAILS. **Shared with US1.T003**. (FR-010, research §5)
+
+### Foundational implementation
+
+- [ ] T004 Delete the existing `SubagentConfig` model and the `ClaudeConfig.subagents` field in `src/holodeck/models/claude_config.py` (lines 63-70 and 115-118 per `plan.md`). Also remove the `SubagentConfig` import in `tests/unit/models/test_claude_config.py` and any test cases that reference it (lines ~158-196, 248-255, and the `subagents=...` line in `test_with_all_fields` around line 269). **Shared with US1.T005/T011**.
+- [ ] T005 Add a `SubagentSpec(BaseModel)` skeleton in `src/holodeck/models/claude_config.py` with `model_config = ConfigDict(extra="forbid")` and the five fields per `data-model.md` §1: `description: str`, `prompt: str | None = None`, `prompt_file: str | None = None`, `tools: list[str] | None = None`, `model: Literal["sonnet", "opus", "haiku", "inherit"] | None = None`. No prompt/prompt_file validators yet — those land in Phase 3. **Shared with US1.T006** — first owner wins. (FR-002, FR-008)
+- [ ] T006 Add the `description` non-empty-after-strip `@model_validator(mode="after")` on `SubagentSpec` in `src/holodeck/models/claude_config.py` that raises `ValueError("subagent requires description")` when `description.strip() == ""`. Confirm T003a now PASSES. (FR-004, SC-004)
+- [ ] T007 Add `agents: dict[str, SubagentSpec] | None = Field(default=None, ...)` to `ClaudeConfig` in `src/holodeck/models/claude_config.py` (description per `data-model.md` §2). Add a `@model_validator(mode="after")` that normalizes `agents == {}` → `agents = None`. Confirm T003c now PASSES. **Shared with US1.T007**. (FR-001, FR-010, research §5)
+- [ ] T008 Add a `@model_validator(mode="before")` on `ClaudeConfig` in `src/holodeck/models/claude_config.py` that detects a legacy `subagents` key in the input dict and raises `ValueError` with the exact message from data-model.md §2 rule 2: `"claude.subagents is no longer supported; remove this block. Subagent forwarding is gated solely by the presence of claude.agents. To cap HoloDeck-side test concurrency, set execution.parallel_test_cases instead."`. The `mode="before"` runs ahead of `extra="forbid"` so the targeted error wins. Confirm T003b now PASSES. **Shared with US1.T008**. (FR-011, SC-005)
+
+**Checkpoint**: `SubagentSpec` exists with `description` validator, `ClaudeConfig.agents` exists with empty-map normalization, the legacy `subagents` block is rejected with the documented friendly error, and all three foundational tests are green. US3 prompt-validation work can now begin.
+
+---
+
+## Phase 3: User Story 3 — Define Subagent with Custom System Prompt (Priority: P1)
+
+**Goal**: Allow users to give each subagent a distinct system prompt, sourced either inline (`prompt`) or from a file (`prompt_file`) resolved relative to the agent.yaml directory. Validation errors fire at config-load time.
+
+**Independent Test**: Load three minimal `agent.yaml` fixtures (inline prompt, prompt_file, neither) through `holodeck.config.loader`. Verify:
+1. Inline prompt → `SubagentSpec.prompt == "You are a financial analyst."`, `prompt_file is None`.
+2. `prompt_file: ./prompts/analyst.md` → `SubagentSpec.prompt` contains the file's contents, `prompt_file is None`.
+3. Neither → `ValidationError("subagent requires either prompt or prompt_file")` at load time.
+
+### Tests for User Story 3 ⚠️ WRITE FIRST — must FAIL before T017–T020
+
+> All test tasks add cases to `tests/unit/models/test_claude_config.py` (single file). They share that file, so NOT marked `[P]`. The fixture-creation task T009 is `[P]` because it touches a different path.
+
+- [ ] T009 [P] [US3] Create test prompt fixture at `tests/unit/models/fixtures/subagent_prompts/analyst.md` containing the literal text `You are a data analyst. Analyze data only — do not write code.` (used by T012 and T015). Confirm parent directories exist; create `tests/unit/models/fixtures/` and `tests/unit/models/fixtures/subagent_prompts/` if missing.
+- [ ] T010 [US3] Add `test_subagent_inline_prompt_loads` to `tests/unit/models/test_claude_config.py` — constructs a `SubagentSpec(description="x", prompt="You are a financial analyst.")`, asserts `.prompt == "You are a financial analyst."` and `.prompt_file is None`. (US3 acceptance scenario 1; FR-002)
+- [ ] T011 [US3] Add `test_subagent_inline_prompt_empty_after_strip_rejected` to `tests/unit/models/test_claude_config.py` — `SubagentSpec(description="x", prompt="   ")` raises `ValidationError`. (data-model.md §1 rule "Non-empty after strip"; SC-004)
+- [ ] T012 [US3] Add `test_subagent_prompt_file_inlined` to `tests/unit/models/test_claude_config.py` — sets `agent_base_dir` `ContextVar` (from `src/holodeck/config/context.py`) to `tests/unit/models/fixtures/subagent_prompts/`, constructs `SubagentSpec(description="x", prompt_file="./analyst.md")`, asserts `.prompt` matches the fixture's contents and `.prompt_file is None`. Use `agent_base_dir.set(...)` with a token and `agent_base_dir.reset(token)` in a `try/finally` (mirror the pattern in `src/holodeck/config/schema.py:104-106`). (US3 acceptance scenario 2; FR-005)
+- [ ] T013 [US3] Add `test_subagent_prompt_file_resolves_relative_to_agent_base_dir` to `tests/unit/models/test_claude_config.py` — same as T012 but uses a nested path (`subdir/analyst.md`) under a temp directory created via `tmp_path`, and verifies absolute paths are also accepted (path resolution doesn't mangle absolute paths). (FR-005; quickstart §5 row "prompt_file resolves relative")
+- [ ] T014 [US3] Add `test_subagent_prompt_file_not_found_rejected` to `tests/unit/models/test_claude_config.py` — `SubagentSpec(description="x", prompt_file="./does-not-exist.md")` raises `ValidationError` whose message contains `"prompt_file not found"` and the offending path. (Edge case: nonexistent prompt_file; SC-004; quickstart §5)
+- [ ] T015 [US3] Add `test_subagent_prompt_and_prompt_file_mutually_exclusive` to `tests/unit/models/test_claude_config.py` — `SubagentSpec(description="x", prompt="hi", prompt_file="./analyst.md")` raises `ValidationError("prompt and prompt_file are mutually exclusive")` (exact message per quickstart §5). (FR-006; SC-004)
+- [ ] T016 [US3] Add `test_subagent_neither_prompt_nor_prompt_file_rejected` to `tests/unit/models/test_claude_config.py` — `SubagentSpec(description="x")` raises `ValidationError("subagent requires either prompt or prompt_file")` (exact message per quickstart §5). (FR-006; US3 acceptance scenario 3; SC-004)
+
+> Run `pytest tests/unit/models/test_claude_config.py -n auto -v` and confirm T010–T016 all FAIL with the expected error shapes before proceeding to implementation.
+
+### Implementation for User Story 3
+
+> All implementation tasks edit `src/holodeck/models/claude_config.py`. Single file, sequential.
+
+- [ ] T017 [US3] In `src/holodeck/models/claude_config.py`, add a `@model_validator(mode="after")` on `SubagentSpec` that raises `ValueError("prompt and prompt_file are mutually exclusive")` when both `self.prompt` and `self.prompt_file` are non-`None` (truthy after the `None` check; explicit empty strings are caught separately by T018/T019). (FR-006; satisfies T015)
+- [ ] T018 [US3] In the same `@model_validator(mode="after")` (or a sibling validator in the same file), raise `ValueError("subagent requires either prompt or prompt_file")` when both are `None`. Order this check after the mutual-exclusion check so the messages don't conflict. (FR-006; satisfies T016; US3 acceptance scenario 3)
+- [ ] T019 [US3] In `src/holodeck/models/claude_config.py`, extend the `SubagentSpec` `@model_validator(mode="after")` to handle `prompt_file` resolution. Mirror the canonical pattern at `src/holodeck/config/schema.py:101-112`:
+
+  ```python
+  from pathlib import Path
+  from holodeck.config.context import agent_base_dir   # ContextVar[str | None]
+
+  if self.prompt_file is not None:
+      base_dir_value = agent_base_dir.get()
+      base_dir = Path.cwd() if base_dir_value is None else Path(base_dir_value)
+      path = Path(self.prompt_file)
+      if not path.is_absolute():
+          path = base_dir / path
+      if not path.exists():
+          raise ValueError(f"prompt_file not found: {path}")
+      self.prompt = path.read_text(encoding="utf-8")
+      self.prompt_file = None
+  ```
+
+  Use `model_validator(mode="after")` so the assignments stick (Pydantic v2 returns `self`). Note the ContextVar is `ContextVar[str | None]` (not `Path | None`), so coerce only after the None check. (FR-005, FR-006; satisfies T012, T013, T014; data-model.md §1 rule 3; research.md §2)
+- [ ] T020 [US3] In `src/holodeck/models/claude_config.py`, after `prompt_file` inlining, add a non-empty-after-strip check on the resulting `self.prompt`: raise `ValueError("subagent prompt must be non-empty")` when `self.prompt is not None and self.prompt.strip() == ""`. This catches both inline empty prompts and prompt_file paths that point at an empty file. (data-model.md §1 invariant "always non-empty after construction"; satisfies T011)
+
+> Run `pytest tests/unit/models/test_claude_config.py -n auto -v` and confirm T010–T016 all PASS.
+
+**Checkpoint**: US3 is fully functional and testable independently. A subagent's `prompt`/`prompt_file` is correctly sourced and validated at config-load time, with the exact error messages spec'd in `quickstart.md` §5.
+
+---
+
+## Phase 4: Polish & Cross-Cutting
+
+- [ ] T021 Run `make format` and `make lint` from the repo root; confirm `src/holodeck/models/claude_config.py` and `tests/unit/models/test_claude_config.py` pass Black (88 cols) + Ruff with no warnings.
+- [ ] T022 Run `make type-check` from the repo root; confirm `src/holodeck/models/claude_config.py` passes MyPy strict (especially the `agent_base_dir.get()` fallback path and the `Path` import).
+- [ ] T023 [P] Run the full unit test suite — `pytest tests/unit/ -n auto -v` — to confirm no regressions in adjacent `ClaudeConfig` tests, in particular that `_warn_effort_with_extended_thinking` still fires.
+- [ ] T024 Validate `quickstart.md` §5 row "prompt_file: ./does-not-exist.md" by writing a 5-line ad-hoc YAML fixture and loading it through `holodeck.config.loader.load_agent_config()` from a Python REPL; confirm the `ValidationError` matches the documented message verbatim. (SC-004 end-to-end smoke check)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately.
+- **Phase 2 (Foundational, TDD)**: Depends on Phase 1. BLOCKS Phase 3. Tests T003a/T003b/T003c authored FIRST and verified FAILING before T004–T008 implementations.
+- **Phase 3 (US3)**: Depends on Phase 2 completion. Within Phase 3, tests T009–T016 must be written and FAIL before implementation T017–T020.
+- **Phase 4 (Polish)**: Depends on Phase 3.
+
+### Task-Level Dependencies (within US3)
+
+- T009 (fixture file) → T012, T013, T015 (tests that read the fixture).
+- T010–T016 (failing tests) → T017–T020 (implementations that make them pass).
+- T017 (mutual-exclusion check) → T018 (at-least-one check; ordered second so the error messages don't collide).
+- T018 → T019 (prompt_file resolution; runs only if at least one of prompt/prompt_file is set).
+- T019 → T020 (non-empty post-strip check; runs after `prompt_file` has been inlined into `prompt`).
+
+### Foundational → US3 Dependencies
+
+- T005 (SubagentSpec skeleton) → all of T010–T020.
+- T006 (description validator) → T010–T016 (tests construct `SubagentSpec(description="x", ...)` so the description rule must already permit non-empty strings).
+- T004 (delete old `SubagentConfig`) → T005 (add new model) → T007 (add `agents` field) → T008 (add legacy migration validator) — strict but safe ordering since they all edit the same file.
+- T003a/T003b/T003c (foundational failing tests) → T006/T008/T007 (the implementations that turn each green).
+
+### Cross-File Dependencies a Developer Should Know
+
+- `src/holodeck/config/context.py` defines `agent_base_dir: ContextVar[str | None]` (line 22 — note `str`, not `Path`). T019 imports it and coerces with `Path(...)` only after the None check; do **not** add a new ContextVar.
+- `src/holodeck/config/loader.py` (lines 775-783) sets `agent_base_dir` for the duration of YAML loading. US3 does NOT modify the loader — the existing wiring is reused.
+- `src/holodeck/config/schema.py` (lines 104-106) is the canonical example of `agent_base_dir.get()` usage with a fallback for the unset case. T019's resolution logic must match that pattern.
+- `src/holodeck/lib/backends/claude_backend.py` `build_options()` is **out of scope for US3** — translation to `AgentDefinition` belongs to US1. US3 only guarantees that `SubagentSpec.prompt` is a non-empty string ready for downstream translation.
+- T004 deletes `SubagentConfig`. Existing tests in `tests/unit/models/test_claude_config.py` (lines 158-196, 248-255 per plan.md) reference it and are removed in the same task. **Shared with US1.T005/T011** — coordinate ownership at PR time.
+
+---
+
+## Parallel Execution Example: User Story 3
+
+The vast majority of US3 tasks edit one file (`tests/unit/models/test_claude_config.py` or `src/holodeck/models/claude_config.py`) and are sequential. Foundational tests T003a/T003b/T003c are `[P]`. In Phase 3, only T009 is genuinely parallel.
+
+```bash
+# Phase 1 setup — independent commands:
+make install-dev                                                          # T001
+python -c "from claude_agent_sdk.types import AgentDefinition; print(AgentDefinition)"   # T002
+
+# Phase 3 — only T009 is parallelizable; the test- and impl-edits all share one file:
+mkdir -p tests/unit/models/fixtures/subagent_prompts                       # T009 setup
+# (then add the file's contents)
+
+# After tests T010–T016 are written and confirmed failing, run the full file in parallel:
+pytest tests/unit/models/test_claude_config.py -n auto -v                  # verify FAIL → implement → verify PASS
+```
+
+---
+
+## Implementation Strategy
+
+### Slice-First (US3 only — this file)
+
+1. Complete Phase 1 (Setup) — environment confirmed.
+2. Complete Phase 2 (Foundational, TDD) — author T003a/T003b/T003c first (failing); land T004 → T005 → T006 → T007 → T008. Each implementation turns the matching foundational test green. **STOP if there is friction here**: T004's deletion of `SubagentConfig` will break unrelated tests in `test_claude_config.py`; the deletion sweeps those legacy cases at the same time, but coordinate with US1 if a parallel branch is open.
+3. Complete Phase 3 tests (T009–T016) — all FAIL.
+4. Complete Phase 3 implementation (T017–T020) — all PASS.
+5. Complete Phase 4 polish — format/lint/type-check/regression suite green.
+6. **STOP and VALIDATE**: Run `pytest tests/unit/models/test_claude_config.py -n auto -v -k subagent` and confirm all foundational + US3 tests pass. Run `make ci` and confirm no regressions.
+
+### Parallel Team Strategy (US3 + US1 + US2)
+
+Phase 2 is the shared foundation. One developer should land Phases 1+2 alone, then US1, US2, and US3 can split:
+
+- Developer A: US1 (build_options translation, schema, sample agent.yaml).
+- Developer B: US2 (tools-list typo warnings, MCP scoping tests).
+- Developer C (this file): US3 (prompt validation rules + fixture).
+
+US3 has no runtime dependency on US1 or US2 once Phase 2 is in place — the model validators it adds are self-contained.
+
+---
+
+## Notes
+
+- Every task line traces to at least one of: FR-002, FR-004, FR-005, FR-006, US3 acceptance scenario 1/2/3, an edge case in spec.md §"Edge Cases", or SC-004.
+- `[P]` is used sparingly and only when the task touches a different file from sibling tasks.
+- US3 does **not** touch `claude_backend.py`, `agent.schema.json`, or any sample YAML — those changes belong to US1.
+- The exact validation error messages in T012, T013, T014 are copied verbatim from `quickstart.md` §5 so users see the documented strings.
+- After Phase 3, `SubagentSpec.prompt_file` is always `None` post-construction (data-model.md §"Invariants"). Downstream code (US1's `build_options()`) can read `spec.prompt` directly without re-resolving paths.
+- Do NOT add a JSON schema fragment in this slice — `contracts/subagent-spec.schema.json` is applied to `schemas/agent.schema.json` by US1.

--- a/src/holodeck/chat/__init__.py
+++ b/src/holodeck/chat/__init__.py
@@ -4,6 +4,7 @@ from holodeck.chat.executor import AgentExecutor, AgentResponse
 from holodeck.chat.message import MessageValidator
 from holodeck.chat.session import ChatSessionManager
 from holodeck.chat.streaming import ToolEvent, ToolEventType, ToolExecutionStream
+from holodeck.chat.tools_panel import ToolsPanel
 
 __all__ = [
     "AgentExecutor",
@@ -13,4 +14,5 @@ __all__ = [
     "ToolEvent",
     "ToolEventType",
     "ToolExecutionStream",
+    "ToolsPanel",
 ]

--- a/src/holodeck/chat/__init__.py
+++ b/src/holodeck/chat/__init__.py
@@ -1,5 +1,6 @@
 """Chat runtime package for interactive chat."""
 
+from holodeck.chat.composer import LiveComposer
 from holodeck.chat.executor import AgentExecutor, AgentResponse
 from holodeck.chat.message import MessageValidator
 from holodeck.chat.session import ChatSessionManager
@@ -10,6 +11,7 @@ __all__ = [
     "AgentExecutor",
     "AgentResponse",
     "ChatSessionManager",
+    "LiveComposer",
     "MessageValidator",
     "ToolEvent",
     "ToolEventType",

--- a/src/holodeck/chat/composer.py
+++ b/src/holodeck/chat/composer.py
@@ -1,0 +1,85 @@
+"""Live screen compositor for the chat REPL.
+
+Owns the region below the streaming-text cursor for the duration of one
+turn. Streamed text is written at the cursor while a multi-line panel
+(tools + spinner) sits below it and is erased + redrawn around every text
+write so it stays visible throughout the response.
+
+Cursor invariant (between operations):
+* Cursor is positioned at the end of the streamed text.
+* Lines immediately below the cursor hold the panel (or nothing if the
+  panel is empty).
+
+The compositor uses DECSC / DECRC (``\\033 7`` / ``\\033 8``) to save and
+restore the cursor around panel paints. This avoids tracking the
+streaming text's column manually — the terminal does it for us.
+
+Limitations: when the cursor is on the bottom row of the terminal, the
+``\\n`` used to descend into the panel region scrolls the screen, which
+invalidates the saved cursor on most terminals. In practice that means
+the panel may flicker if the chat output reaches the very bottom of the
+window.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from holodeck.lib.ui import is_tty
+
+
+class LiveComposer:
+    """Serialises stdout writes around a panel pinned below the cursor."""
+
+    def __init__(self) -> None:
+        self._panel_lines: list[str] = []
+        self._lock = asyncio.Lock()
+        self._active = False
+
+    async def begin(self) -> None:
+        """Mark the start of a turn — the panel may now be drawn."""
+        async with self._lock:
+            self._panel_lines = []
+            self._active = True
+
+    async def end(self) -> None:
+        """End the turn — erase any visible panel and reset state."""
+        async with self._lock:
+            self._erase_panel()
+            self._panel_lines = []
+            self._active = False
+            sys.stdout.flush()
+
+    async def update_panel(self, lines: list[str]) -> None:
+        """Replace the visible panel with *lines* (no-op if unchanged)."""
+        async with self._lock:
+            if not self._active:
+                return
+            if lines == self._panel_lines:
+                return
+            self._erase_panel()
+            self._panel_lines = list(lines)
+            self._draw_panel()
+            sys.stdout.flush()
+
+    async def write_text(self, chunk: str) -> None:
+        """Append *chunk* at the cursor while keeping the panel visible."""
+        async with self._lock:
+            self._erase_panel()
+            sys.stdout.write(chunk)
+            self._draw_panel()
+            sys.stdout.flush()
+
+    def _erase_panel(self) -> None:
+        if not self._panel_lines or not is_tty():
+            return
+        # Save cursor at text-end, descend one line into the panel region,
+        # clear from there to end of screen, restore cursor.
+        sys.stdout.write("\0337\n\033[J\0338")
+
+    def _draw_panel(self) -> None:
+        if not self._panel_lines or not is_tty():
+            return
+        body = "\n".join(self._panel_lines)
+        sys.stdout.write(f"\0337\n{body}\0338")

--- a/src/holodeck/chat/progress.py
+++ b/src/holodeck/chat/progress.py
@@ -42,6 +42,9 @@ class ChatProgressIndicator(SpinnerMixin):
         # Tool execution tracking
         self.last_tool_executions: list[ToolExecution] = []
         self.total_tool_calls: int = 0
+        # Snapshot of tools observed via the live panel for the verbose
+        # post-turn summary.  Populated by :meth:`set_active_snapshot`.
+        self._panel_snapshot: list[tuple[str, bool, str | None]] = []
 
     def get_spinner_line(self) -> str:
         """Get current spinner animation frame.
@@ -54,6 +57,24 @@ class ChatProgressIndicator(SpinnerMixin):
 
         spinner_char = self.get_spinner_char()
         return f"{spinner_char} Thinking..."
+
+    def set_active_snapshot(self, entries: Any) -> None:
+        """Record the panel's view of tools that ran this turn.
+
+        Streaming responses don't surface ``tool_executions`` (they always
+        return ``[]``), so the verbose summary panel uses this snapshot
+        from :class:`holodeck.chat.tools_panel.ToolsPanel` instead.
+
+        Args:
+            entries: Iterable of objects exposing ``tool_name``,
+                ``is_subagent``, and ``subagent_type`` attributes (i.e. the
+                ``_Active`` records returned by ``ToolsPanel.snapshot()``).
+        """
+        self._panel_snapshot = [
+            (e.tool_name, e.is_subagent, e.subagent_type) for e in entries
+        ]
+        # Count every tool the panel saw towards the cumulative total.
+        self.total_tool_calls += len(self._panel_snapshot)
 
     def update(self, response: Any) -> None:
         """Update progress after agent response.
@@ -152,8 +173,24 @@ class ChatProgressIndicator(SpinnerMixin):
         content = f"Tool Calls (Total): {self.total_tool_calls}"
         lines.append(f"│ {content:<{content_width}} │")
 
-        # Last tool executions (if any)
-        if self.last_tool_executions:
+        # Last tool executions (if any) — prefer the live-panel snapshot
+        # when available since streaming responses never populate
+        # ``last_tool_executions``.
+        if self._panel_snapshot:
+            lines.append(f"│ {'Last Tools Called:':<{content_width}} │")
+            status_icon = self._get_status_icon(ToolStatus.SUCCESS)
+            for tool_name, is_subagent, subagent_type in self._panel_snapshot:
+                label = (
+                    f"Task[{subagent_type}]"
+                    if is_subagent and subagent_type
+                    else tool_name
+                )
+                max_name_len = content_width - 6
+                if len(label) > max_name_len:
+                    label = label[: max_name_len - 3] + "..."
+                content = f"  └─ {status_icon} {label}"
+                lines.append(f"│ {content:<{content_width}} │")
+        elif self.last_tool_executions:
             lines.append(f"│ {'Last Tools Called:':<{content_width}} │")
             for tool_exec in self.last_tool_executions:
                 # Get status indicator

--- a/src/holodeck/chat/tools_panel.py
+++ b/src/holodeck/chat/tools_panel.py
@@ -1,0 +1,158 @@
+"""Live panel of in-flight tools and subagents for the chat REPL.
+
+Maintains state from the ``ToolEvent`` queue published by
+:class:`holodeck.lib.backends.claude_backend.ClaudeSession` and renders a
+multi-line ANSI panel above the spinner.  Two kinds of entries are tracked:
+
+* Regular tools — created on ``"start"``, removed on ``"end"`` / ``"error"``.
+* Subagents — Task tool calls (``tool_name == "Task"``).  Their last
+  assistant text snippet is recorded from ``"subagent_message"`` events and
+  shown as a status line under the entry.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from holodeck.lib.backends.base import ToolEvent
+from holodeck.lib.ui import SpinnerMixin, is_tty
+
+
+@dataclass
+class _Active:
+    """In-flight tool or subagent tracked by :class:`ToolsPanel`."""
+
+    tool_name: str
+    tool_use_id: str
+    started_at: float
+    is_subagent: bool
+    subagent_type: str | None = None
+    last_status: str | None = None
+
+
+_PANEL_WIDTH = 60
+_STATUS_MAX = _PANEL_WIDTH - 8  # account for "│   └─ " and trailing " │"
+_BORDER_TOP = "╭─── Active Tools " + "─" * (_PANEL_WIDTH - 19) + "╮"
+_BORDER_BOTTOM = "╰" + "─" * (_PANEL_WIDTH - 2) + "╯"
+
+
+class ToolsPanel(SpinnerMixin):
+    """State + ANSI renderer for in-flight tools and subagents.
+
+    Not coroutine-safe across producers — consumers are expected to
+    serialise calls (the chat REPL runs the drainer on a single asyncio
+    task).  No locking is required because mutations and reads happen on
+    the same event loop.
+    """
+
+    def __init__(self) -> None:
+        self._active: dict[str, _Active] = {}
+        self._spinner_index = 0
+
+    def apply(self, evt: ToolEvent) -> None:
+        """Update state from a ToolEvent.
+
+        Args:
+            evt: Event from the backend's tool event queue.
+        """
+        if evt.kind == "start":
+            is_subagent = evt.tool_name == "Task"
+            subagent_type: str | None = None
+            if is_subagent and evt.tool_input:
+                raw = evt.tool_input.get("subagent_type")
+                if isinstance(raw, str):
+                    subagent_type = raw
+            self._active[evt.tool_use_id] = _Active(
+                tool_name=evt.tool_name,
+                tool_use_id=evt.tool_use_id,
+                started_at=time.monotonic(),
+                is_subagent=is_subagent,
+                subagent_type=subagent_type,
+            )
+        elif evt.kind in ("end", "error"):
+            self._active.pop(evt.tool_use_id, None)
+        elif evt.kind == "subagent_message" and evt.text:
+            entry = self._active.get(evt.tool_use_id)
+            if entry is not None:
+                entry.last_status = _summarize_status(evt.text)
+
+    def render_lines(self) -> list[str]:
+        """Render current state as panel lines.
+
+        Returns:
+            A list of fully-formed lines (no trailing newline).  Empty list
+            when nothing is active or stdout is not a TTY.
+        """
+        if not is_tty() or not self._active:
+            return []
+
+        spinner_char = self.get_spinner_char()
+        lines: list[str] = [_BORDER_TOP]
+        for entry in self._active.values():
+            label = _entry_label(entry)
+            elapsed = f"{time.monotonic() - entry.started_at:.1f}s"
+            content = _fit_row(f"{spinner_char} {label}", elapsed)
+            lines.append(f"│ {content} │")
+            if entry.is_subagent and entry.last_status:
+                status_line = _truncate(f"  └─ {entry.last_status}", _STATUS_MAX)
+                lines.append(f"│ {status_line:<{_PANEL_WIDTH - 4}} │")
+        lines.append(_BORDER_BOTTOM)
+        return lines
+
+    @property
+    def line_count(self) -> int:
+        """Number of lines :meth:`render_lines` would produce right now."""
+        if not is_tty() or not self._active:
+            return 0
+        # 2 borders + 1 line per entry + 1 status line per subagent w/ status
+        n = 2 + len(self._active)
+        for entry in self._active.values():
+            if entry.is_subagent and entry.last_status:
+                n += 1
+        return n
+
+    def snapshot(self) -> list[_Active]:
+        """Return a copy of the in-flight entries (for post-turn display)."""
+        return list(self._active.values())
+
+
+def _entry_label(entry: _Active) -> str:
+    """Build the human label for a panel entry."""
+    if entry.is_subagent and entry.subagent_type:
+        return f"Task[{entry.subagent_type}]"
+    return entry.tool_name
+
+
+def _summarize_status(text: str) -> str:
+    """Reduce a multi-line subagent text snapshot to a single status line."""
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return _truncate(stripped, _STATUS_MAX - len("  └─ "))
+    return _truncate(text.strip(), _STATUS_MAX - len("  └─ "))
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Truncate *text* to *max_len* characters with an ellipsis."""
+    if max_len <= 1:
+        return text[:max_len]
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def _fit_row(label: str, suffix: str) -> str:
+    """Pack a row so *label* sits left-aligned and *suffix* sits right-aligned.
+
+    Total content width is :data:`_PANEL_WIDTH` minus the 4 chars of border
+    padding (``"│ "`` + ``" │"``).  If *label* is too long, it is truncated
+    so the suffix always remains visible.
+    """
+    content_width = _PANEL_WIDTH - 4
+    suffix_room = len(suffix) + 1  # at least one space between
+    label_room = content_width - suffix_room
+    if label_room < 1:
+        return _truncate(label, content_width)
+    label_fit = _truncate(label, label_room)
+    return f"{label_fit:<{label_room}} {suffix:>{suffix_room - 1}}"

--- a/src/holodeck/chat/tools_panel.py
+++ b/src/holodeck/chat/tools_panel.py
@@ -5,15 +5,20 @@ Maintains state from the ``ToolEvent`` queue published by
 multi-line ANSI panel above the spinner.  Two kinds of entries are tracked:
 
 * Regular tools — created on ``"start"``, removed on ``"end"`` / ``"error"``.
+  Their input args are recorded from the ``"start"`` event and rendered
+  as a compact status line under the entry.
 * Subagents — Task tool calls (``tool_name == "Task"``).  Their last
   assistant text snippet is recorded from ``"subagent_message"`` events and
-  shown as a status line under the entry.
+  shown as a status line under the entry, replacing the args view once
+  the subagent starts streaming.
 """
 
 from __future__ import annotations
 
+import json
 import time
 from dataclasses import dataclass
+from typing import Any
 
 from holodeck.lib.backends.base import ToolEvent
 from holodeck.lib.ui import SpinnerMixin, is_tty
@@ -29,6 +34,8 @@ class _Active:
     is_subagent: bool
     subagent_type: str | None = None
     last_status: str | None = None
+    tool_input: dict[str, Any] | None = None
+    parent_tool_use_id: str | None = None
 
 
 _PANEL_WIDTH = 60
@@ -48,6 +55,11 @@ class ToolsPanel(SpinnerMixin):
 
     def __init__(self) -> None:
         self._active: dict[str, _Active] = {}
+        # parent_link can arrive before the child's "start" event (the SDK
+        # surfaces parent_tool_use_id via AssistantMessage on a separate path
+        # from PreToolUse hooks), so stash early arrivals and apply them when
+        # the start finally lands.
+        self._pending_parents: dict[str, str] = {}
         self._spinner_index = 0
 
     def apply(self, evt: ToolEvent) -> None:
@@ -69,13 +81,22 @@ class ToolsPanel(SpinnerMixin):
                 started_at=time.monotonic(),
                 is_subagent=is_subagent,
                 subagent_type=subagent_type,
+                tool_input=evt.tool_input,
+                parent_tool_use_id=self._pending_parents.pop(evt.tool_use_id, None),
             )
         elif evt.kind in ("end", "error"):
             self._active.pop(evt.tool_use_id, None)
+            self._pending_parents.pop(evt.tool_use_id, None)
         elif evt.kind == "subagent_message" and evt.text:
             entry = self._active.get(evt.tool_use_id)
             if entry is not None:
                 entry.last_status = _summarize_status(evt.text)
+        elif evt.kind == "parent_link" and evt.parent_tool_use_id:
+            entry = self._active.get(evt.tool_use_id)
+            if entry is None:
+                self._pending_parents[evt.tool_use_id] = evt.parent_tool_use_id
+            else:
+                entry.parent_tool_use_id = evt.parent_tool_use_id
 
     def render_lines(self) -> list[str]:
         """Render current state as panel lines.
@@ -88,29 +109,51 @@ class ToolsPanel(SpinnerMixin):
             return []
 
         spinner_char = self.get_spinner_char()
+        children_by_parent: dict[str, list[_Active]] = {}
+        for entry in self._active.values():
+            if entry.parent_tool_use_id:
+                children_by_parent.setdefault(entry.parent_tool_use_id, []).append(
+                    entry
+                )
+
         lines: list[str] = [_BORDER_TOP]
         for entry in self._active.values():
-            label = _entry_label(entry)
-            elapsed = f"{time.monotonic() - entry.started_at:.1f}s"
-            content = _fit_row(f"{spinner_char} {label}", elapsed)
-            lines.append(f"│ {content} │")
-            if entry.is_subagent and entry.last_status:
-                status_line = _truncate(f"  └─ {entry.last_status}", _STATUS_MAX)
-                lines.append(f"│ {status_line:<{_PANEL_WIDTH - 4}} │")
+            # Top-level pass: skip entries whose parent is still active — they
+            # are rendered nested under the parent below.
+            if entry.parent_tool_use_id and entry.parent_tool_use_id in self._active:
+                continue
+            self._render_entry(entry, 0, spinner_char, lines, children_by_parent)
         lines.append(_BORDER_BOTTOM)
         return lines
+
+    def _render_entry(
+        self,
+        entry: _Active,
+        indent: int,
+        spinner_char: str,
+        lines: list[str],
+        children_by_parent: dict[str, list[_Active]],
+    ) -> None:
+        """Append entry header, secondary line, and children to *lines*."""
+        inner_width = _PANEL_WIDTH - 4 - indent
+        pad = " " * indent
+        label = _entry_label(entry)
+        elapsed = f"{time.monotonic() - entry.started_at:.1f}s"
+        content = _fit_row(f"{spinner_char} {label}", elapsed, inner_width)
+        lines.append(f"│ {pad}{content} │")
+        secondary = _secondary_text(entry)
+        if secondary:
+            status_line = _truncate(f"  └─ {secondary}", inner_width)
+            lines.append(f"│ {pad}{status_line:<{inner_width}} │")
+        for child in children_by_parent.get(entry.tool_use_id, []):
+            self._render_entry(
+                child, indent + 2, spinner_char, lines, children_by_parent
+            )
 
     @property
     def line_count(self) -> int:
         """Number of lines :meth:`render_lines` would produce right now."""
-        if not is_tty() or not self._active:
-            return 0
-        # 2 borders + 1 line per entry + 1 status line per subagent w/ status
-        n = 2 + len(self._active)
-        for entry in self._active.values():
-            if entry.is_subagent and entry.last_status:
-                n += 1
-        return n
+        return len(self.render_lines())
 
     def snapshot(self) -> list[_Active]:
         """Return a copy of the in-flight entries (for post-turn display)."""
@@ -122,6 +165,46 @@ def _entry_label(entry: _Active) -> str:
     if entry.is_subagent and entry.subagent_type:
         return f"Task[{entry.subagent_type}]"
     return entry.tool_name
+
+
+def _secondary_text(entry: _Active) -> str | None:
+    """Choose the text shown under the entry header.
+
+    Subagent status (from streamed assistant text) wins once it arrives.
+    Otherwise we render compact ``key=value`` pairs from the tool input so
+    the user can see *what* the tool was invoked with.  ``subagent_type``
+    is suppressed because it's already shown in the entry label.
+    """
+    if entry.is_subagent and entry.last_status:
+        return entry.last_status
+    if entry.tool_input:
+        skip = {"subagent_type"} if entry.is_subagent else set()
+        args = _format_args(entry.tool_input, skip_keys=skip)
+        return args or None
+    return None
+
+
+def _format_args(tool_input: dict[str, Any], skip_keys: set[str] | None = None) -> str:
+    """Format tool input as ``k=v`` pairs joined by spaces."""
+    skip = skip_keys or set()
+    parts: list[str] = []
+    for key, value in tool_input.items():
+        if key in skip:
+            continue
+        parts.append(f"{key}={_format_value(value)}")
+    return " ".join(parts)
+
+
+def _format_value(value: Any) -> str:
+    """Render a single arg value as a single-line string."""
+    if isinstance(value, str):
+        return value.replace("\n", " ").replace("\t", " ").strip()
+    if isinstance(value, (dict, list)):
+        try:
+            return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(value)
+    return str(value)
 
 
 def _summarize_status(text: str) -> str:
@@ -142,14 +225,12 @@ def _truncate(text: str, max_len: int) -> str:
     return text[: max_len - 1] + "…"
 
 
-def _fit_row(label: str, suffix: str) -> str:
+def _fit_row(label: str, suffix: str, content_width: int) -> str:
     """Pack a row so *label* sits left-aligned and *suffix* sits right-aligned.
 
-    Total content width is :data:`_PANEL_WIDTH` minus the 4 chars of border
-    padding (``"│ "`` + ``" │"``).  If *label* is too long, it is truncated
-    so the suffix always remains visible.
+    Total content width is *content_width*.  If *label* is too long, it is
+    truncated so the suffix always remains visible.
     """
-    content_width = _PANEL_WIDTH - 4
     suffix_room = len(suffix) + 1  # at least one space between
     label_room = content_width - suffix_room
     if label_room < 1:

--- a/src/holodeck/cli/commands/chat.py
+++ b/src/holodeck/cli/commands/chat.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import click
 
-from holodeck.chat import ChatSessionManager, ToolsPanel
+from holodeck.chat import ChatSessionManager, LiveComposer, ToolsPanel
 from holodeck.chat.executor import AgentExecutor, AgentResponse
 from holodeck.chat.progress import ChatProgressIndicator
 from holodeck.lib.backends.base import ToolEvent
@@ -25,7 +25,6 @@ from holodeck.lib.observability import (
     initialize_observability,
     shutdown_observability,
 )
-from holodeck.lib.ui import is_tty
 from holodeck.models.agent import Agent
 from holodeck.models.chat import ChatConfig
 from holodeck.models.config import ExecutionConfig
@@ -63,58 +62,35 @@ def _drain_remaining(queue: asyncio.Queue[ToolEvent], panel: ToolsPanel) -> None
         panel.apply(evt)
 
 
-async def _render_tools_panel(
+async def _paint_panel_loop(
     panel: ToolsPanel,
     progress: ChatProgressIndicator,
+    composer: LiveComposer,
     stop_event: asyncio.Event,
-) -> int:
-    """Repaint the tools panel + spinner above the prompt at 10 fps.
+) -> None:
+    """Drive panel repaints via *composer* at 10 fps until *stop_event*.
 
-    Returns:
-        The number of lines occupied by the last paint, so the caller can
-        clear them before streaming agent text.
+    The composer keeps the panel pinned below the streaming-text cursor,
+    so this task can run for the full turn — text writes interleave with
+    panel repaints without trampling each other.
     """
-    if not is_tty():
-        return 0
-
-    last_lines = 0
-    try:
-        while not stop_event.is_set():
-            new_lines = list(panel.render_lines())
-            spinner = progress.get_spinner_line()
-            if spinner:
-                new_lines.append(spinner)
-
-            _repaint(new_lines, last_lines)
-            last_lines = len(new_lines)
-            try:
-                await asyncio.wait_for(stop_event.wait(), timeout=_RENDER_INTERVAL_SEC)
-            except asyncio.TimeoutError:
-                continue
-    finally:
-        # Don't leave the cursor parked at the start of the rendered region;
-        # caller is responsible for clearing via the returned line count.
-        pass
-    return last_lines
-
-
-def _repaint(new_lines: list[str], last_lines: int) -> None:
-    """Overwrite the previously drawn region with *new_lines* in place."""
-    if last_lines:
-        sys.stdout.write(f"\r\033[{last_lines}A\033[J")
-    elif new_lines:
-        sys.stdout.write("\r")
-    if new_lines:
-        sys.stdout.write("\n".join(new_lines))
-    sys.stdout.flush()
-
-
-def _clear_panel(line_count: int) -> None:
-    """Clear *line_count* lines from the current paint region."""
-    if line_count <= 0:
-        return
-    sys.stdout.write(f"\r\033[{line_count}A\033[J")
-    sys.stdout.flush()
+    while not stop_event.is_set():
+        lines = list(panel.render_lines())
+        spinner = progress.get_spinner_line()
+        if spinner:
+            lines.append(spinner)
+        await composer.update_panel(lines)
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=_RENDER_INTERVAL_SEC)
+        except asyncio.TimeoutError:
+            continue
+    # One last paint so end-of-turn state (e.g. final tool just finished)
+    # is reflected before the composer tears the panel down.
+    lines = list(panel.render_lines())
+    spinner = progress.get_spinner_line()
+    if spinner:
+        lines.append(spinner)
+    await composer.update_panel(lines)
 
 
 async def _ensure_executor_ready(executor: AgentExecutor) -> None:
@@ -384,38 +360,32 @@ async def _run_chat_session(
                         )
 
                         panel = ToolsPanel()
+                        composer = LiveComposer()
                         stop_event = asyncio.Event()
                         drain_task: asyncio.Task[None] | None = None
                         if queue is not None:
                             drain_task = asyncio.create_task(
                                 _drain_tool_events(queue, panel, stop_event)
                             )
-                        render_task: asyncio.Task[int] = asyncio.create_task(
-                            _render_tools_panel(panel, progress, stop_event)
+
+                        await composer.begin()
+                        click.echo("Agent: ", nl=False)
+                        sys.stdout.flush()
+                        paint_task: asyncio.Task[None] = asyncio.create_task(
+                            _paint_panel_loop(panel, progress, composer, stop_event)
                         )
 
                         start_time = time.time()
                         chunks: list[str] = []
-                        first_chunk = True
                         try:
                             async for (
                                 chunk
                             ) in session_manager.process_message_streaming(user_input):
-                                if first_chunk:
-                                    stop_event.set()
-                                    last_lines = await render_task
-                                    _clear_panel(last_lines)
-                                    click.echo("Agent: ", nl=False)
-                                    first_chunk = False
-                                sys.stdout.write(chunk)
-                                sys.stdout.flush()
+                                await composer.write_text(chunk)
                                 chunks.append(chunk)
                         finally:
                             stop_event.set()
-                            if not render_task.done():
-                                last_lines = await render_task
-                                if first_chunk:
-                                    _clear_panel(last_lines)
+                            await paint_task
                             if drain_task is not None:
                                 try:
                                     await asyncio.wait_for(drain_task, timeout=0.25)
@@ -425,12 +395,9 @@ async def _run_chat_session(
                                         await drain_task
                             if queue is not None:
                                 _drain_remaining(queue, panel)
+                            await composer.end()
 
                         elapsed = time.time() - start_time
-
-                        # Print "Agent: " if no chunks ever arrived.
-                        if first_chunk:
-                            click.echo("Agent: ", nl=False)
 
                         click.echo()  # newline after streamed content
 

--- a/src/holodeck/cli/commands/chat.py
+++ b/src/holodeck/cli/commands/chat.py
@@ -5,8 +5,8 @@ including message validation, tool execution streaming, and optional observabili
 """
 
 import asyncio
+import contextlib
 import sys
-import threading
 import time
 from contextlib import nullcontext
 from pathlib import Path
@@ -14,9 +14,10 @@ from typing import Any
 
 import click
 
-from holodeck.chat import ChatSessionManager
-from holodeck.chat.executor import AgentResponse
+from holodeck.chat import ChatSessionManager, ToolsPanel
+from holodeck.chat.executor import AgentExecutor, AgentResponse
 from holodeck.chat.progress import ChatProgressIndicator
+from holodeck.lib.backends.base import ToolEvent
 from holodeck.lib.errors import AgentInitializationError, ConfigError, ExecutionError
 from holodeck.lib.logging_config import get_logger, setup_logging
 from holodeck.lib.observability import (
@@ -24,45 +25,108 @@ from holodeck.lib.observability import (
     initialize_observability,
     shutdown_observability,
 )
+from holodeck.lib.ui import is_tty
 from holodeck.models.agent import Agent
 from holodeck.models.chat import ChatConfig
 from holodeck.models.config import ExecutionConfig
 
 logger = get_logger(__name__)
 
+_RENDER_INTERVAL_SEC = 0.1
 
-class ChatSpinnerThread(threading.Thread):
-    """Background thread for displaying animated spinner during agent execution."""
 
-    def __init__(self, progress: ChatProgressIndicator) -> None:
-        """Initialize spinner thread.
+async def _drain_tool_events(
+    queue: asyncio.Queue[ToolEvent],
+    panel: ToolsPanel,
+    stop_event: asyncio.Event,
+) -> None:
+    """Forward tool events into *panel* until *stop_event* is set.
 
-        Args:
-            progress: ChatProgressIndicator instance for spinner animation.
-        """
-        super().__init__(daemon=True)
-        self.progress = progress
-        self._stop_event = threading.Event()
-        self._running = False
+    Uses a short timeout on each ``get`` so the loop exits promptly when
+    the chat turn ends, even if no further events arrive.
+    """
+    while not stop_event.is_set():
+        try:
+            evt = await asyncio.wait_for(queue.get(), timeout=0.1)
+        except asyncio.TimeoutError:
+            continue
+        panel.apply(evt)
 
-    def run(self) -> None:
-        """Run spinner animation loop."""
-        self._running = True
-        while not self._stop_event.is_set():
-            line = self.progress.get_spinner_line()
-            if line:
-                sys.stdout.write(f"\r{line}")
-                sys.stdout.flush()
-            time.sleep(0.1)  # 10 FPS update rate
-        self._running = False
 
-    def stop(self) -> None:
-        """Stop spinner animation and clear spinner line."""
-        self._stop_event.set()
-        if self._running:
-            # Clear spinner line
-            sys.stdout.write("\r" + " " * 80 + "\r")
-            sys.stdout.flush()
+def _drain_remaining(queue: asyncio.Queue[ToolEvent], panel: ToolsPanel) -> None:
+    """Apply any events buffered between the last drainer tick and now."""
+    while True:
+        try:
+            evt = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return
+        panel.apply(evt)
+
+
+async def _render_tools_panel(
+    panel: ToolsPanel,
+    progress: ChatProgressIndicator,
+    stop_event: asyncio.Event,
+) -> int:
+    """Repaint the tools panel + spinner above the prompt at 10 fps.
+
+    Returns:
+        The number of lines occupied by the last paint, so the caller can
+        clear them before streaming agent text.
+    """
+    if not is_tty():
+        return 0
+
+    last_lines = 0
+    try:
+        while not stop_event.is_set():
+            new_lines = list(panel.render_lines())
+            spinner = progress.get_spinner_line()
+            if spinner:
+                new_lines.append(spinner)
+
+            _repaint(new_lines, last_lines)
+            last_lines = len(new_lines)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=_RENDER_INTERVAL_SEC)
+            except asyncio.TimeoutError:
+                continue
+    finally:
+        # Don't leave the cursor parked at the start of the rendered region;
+        # caller is responsible for clearing via the returned line count.
+        pass
+    return last_lines
+
+
+def _repaint(new_lines: list[str], last_lines: int) -> None:
+    """Overwrite the previously drawn region with *new_lines* in place."""
+    if last_lines:
+        sys.stdout.write(f"\r\033[{last_lines}A\033[J")
+    elif new_lines:
+        sys.stdout.write("\r")
+    if new_lines:
+        sys.stdout.write("\n".join(new_lines))
+    sys.stdout.flush()
+
+
+def _clear_panel(line_count: int) -> None:
+    """Clear *line_count* lines from the current paint region."""
+    if line_count <= 0:
+        return
+    sys.stdout.write(f"\r\033[{line_count}A\033[J")
+    sys.stdout.flush()
+
+
+async def _ensure_executor_ready(executor: AgentExecutor) -> None:
+    """Eagerly initialise backend + session so ``tool_event_queue`` is live.
+
+    Mirrors :func:`holodeck.serve.protocols.agui.AGUIProtocol.handle_request`'s
+    eager-init pattern.  Gracefully degrades if the executor doesn't expose
+    the private hook (e.g. test mocks).
+    """
+    ensure = getattr(executor, "_ensure_backend_and_session", None)
+    if callable(ensure) and asyncio.iscoroutinefunction(ensure):
+        await ensure()
 
 
 @click.command()
@@ -309,30 +373,63 @@ async def _run_chat_session(
                     try:
                         logger.debug(f"Processing user message: {user_input[:50]}...")
 
-                        # Show spinner while waiting for first token
-                        spinner = ChatSpinnerThread(progress)
-                        spinner.start()
+                        # Eager-init so the backend's tool_event_queue is
+                        # live before we spawn the drainer (mirrors the
+                        # AGUI protocol path in holodeck serve).
+                        executor = session_manager._executor
+                        if executor is not None:
+                            await _ensure_executor_ready(executor)
+                        queue = (
+                            executor.tool_event_queue if executor is not None else None
+                        )
+
+                        panel = ToolsPanel()
+                        stop_event = asyncio.Event()
+                        drain_task: asyncio.Task[None] | None = None
+                        if queue is not None:
+                            drain_task = asyncio.create_task(
+                                _drain_tool_events(queue, panel, stop_event)
+                            )
+                        render_task: asyncio.Task[int] = asyncio.create_task(
+                            _render_tools_panel(panel, progress, stop_event)
+                        )
 
                         start_time = time.time()
                         chunks: list[str] = []
                         first_chunk = True
-                        async for chunk in session_manager.process_message_streaming(
-                            user_input
-                        ):
-                            if first_chunk:
-                                spinner.stop()
-                                spinner.join()
-                                click.echo("Agent: ", nl=False)
-                                first_chunk = False
-                            sys.stdout.write(chunk)
-                            sys.stdout.flush()
-                            chunks.append(chunk)
+                        try:
+                            async for (
+                                chunk
+                            ) in session_manager.process_message_streaming(user_input):
+                                if first_chunk:
+                                    stop_event.set()
+                                    last_lines = await render_task
+                                    _clear_panel(last_lines)
+                                    click.echo("Agent: ", nl=False)
+                                    first_chunk = False
+                                sys.stdout.write(chunk)
+                                sys.stdout.flush()
+                                chunks.append(chunk)
+                        finally:
+                            stop_event.set()
+                            if not render_task.done():
+                                last_lines = await render_task
+                                if first_chunk:
+                                    _clear_panel(last_lines)
+                            if drain_task is not None:
+                                try:
+                                    await asyncio.wait_for(drain_task, timeout=0.25)
+                                except asyncio.TimeoutError:
+                                    drain_task.cancel()
+                                    with contextlib.suppress(asyncio.CancelledError):
+                                        await drain_task
+                            if queue is not None:
+                                _drain_remaining(queue, panel)
+
                         elapsed = time.time() - start_time
 
-                        # Stop spinner if no chunks arrived at all
+                        # Print "Agent: " if no chunks ever arrived.
                         if first_chunk:
-                            spinner.stop()
-                            spinner.join()
                             click.echo("Agent: ", nl=False)
 
                         click.echo()  # newline after streamed content
@@ -348,6 +445,7 @@ async def _run_chat_session(
 
                         # Update progress
                         progress.update(response)
+                        progress.set_active_snapshot(panel.snapshot())
 
                         # Display status
                         if verbose:

--- a/src/holodeck/lib/backends/base.py
+++ b/src/holodeck/lib/backends/base.py
@@ -54,21 +54,31 @@ class ToolEvent:
 
     Attributes:
         kind: Event type — ``"start"`` before execution, ``"end"`` after
-            success, ``"error"`` after failure.
+            success, ``"error"`` after failure, ``"subagent_message"`` for an
+            assistant text snapshot streamed by an in-flight subagent (Task
+            tool).
         tool_name: Name of the tool being invoked.
         tool_use_id: Unique identifier correlating start/end/error for the
-            same invocation.
+            same invocation. For ``"subagent_message"`` events this is the
+            parent Task's ``tool_use_id`` so consumers can attach the
+            snapshot to the corresponding active entry.
         tool_input: Tool input parameters (present on ``"start"``).
         tool_response: Tool output (present on ``"end"``).
         error: Error description (present on ``"error"``).
+        parent_tool_use_id: For nested events, the parent Task's
+            ``tool_use_id``.  Present on ``"subagent_message"``.
+        text: Latest assistant text snapshot from a subagent (present on
+            ``"subagent_message"``).
     """
 
-    kind: Literal["start", "end", "error"]
+    kind: Literal["start", "end", "error", "subagent_message"]
     tool_name: str
     tool_use_id: str
     tool_input: dict[str, Any] | None = None
     tool_response: str | None = None
     error: str | None = None
+    parent_tool_use_id: str | None = None
+    text: str | None = None
 
 
 @runtime_checkable

--- a/src/holodeck/lib/backends/base.py
+++ b/src/holodeck/lib/backends/base.py
@@ -56,22 +56,25 @@ class ToolEvent:
         kind: Event type — ``"start"`` before execution, ``"end"`` after
             success, ``"error"`` after failure, ``"subagent_message"`` for an
             assistant text snapshot streamed by an in-flight subagent (Task
-            tool).
+            tool), ``"parent_link"`` to declare that a tool invocation was
+            spawned by a subagent (so the panel can annotate it).
         tool_name: Name of the tool being invoked.
         tool_use_id: Unique identifier correlating start/end/error for the
             same invocation. For ``"subagent_message"`` events this is the
             parent Task's ``tool_use_id`` so consumers can attach the
-            snapshot to the corresponding active entry.
+            snapshot to the corresponding active entry. For ``"parent_link"``
+            this is the *child* tool's id.
         tool_input: Tool input parameters (present on ``"start"``).
         tool_response: Tool output (present on ``"end"``).
         error: Error description (present on ``"error"``).
         parent_tool_use_id: For nested events, the parent Task's
-            ``tool_use_id``.  Present on ``"subagent_message"``.
+            ``tool_use_id``.  Present on ``"subagent_message"`` and
+            ``"parent_link"``.
         text: Latest assistant text snapshot from a subagent (present on
             ``"subagent_message"``).
     """
 
-    kind: Literal["start", "end", "error", "subagent_message"]
+    kind: Literal["start", "end", "error", "subagent_message", "parent_link"]
     tool_name: str
     tool_use_id: str
     tool_input: dict[str, Any] | None = None

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -355,17 +355,12 @@ def build_options(
         if claude.disallowed_tools:
             opts_kwargs["disallowed_tools"] = list(claude.disallowed_tools)
         if claude.agents:
-            # HoloDeck keeps `SubagentSpec.model` as `str | None` so the SDK
-            # remains the source of truth for valid model names; cast at the
-            # boundary to satisfy AgentDefinition's narrower Literal type.
-            # `prompt or ""` is a stopgap until US3 lands the at-least-one /
-            # prompt_file inlining validator that guarantees a non-empty prompt.
             opts_kwargs["agents"] = {
                 name: AgentDefinition(
                     description=spec.description,
                     prompt=spec.prompt or "",
                     tools=spec.tools,
-                    model=cast(Any, spec.model),
+                    model=spec.model,
                 )
                 for name, spec in claude.agents.items()
             }
@@ -513,14 +508,18 @@ def _maybe_emit_subagent_message(
     msg: Any,
     queue: asyncio.Queue[ToolEvent],
 ) -> None:
-    """Push a ``subagent_message`` event when *msg* is subagent assistant text.
+    """Push ``subagent_message`` and ``parent_link`` events for subagent traffic.
 
     The Claude SDK yields nested messages from subagents (Task tool) on the
     same response stream as the parent.  Each subagent ``AssistantMessage``
     carries a non-null ``parent_tool_use_id`` pointing at the launching
-    Task's tool use id.  We use that to surface the latest text snapshot to
-    consumers (e.g. the chat tools panel) without filtering anything out of
-    the user-facing stream.
+    Task's tool use id.  We use it for two things:
+
+    1. Surface the latest assistant-text snapshot via ``subagent_message`` so
+       the chat tools panel can display in-flight subagent activity.
+    2. Emit a ``parent_link`` for every ``ToolUseBlock`` carried by the
+       subagent message, so the panel knows which top-level tool entries are
+       actually nested under a subagent and can render them indented.
 
     Args:
         msg: A message from ``client.receive_response()``.
@@ -531,20 +530,31 @@ def _maybe_emit_subagent_message(
     parent_id = getattr(msg, "parent_tool_use_id", None)
     if not parent_id:
         return
-    text = _extract_result_text(getattr(msg, "content", []) or []).strip()
-    if not text:
-        return
+    content = getattr(msg, "content", []) or []
+    text = _extract_result_text(content).strip()
     # Best-effort surface; never block message processing on a full queue.
     with contextlib.suppress(asyncio.QueueFull):
-        queue.put_nowait(
-            ToolEvent(
-                kind="subagent_message",
-                tool_name="Task",
-                tool_use_id=parent_id,
-                parent_tool_use_id=parent_id,
-                text=text,
+        if text:
+            queue.put_nowait(
+                ToolEvent(
+                    kind="subagent_message",
+                    tool_name="Task",
+                    tool_use_id=parent_id,
+                    parent_tool_use_id=parent_id,
+                    text=text,
+                )
             )
-        )
+        for block in content:
+            if block.__class__.__name__ != "ToolUseBlock":
+                continue
+            queue.put_nowait(
+                ToolEvent(
+                    kind="parent_link",
+                    tool_name=getattr(block, "name", ""),
+                    tool_use_id=getattr(block, "id", ""),
+                    parent_tool_use_id=parent_id,
+                )
+            )
 
 
 class ClaudeSession:

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -8,6 +8,7 @@ top-level ``query()`` function; multi-turn chat sessions use ``ClaudeSDKClient``
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from collections.abc import AsyncGenerator
@@ -482,6 +483,44 @@ def _build_tool_hooks(
     }
 
 
+def _maybe_emit_subagent_message(
+    msg: Any,
+    queue: asyncio.Queue[ToolEvent],
+) -> None:
+    """Push a ``subagent_message`` event when *msg* is subagent assistant text.
+
+    The Claude SDK yields nested messages from subagents (Task tool) on the
+    same response stream as the parent.  Each subagent ``AssistantMessage``
+    carries a non-null ``parent_tool_use_id`` pointing at the launching
+    Task's tool use id.  We use that to surface the latest text snapshot to
+    consumers (e.g. the chat tools panel) without filtering anything out of
+    the user-facing stream.
+
+    Args:
+        msg: A message from ``client.receive_response()``.
+        queue: Destination event queue.
+    """
+    if msg.__class__.__name__ != "AssistantMessage":
+        return
+    parent_id = getattr(msg, "parent_tool_use_id", None)
+    if not parent_id:
+        return
+    text = _extract_result_text(getattr(msg, "content", []) or []).strip()
+    if not text:
+        return
+    # Best-effort surface; never block message processing on a full queue.
+    with contextlib.suppress(asyncio.QueueFull):
+        queue.put_nowait(
+            ToolEvent(
+                kind="subagent_message",
+                tool_name="Task",
+                tool_use_id=parent_id,
+                parent_tool_use_id=parent_id,
+                text=text,
+            )
+        )
+
+
 class ClaudeSession:
     """Stateful multi-turn session backed by ``ClaudeSDKClient``.
 
@@ -588,6 +627,7 @@ class ClaudeSession:
             num_turns = 1
 
             async for msg in client.receive_response():
+                _maybe_emit_subagent_message(msg, self._tool_event_queue)
                 text_parts, tool_calls, tool_results = _process_message(
                     msg, text_parts, tool_calls, tool_results
                 )
@@ -642,6 +682,7 @@ class ClaudeSession:
             await client.query(message, session_id=self._get_session_id())
 
             async for msg in client.receive_response():
+                _maybe_emit_subagent_message(msg, self._tool_event_queue)
                 if msg.__class__.__name__ == "AssistantMessage":
                     for block in cast(Any, msg).content:
                         if block.__class__.__name__ == "TextBlock" and block.text:

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -343,6 +343,16 @@ def build_options(
     if max_thinking_tokens is not None:
         opts_kwargs["max_thinking_tokens"] = max_thinking_tokens
 
+    if claude is not None:
+        if claude.effort is not None:
+            opts_kwargs["effort"] = claude.effort
+        if claude.max_budget_usd is not None:
+            opts_kwargs["max_budget_usd"] = claude.max_budget_usd
+        if claude.fallback_model is not None:
+            opts_kwargs["fallback_model"] = claude.fallback_model
+        if claude.disallowed_tools:
+            opts_kwargs["disallowed_tools"] = list(claude.disallowed_tools)
+
     return ClaudeAgentOptions(**opts_kwargs)
 
 

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -23,6 +23,7 @@ from claude_agent_sdk import (
 )
 from claude_agent_sdk._errors import CLIConnectionError, MessageParseError
 from claude_agent_sdk.types import (
+    AgentDefinition,
     HookContext,
     HookEvent,
     McpSdkServerConfig,
@@ -352,6 +353,21 @@ def build_options(
             opts_kwargs["fallback_model"] = claude.fallback_model
         if claude.disallowed_tools:
             opts_kwargs["disallowed_tools"] = list(claude.disallowed_tools)
+        if claude.agents:
+            # HoloDeck keeps `SubagentSpec.model` as `str | None` so the SDK
+            # remains the source of truth for valid model names; cast at the
+            # boundary to satisfy AgentDefinition's narrower Literal type.
+            # `prompt or ""` is a stopgap until US3 lands the at-least-one /
+            # prompt_file inlining validator that guarantees a non-empty prompt.
+            opts_kwargs["agents"] = {
+                name: AgentDefinition(
+                    description=spec.description,
+                    prompt=spec.prompt or "",
+                    tools=spec.tools,
+                    model=cast(Any, spec.model),
+                )
+                for name, spec in claude.agents.items()
+            }
 
     return ClaudeAgentOptions(**opts_kwargs)
 

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -5,9 +5,11 @@ including authentication, permissions, and capability settings.
 All capabilities default to disabled (least-privilege).
 """
 
+import warnings
 from enum import Enum
+from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AuthProvider(str, Enum):
@@ -118,3 +120,39 @@ class ClaudeConfig(BaseModel):
         default=None,
         description="Explicit tool allowlist. None = all configured tools.",
     )
+    effort: Literal["low", "medium", "high", "max"] | None = Field(
+        default=None,
+        description="Thinking effort level. SDK accepts low|medium|high|max.",
+    )
+    max_budget_usd: float | None = Field(
+        default=None,
+        gt=0,
+        description="Hard cap on session spend in USD. Must be > 0.",
+    )
+    fallback_model: str | None = Field(
+        default=None,
+        description="Model used when the primary model is unavailable.",
+    )
+    disallowed_tools: list[str] | None = Field(
+        default=None,
+        description=(
+            "Tools that must never be used; takes precedence over allowed_tools."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _warn_effort_with_extended_thinking(self) -> "ClaudeConfig":
+        if (
+            self.effort is not None
+            and self.extended_thinking is not None
+            and self.extended_thinking.enabled
+        ):
+            warnings.warn(
+                "Both `effort` and `extended_thinking` are set on ClaudeConfig. "
+                "The Claude Agent SDK does not document precedence between "
+                "`effort` and `thinking.budget_tokens`; pick one to avoid "
+                "ambiguity.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return self

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -122,12 +122,14 @@ class SubagentSpec(BaseModel):
             "inherits all parent tools."
         ),
     )
-    model: str | None = Field(
+    model: Literal["sonnet", "opus", "haiku", "inherit"] | None = Field(
         default=None,
         description=(
-            "Model override for this subagent. Passed through to the SDK verbatim "
-            "(e.g. 'sonnet', 'haiku', 'inherit', or a full model id). "
-            "The SDK is the source of truth for valid values."
+            "Model override for this subagent. Must be one of the SDK's "
+            "literal aliases: 'sonnet', 'opus', 'haiku', 'inherit'. Full "
+            "model IDs (e.g. 'claude-haiku-4-5') are rejected — the Claude "
+            "CLI silently drops AgentDefinitions whose `model` is not in "
+            "this set, so the validator catches it at config-load time."
         ),
     )
 

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -7,9 +7,26 @@ All capabilities default to disabled (least-privilege).
 
 import warnings
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# Known built-in SDK tool names used for tool-name typo warnings (data-model.md rule 5).
+KNOWN_BUILTIN_TOOLS: frozenset[str] = frozenset(
+    {
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep",
+        "WebSearch",
+        "WebFetch",
+        "Task",
+        "TodoWrite",
+        "NotebookEdit",
+    }
+)
 
 
 class AuthProvider(str, Enum):
@@ -60,13 +77,97 @@ class FileSystemConfig(BaseModel):
     edit: bool = False
 
 
-class SubagentConfig(BaseModel):
-    """Parallel sub-agent execution settings."""
+class SubagentSpec(BaseModel):
+    """A single subagent definition for multi-agent orchestration.
+
+    Each entry under ``claude.agents`` becomes an
+    ``claude_agent_sdk.types.AgentDefinition`` on
+    ``ClaudeAgentOptions.agents``. The SDK uses ``description`` for routing.
+
+    US3 validators (prompt/prompt_file mutual exclusion and file resolution)
+    are deliberately omitted here — they belong to the US3 task slice.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = False
-    max_parallel: int = Field(default=4, ge=1, le=16)
+    description: str = Field(
+        description=(
+            "Human-readable description used by the parent agent for routing "
+            "decisions. Required by the SDK."
+        )
+    )
+    prompt: str | None = Field(
+        default=None,
+        description=(
+            "Inline system prompt for the subagent. "
+            "Mutually exclusive with prompt_file."
+        ),
+    )
+    prompt_file: str | None = Field(
+        default=None,
+        description=(
+            "Path to a file containing the subagent's system prompt. "
+            "Resolved relative to the agent.yaml directory. "
+            "Mutually exclusive with prompt. "
+            "File contents are inlined at config-load time."
+        ),
+    )
+    tools: list[str] | None = Field(
+        default=None,
+        description=(
+            "Allowlist of tool names. When null/omitted, the subagent "
+            "inherits all parent tools."
+        ),
+    )
+    model: str | None = Field(
+        default=None,
+        description=(
+            "Model override for this subagent. Passed through to the SDK verbatim "
+            "(e.g. 'sonnet', 'haiku', 'inherit', or a full model id). "
+            "The SDK is the source of truth for valid values."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_description_non_empty(self) -> "SubagentSpec":
+        """Validate description is non-empty after strip (data-model.md rule 4)."""
+        if not self.description.strip():
+            raise ValueError("description must not be empty or whitespace")
+        return self
+
+    @model_validator(mode="after")
+    def _warn_unknown_tool_names(self) -> "SubagentSpec":
+        """Emit UserWarning for tool names that don't match a known pattern.
+
+        Three accepted patterns (research.md §3):
+          1. Known SDK built-ins — names in ``KNOWN_BUILTIN_TOOLS``.
+          2. MCP tool names — entries prefixed with ``mcp__``.
+          3. HoloDeck-bridged tool names — entries registered in the parent
+             agent's top-level ``tools`` field.
+
+        NOTE: Pattern 3 (HoloDeck-bridged tools) cannot be checked here because
+        this model validator runs in isolation and does not have access to the
+        parent ``Agent`` context.  The warning message names all three accepted
+        patterns so users understand bridged names are valid and won't trigger
+        a hard error.  Cross-checking against the parent ``Agent.tools`` list is
+        intentionally deferred — it would require ``Agent``-level context.
+
+        Traces to data-model.md rule #5, research.md §3.
+        """
+        for entry in self.tools or []:
+            if entry in KNOWN_BUILTIN_TOOLS:
+                continue
+            if entry.startswith("mcp__"):
+                continue
+            warnings.warn(
+                f"Subagent tool '{entry}' does not match a known built-in "
+                f"(one of {sorted(KNOWN_BUILTIN_TOOLS)}), an MCP tool name "
+                f"(mcp__<server>__<tool>), or a HoloDeck-bridged tool. "
+                f"This may be a typo.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return self
 
 
 class ClaudeConfig(BaseModel):
@@ -112,9 +213,13 @@ class ClaudeConfig(BaseModel):
         default=None,
         description="File read/write/edit access settings.",
     )
-    subagents: SubagentConfig | None = Field(
+    agents: dict[str, SubagentSpec] | None = Field(
         default=None,
-        description="Parallel sub-agent execution settings.",
+        description=(
+            "Named subagent definitions. Each entry becomes an AgentDefinition "
+            "on ClaudeAgentOptions.agents. Subagents share parent MCP servers "
+            "and use their `tools` allowlist to scope MCP tool access."
+        ),
     )
     allowed_tools: list[str] | None = Field(
         default=None,
@@ -139,6 +244,30 @@ class ClaudeConfig(BaseModel):
             "Tools that must never be used; takes precedence over allowed_tools."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_legacy_subagents_block(cls, data: Any) -> Any:
+        """Raise a targeted error when the legacy claude.subagents block is present.
+
+        Runs before extra="forbid" so the user gets a helpful message instead of
+        a generic "extra fields not permitted" error. Traces to FR-011, SC-005.
+        """
+        if isinstance(data, dict) and "subagents" in data:
+            raise ValueError(
+                "`claude.subagents` is no longer supported; remove this block. "
+                "Subagent forwarding is gated solely by the presence of "
+                "`claude.agents`. To cap HoloDeck-side test concurrency, set "
+                "`execution.parallel_test_cases` instead."
+            )
+        return data
+
+    @model_validator(mode="after")
+    def _normalize_agents_empty_map(self) -> "ClaudeConfig":
+        """Normalize agents={} to agents=None (data-model.md rule 1)."""
+        if self.agents == {}:
+            self.agents = None
+        return self
 
     @model_validator(mode="after")
     def _warn_effort_with_extended_thinking(self) -> "ClaudeConfig":

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -7,9 +7,12 @@ All capabilities default to disabled (least-privilege).
 
 import warnings
 from enum import Enum
+from pathlib import Path
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from holodeck.config.context import agent_base_dir
 
 # Known built-in SDK tool names used for tool-name typo warnings (data-model.md rule 5).
 KNOWN_BUILTIN_TOOLS: frozenset[str] = frozenset(
@@ -132,7 +135,36 @@ class SubagentSpec(BaseModel):
     def _validate_description_non_empty(self) -> "SubagentSpec":
         """Validate description is non-empty after strip (data-model.md rule 4)."""
         if not self.description.strip():
-            raise ValueError("description must not be empty or whitespace")
+            raise ValueError("subagent requires description")
+        return self
+
+    @model_validator(mode="after")
+    def _resolve_prompt_sources(self) -> "SubagentSpec":
+        """Enforce prompt/prompt_file rules and inline prompt_file contents.
+
+        Order matters: mutual-exclusion → at-least-one → file resolution →
+        post-strip non-empty check. After this validator returns, ``prompt`` is
+        always a non-empty string and ``prompt_file`` is always ``None``
+        (data-model.md §1 invariants).
+        """
+        if self.prompt is not None and self.prompt_file is not None:
+            raise ValueError("prompt and prompt_file are mutually exclusive")
+        if self.prompt is None and self.prompt_file is None:
+            raise ValueError("subagent requires either prompt or prompt_file")
+
+        if self.prompt_file is not None:
+            base_dir_value = agent_base_dir.get()
+            base_dir = Path.cwd() if base_dir_value is None else Path(base_dir_value)
+            path = Path(self.prompt_file)
+            if not path.is_absolute():
+                path = base_dir / path
+            if not path.exists():
+                raise ValueError(f"prompt_file not found: {path}")
+            self.prompt = path.read_text(encoding="utf-8")
+            self.prompt_file = None
+
+        if self.prompt is not None and not self.prompt.strip():
+            raise ValueError("subagent prompt must be non-empty")
         return self
 
     @model_validator(mode="after")

--- a/tests/unit/chat/test_composer.py
+++ b/tests/unit/chat/test_composer.py
@@ -1,0 +1,101 @@
+"""Unit tests for :class:`holodeck.chat.composer.LiveComposer`."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from holodeck.chat.composer import LiveComposer
+
+
+@contextmanager
+def _captured_stdout() -> Iterator[io.StringIO]:
+    """Patch ``sys.stdout`` with an in-memory buffer for the duration of the test."""
+    buf = io.StringIO()
+    with patch("holodeck.chat.composer.sys.stdout", buf):
+        yield buf
+
+
+def _force_tty(value: bool) -> Iterator[None]:
+    return patch("holodeck.chat.composer.is_tty", return_value=value)
+
+
+class TestLiveComposer:
+    @pytest.mark.asyncio
+    async def test_inactive_composer_skips_panel_updates(self) -> None:
+        composer = LiveComposer()
+        with _captured_stdout() as buf, _force_tty(True):
+            await composer.update_panel(["one"])
+        # Never began — must not paint.
+        assert buf.getvalue() == ""
+
+    @pytest.mark.asyncio
+    async def test_update_panel_writes_when_active_and_tty(self) -> None:
+        composer = LiveComposer()
+        with _captured_stdout() as buf, _force_tty(True):
+            await composer.begin()
+            await composer.update_panel(["row-a", "row-b"])
+            output = buf.getvalue()
+        # DECSC + newline + body + DECRC.
+        assert "\0337\nrow-a\nrow-b\0338" in output
+
+    @pytest.mark.asyncio
+    async def test_update_panel_noops_when_lines_unchanged(self) -> None:
+        composer = LiveComposer()
+        with _captured_stdout() as buf, _force_tty(True):
+            await composer.begin()
+            await composer.update_panel(["row-a"])
+            buf.truncate(0)
+            buf.seek(0)
+            await composer.update_panel(["row-a"])
+            assert buf.getvalue() == ""
+
+    @pytest.mark.asyncio
+    async def test_write_text_erases_then_redraws_panel(self) -> None:
+        composer = LiveComposer()
+        with _captured_stdout() as buf, _force_tty(True):
+            await composer.begin()
+            await composer.update_panel(["row-a"])
+            buf.truncate(0)
+            buf.seek(0)
+            await composer.write_text("hello")
+            output = buf.getvalue()
+        # Erase sequence + chunk + redraw sequence.
+        assert output.startswith("\0337\n\033[J\0338")
+        assert "hello" in output
+        assert output.endswith("\0337\nrow-a\0338")
+
+    @pytest.mark.asyncio
+    async def test_end_clears_panel_and_resets_state(self) -> None:
+        composer = LiveComposer()
+        with _captured_stdout() as buf, _force_tty(True):
+            await composer.begin()
+            await composer.update_panel(["row-a"])
+            buf.truncate(0)
+            buf.seek(0)
+            await composer.end()
+            output = buf.getvalue()
+        # Erase escape was emitted.
+        assert "\0337\n\033[J\0338" in output
+
+        # After end(), update_panel must noop (composer inactive).
+        with _captured_stdout() as buf2, _force_tty(True):
+            await composer.update_panel(["new-row"])
+            assert buf2.getvalue() == ""
+
+    @pytest.mark.asyncio
+    async def test_non_tty_skips_ansi_writes_but_streams_text(self) -> None:
+        composer = LiveComposer()
+        with _captured_stdout() as buf, _force_tty(False):
+            await composer.begin()
+            await composer.update_panel(["row-a"])
+            await composer.write_text("hello")
+            output = buf.getvalue()
+        # No ANSI sequences when not a TTY; text still arrives so logs are usable.
+        assert "\0337" not in output
+        assert "\033[J" not in output
+        assert output == "hello"

--- a/tests/unit/chat/test_tools_panel.py
+++ b/tests/unit/chat/test_tools_panel.py
@@ -1,0 +1,218 @@
+"""Unit tests for the chat ToolsPanel state + renderer.
+
+Drives :class:`holodeck.chat.tools_panel.ToolsPanel` with crafted
+:class:`holodeck.lib.backends.base.ToolEvent` sequences and asserts both
+state transitions (snapshot, line_count) and rendered content.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from holodeck.chat.tools_panel import ToolsPanel
+from holodeck.lib.backends.base import ToolEvent
+
+
+def _force_tty(value: bool = True) -> patch:
+    """Patch is_tty in the tools_panel module."""
+    return patch("holodeck.chat.tools_panel.is_tty", return_value=value)
+
+
+class TestEmptyState:
+    """Empty panels render nothing regardless of TTY state."""
+
+    def test_no_active_tools_returns_empty_lines_in_tty(self) -> None:
+        panel = ToolsPanel()
+        with _force_tty(True):
+            assert panel.render_lines() == []
+            assert panel.line_count == 0
+
+    def test_non_tty_renders_nothing_even_with_active_tools(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(ToolEvent(kind="start", tool_name="Read", tool_use_id="tu_1"))
+        with _force_tty(False):
+            assert panel.render_lines() == []
+            assert panel.line_count == 0
+
+
+class TestRegularToolLifecycle:
+    """start → end / error transitions for non-Task tools."""
+
+    def test_start_creates_active_entry(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(ToolEvent(kind="start", tool_name="Read", tool_use_id="tu_1"))
+        with _force_tty(True):
+            lines = panel.render_lines()
+        assert any("Read" in line for line in lines)
+        # 2 borders + 1 entry
+        with _force_tty(True):
+            assert panel.line_count == 3
+
+    def test_end_removes_active_entry(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(ToolEvent(kind="start", tool_name="Read", tool_use_id="tu_1"))
+        panel.apply(ToolEvent(kind="end", tool_name="Read", tool_use_id="tu_1"))
+        with _force_tty(True):
+            assert panel.render_lines() == []
+            assert panel.line_count == 0
+
+    def test_error_removes_active_entry(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(ToolEvent(kind="start", tool_name="Bash", tool_use_id="tu_1"))
+        panel.apply(
+            ToolEvent(
+                kind="error",
+                tool_name="Bash",
+                tool_use_id="tu_1",
+                error="boom",
+            )
+        )
+        with _force_tty(True):
+            assert panel.render_lines() == []
+
+    def test_multiple_tools_render_in_order(self) -> None:
+        panel = ToolsPanel()
+        for name, tu in [("Read", "tu_1"), ("Bash", "tu_2"), ("Grep", "tu_3")]:
+            panel.apply(ToolEvent(kind="start", tool_name=name, tool_use_id=tu))
+        with _force_tty(True):
+            lines = panel.render_lines()
+        joined = "\n".join(lines)
+        # All names present, in insertion order
+        assert joined.index("Read") < joined.index("Bash") < joined.index("Grep")
+
+
+class TestSubagentLifecycle:
+    """Task tool calls render as subagents and surface status text."""
+
+    def test_task_tool_labels_with_subagent_type(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "code-reviewer"},
+            )
+        )
+        with _force_tty(True):
+            lines = panel.render_lines()
+        assert any("Task[code-reviewer]" in line for line in lines)
+
+    def test_subagent_message_attaches_status_line(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "researcher"},
+            )
+        )
+        panel.apply(
+            ToolEvent(
+                kind="subagent_message",
+                tool_name="Task",
+                tool_use_id="task_1",
+                parent_tool_use_id="task_1",
+                text="Found 3 candidate files\nReading src/foo.py…",
+            )
+        )
+        with _force_tty(True):
+            lines = panel.render_lines()
+            count = panel.line_count
+        # Status uses the LAST non-empty line
+        assert any("Reading src/foo.py" in line for line in lines)
+        # 2 borders + 1 entry + 1 status
+        assert count == 4
+
+    def test_subagent_message_replaces_previous_status(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "x"},
+            )
+        )
+        panel.apply(
+            ToolEvent(
+                kind="subagent_message",
+                tool_name="Task",
+                tool_use_id="task_1",
+                parent_tool_use_id="task_1",
+                text="step one",
+            )
+        )
+        panel.apply(
+            ToolEvent(
+                kind="subagent_message",
+                tool_name="Task",
+                tool_use_id="task_1",
+                parent_tool_use_id="task_1",
+                text="step two",
+            )
+        )
+        with _force_tty(True):
+            joined = "\n".join(panel.render_lines())
+        assert "step two" in joined
+        assert "step one" not in joined
+
+    def test_subagent_message_for_unknown_id_is_dropped(self) -> None:
+        panel = ToolsPanel()
+        # No corresponding start event — message must not crash and must
+        # not introduce a phantom entry.
+        panel.apply(
+            ToolEvent(
+                kind="subagent_message",
+                tool_name="Task",
+                tool_use_id="task_unknown",
+                parent_tool_use_id="task_unknown",
+                text="hello",
+            )
+        )
+        with _force_tty(True):
+            assert panel.render_lines() == []
+
+    def test_end_clears_subagent_and_status(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "rev"},
+            )
+        )
+        panel.apply(
+            ToolEvent(
+                kind="subagent_message",
+                tool_name="Task",
+                tool_use_id="task_1",
+                parent_tool_use_id="task_1",
+                text="working",
+            )
+        )
+        panel.apply(ToolEvent(kind="end", tool_name="Task", tool_use_id="task_1"))
+        with _force_tty(True):
+            assert panel.render_lines() == []
+
+
+class TestSnapshot:
+    """`snapshot()` returns the current in-flight entries."""
+
+    def test_snapshot_reflects_active_tools(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(ToolEvent(kind="start", tool_name="Read", tool_use_id="tu_1"))
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "rev"},
+            )
+        )
+        snap = panel.snapshot()
+        assert {e.tool_name for e in snap} == {"Read", "Task"}
+        task_entry = next(e for e in snap if e.is_subagent)
+        assert task_entry.subagent_type == "rev"

--- a/tests/unit/chat/test_tools_panel.py
+++ b/tests/unit/chat/test_tools_panel.py
@@ -198,6 +198,226 @@ class TestSubagentLifecycle:
             assert panel.render_lines() == []
 
 
+class TestToolArgsRendering:
+    """Tool input args render as a compact ``k=v`` line under the entry."""
+
+    def test_string_args_render_under_entry(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Read",
+                tool_use_id="tu_1",
+                tool_input={"file_path": "/etc/hosts"},
+            )
+        )
+        with _force_tty(True):
+            lines = panel.render_lines()
+            count = panel.line_count
+        assert any("file_path=/etc/hosts" in line for line in lines)
+        # 2 borders + 1 entry + 1 args line
+        assert count == 4
+
+    def test_subagent_type_is_omitted_from_args(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "reviewer", "description": "Review code"},
+            )
+        )
+        with _force_tty(True):
+            joined = "\n".join(panel.render_lines())
+        assert "description=Review code" in joined
+        assert "subagent_type=" not in joined
+
+    def test_subagent_status_replaces_args_line(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "rev", "description": "Review"},
+            )
+        )
+        # Before status arrives: args line shows description.
+        with _force_tty(True):
+            joined = "\n".join(panel.render_lines())
+        assert "description=Review" in joined
+
+        panel.apply(
+            ToolEvent(
+                kind="subagent_message",
+                tool_name="Task",
+                tool_use_id="task_1",
+                parent_tool_use_id="task_1",
+                text="Reading src/foo.py",
+            )
+        )
+        with _force_tty(True):
+            joined = "\n".join(panel.render_lines())
+        assert "Reading src/foo.py" in joined
+        assert "description=Review" not in joined
+
+    def test_long_args_truncated_within_panel(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Bash",
+                tool_use_id="tu_1",
+                tool_input={"command": "x" * 500},
+            )
+        )
+        with _force_tty(True):
+            lines = panel.render_lines()
+        args_line = next(line for line in lines if "command=" in line)
+        # Stripped of border padding the line still respects the panel width.
+        assert len(args_line) <= 60
+        assert "…" in args_line
+
+    def test_dict_value_renders_as_compact_json(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="WebSearch",
+                tool_use_id="tu_1",
+                tool_input={"params": {"q": "claude code", "n": 5}},
+            )
+        )
+        with _force_tty(True):
+            joined = "\n".join(panel.render_lines())
+        assert '{"q":"claude code","n":5}' in joined
+
+    def test_newlines_in_string_args_collapse_to_single_line(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Edit",
+                tool_use_id="tu_1",
+                tool_input={"old_string": "line1\nline2"},
+            )
+        )
+        with _force_tty(True):
+            args_line = next(
+                line for line in panel.render_lines() if "old_string=" in line
+            )
+        assert "\n" not in args_line.strip("│ ").strip()
+        assert "line1 line2" in args_line
+
+
+class TestParentLink:
+    """`parent_link` events nest child tools under their parent subagent."""
+
+    def test_parent_link_after_start_indents_child(self) -> None:
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "researcher"},
+            )
+        )
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="WebSearch",
+                tool_use_id="tu_child",
+                tool_input={"query": "claude"},
+            )
+        )
+        panel.apply(
+            ToolEvent(
+                kind="parent_link",
+                tool_name="WebSearch",
+                tool_use_id="tu_child",
+                parent_tool_use_id="task_1",
+            )
+        )
+        with _force_tty(True):
+            lines = panel.render_lines()
+        # Find the WebSearch row — must be indented (leading "│  " + space).
+        web_row = next(line for line in lines if "WebSearch" in line)
+        # Border + at least 2 indent spaces before the spinner/label.
+        assert web_row.startswith("│   ")
+        # Task entry sits above the WebSearch row in render order.
+        joined = "\n".join(lines)
+        assert joined.index("Task[researcher]") < joined.index("WebSearch")
+
+    def test_parent_link_before_start_still_indents(self) -> None:
+        """parent_link can race ahead of the child's PreToolUse hook."""
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "x"},
+            )
+        )
+        panel.apply(
+            ToolEvent(
+                kind="parent_link",
+                tool_name="Read",
+                tool_use_id="tu_child",
+                parent_tool_use_id="task_1",
+            )
+        )
+        # Child start arrives later — pending parent must apply.
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Read",
+                tool_use_id="tu_child",
+                tool_input={"file_path": "/etc/hosts"},
+            )
+        )
+        with _force_tty(True):
+            lines = panel.render_lines()
+        read_row = next(line for line in lines if "Read" in line)
+        assert read_row.startswith("│   ")
+
+    def test_child_renders_at_top_level_when_parent_already_ended(self) -> None:
+        """If the parent ended before the child appears, child shows flat."""
+        panel = ToolsPanel()
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "x"},
+            )
+        )
+        panel.apply(ToolEvent(kind="end", tool_name="Task", tool_use_id="task_1"))
+        panel.apply(
+            ToolEvent(
+                kind="start",
+                tool_name="Read",
+                tool_use_id="tu_child",
+                tool_input={"file_path": "/etc/hosts"},
+            )
+        )
+        panel.apply(
+            ToolEvent(
+                kind="parent_link",
+                tool_name="Read",
+                tool_use_id="tu_child",
+                parent_tool_use_id="task_1",
+            )
+        )
+        with _force_tty(True):
+            lines = panel.render_lines()
+        read_row = next(line for line in lines if "Read" in line)
+        # Top-level entries start with "│ ⠋ ..." (single space indent only).
+        assert not read_row.startswith("│   ")
+
+
 class TestSnapshot:
     """`snapshot()` returns the current in-flight entries."""
 

--- a/tests/unit/cli/commands/test_chat.py
+++ b/tests/unit/cli/commands/test_chat.py
@@ -6,17 +6,20 @@ Tests cover:
 - Exit code logic (0=normal exit, 1=config error, 2=agent error, 130=interrupt)
 - Multi-turn conversation flow
 - Tool execution display (standard and verbose modes)
-- Spinner thread animation and lifecycle
+- Async drainer + renderer helpers for the live tools panel
 """
 
+import asyncio
 import tempfile
-import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from holodeck.chat.progress import ChatProgressIndicator
+from holodeck.chat.tools_panel import ToolsPanel
+from holodeck.lib.backends.base import ToolEvent
 from holodeck.models.agent import Agent
 from holodeck.models.config import ExecutionConfig
 
@@ -708,201 +711,100 @@ class TestCLIHappyPath:
             Path(tmp_path).unlink(missing_ok=True)
 
 
-class TestChatSpinnerThread:
-    """Tests for ChatSpinnerThread spinner animation."""
+class TestToolEventDrainer:
+    """Tests for the chat REPL's tool-event drainer task."""
 
-    def test_spinner_thread_initializes(self) -> None:
-        """ChatSpinnerThread initializes with progress indicator."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
+    @pytest.mark.asyncio
+    async def test_drainer_applies_events_to_panel(self) -> None:
+        """Events on the queue are forwarded into the panel."""
+        from holodeck.cli.commands.chat import _drain_tool_events
 
+        queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
+        panel = ToolsPanel()
+        stop_event = asyncio.Event()
+
+        await queue.put(ToolEvent(kind="start", tool_name="Read", tool_use_id="tu_1"))
+        await queue.put(
+            ToolEvent(
+                kind="start",
+                tool_name="Task",
+                tool_use_id="task_1",
+                tool_input={"subagent_type": "rev"},
+            )
+        )
+
+        task = asyncio.create_task(_drain_tool_events(queue, panel, stop_event))
+        # Yield enough times for the drainer to consume both items.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        stop_event.set()
+        await task
+
+        names = {e.tool_name for e in panel.snapshot()}
+        assert names == {"Read", "Task"}
+
+    @pytest.mark.asyncio
+    async def test_drainer_exits_promptly_when_stop_event_set(self) -> None:
+        """Drainer must not block forever waiting on an empty queue."""
+        from holodeck.cli.commands.chat import _drain_tool_events
+
+        queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
+        panel = ToolsPanel()
+        stop_event = asyncio.Event()
+
+        task = asyncio.create_task(_drain_tool_events(queue, panel, stop_event))
+        stop_event.set()
+        # Should return well within the per-iteration timeout.
+        await asyncio.wait_for(task, timeout=1.0)
+
+
+class TestRemainingDrain:
+    """Tests for ``_drain_remaining`` that consumes buffered events."""
+
+    def test_drains_all_buffered_events(self) -> None:
+        from holodeck.cli.commands.chat import _drain_remaining
+
+        queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
+        panel = ToolsPanel()
+        queue.put_nowait(ToolEvent(kind="start", tool_name="Read", tool_use_id="tu_1"))
+        queue.put_nowait(ToolEvent(kind="end", tool_name="Read", tool_use_id="tu_1"))
+
+        _drain_remaining(queue, panel)
+
+        assert queue.empty()
+        assert panel.snapshot() == []
+
+
+class TestPanelRenderer:
+    """Tests for ``_render_tools_panel`` and ``_clear_panel`` helpers."""
+
+    @pytest.mark.asyncio
+    async def test_renderer_returns_immediately_when_not_tty(self) -> None:
+        from holodeck.cli.commands.chat import _render_tools_panel
+
+        panel = ToolsPanel()
         progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
+        stop_event = asyncio.Event()
 
-        assert spinner.progress is progress
-        assert spinner.daemon is True
+        with patch("holodeck.cli.commands.chat.is_tty", return_value=False):
+            last_lines = await asyncio.wait_for(
+                _render_tools_panel(panel, progress, stop_event), timeout=1.0
+            )
+        assert last_lines == 0
 
-    def test_spinner_thread_has_stop_event(self) -> None:
-        """ChatSpinnerThread has _stop_event for thread control."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        assert hasattr(spinner, "_stop_event")
-        assert spinner._stop_event.is_set() is False
-
-    def test_spinner_thread_has_running_flag(self) -> None:
-        """ChatSpinnerThread has _running flag."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        assert hasattr(spinner, "_running")
-        assert spinner._running is False
-
-    def test_spinner_thread_stop_sets_event(self) -> None:
-        """ChatSpinnerThread.stop() sets the stop event."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        spinner.stop()
-
-        assert spinner._stop_event.is_set() is True
-
-    def test_spinner_thread_run_sets_running_flag(self) -> None:
-        """ChatSpinnerThread.run() sets _running flag to True."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        # Mock the progress.get_spinner_line to return immediately
-        with patch.object(progress, "get_spinner_line", return_value=""):
-            spinner._stop_event.set()
-            spinner.run()
-
-            # After run completes, _running should be False
-            assert spinner._running is False
-
-    def test_spinner_thread_clears_line_on_stop(self) -> None:
-        """ChatSpinnerThread.stop() clears the spinner line from output."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
+    def test_clear_panel_emits_no_output_for_zero_lines(self) -> None:
+        from holodeck.cli.commands.chat import _clear_panel
 
         with patch("sys.stdout.write") as mock_write, patch("sys.stdout.flush"):
-            # Mark as running so stop will clear the line
-            spinner._running = True
-            spinner.stop()
+            _clear_panel(0)
+        mock_write.assert_not_called()
 
-            # Should write clear sequence with spaces and carriage returns
-            assert mock_write.called
-            # Verify clear sequence was written (carriage return + spaces)
-            call_args = [call[0][0] for call in mock_write.call_args_list]
-            assert any("\r" in str(arg) for arg in call_args)
+    def test_clear_panel_writes_ansi_clear_for_positive_lines(self) -> None:
+        from holodeck.cli.commands.chat import _clear_panel
 
-    def test_spinner_thread_with_tty_writes_spinner(self) -> None:
-        """ChatSpinnerThread writes spinner text when spinner line is not empty."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        with (
-            patch.object(progress, "get_spinner_line", return_value="⠋ Thinking..."),
-            patch("sys.stdout.write"),
-            patch("sys.stdout.flush"),
-        ):
-            # Set up to run for just one iteration
-            spinner._stop_event.set()
-            spinner.run()
-
-            # Spinner runs even if loop exits immediately
-            assert spinner is not None
-
-    def test_spinner_thread_without_tty_no_output(self) -> None:
-        """ChatSpinnerThread produces no output when spinner returns empty."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        with (
-            patch.object(progress, "get_spinner_line", return_value=""),
-            patch("sys.stdout.write"),
-            patch("sys.stdout.flush"),
-        ):
-            # Set up to run for one iteration with empty output
-            spinner._stop_event.set()
-            spinner.run()
-
-            # Should complete without error
-            assert spinner is not None
-
-    def test_spinner_thread_respects_stop_event(self) -> None:
-        """ChatSpinnerThread stops when stop_event is set."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        with patch.object(progress, "get_spinner_line", return_value="⠋ Thinking..."):
-            # Immediately set stop event
-            spinner._stop_event.set()
-
-            # Run should exit quickly
-            spinner.run()
-
-            # Verify _running is now False
-            assert spinner._running is False
-
-    def test_spinner_thread_runs_in_background(self) -> None:
-        """ChatSpinnerThread is a daemon thread."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        assert spinner.daemon is True
-
-    def test_spinner_thread_updates_progress_spinner_index(self) -> None:
-        """ChatSpinnerThread calls progress.get_spinner_line repeatedly."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        initial_index = progress._spinner_index
-
-        with patch("sys.stdout.write"), patch("sys.stdout.flush"):
-            # Set up to run briefly
-            def stop_after_calls():
-                # Give it a few iterations
-                time.sleep(0.15)  # Longer sleep to ensure multiple iterations
-                spinner.stop()
-
-            import threading as t
-
-            stop_thread = t.Thread(target=stop_after_calls)
-            stop_thread.start()
-            spinner.run()
-            stop_thread.join()
-
-            # Spinner index should have advanced (at least 1 iteration)
-            assert progress._spinner_index >= initial_index
-
-    def test_spinner_thread_multiple_stop_calls_safe(self) -> None:
-        """Calling stop() multiple times is safe."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        # Should not raise
-        spinner.stop()
-        spinner.stop()
-        spinner.stop()
-
-        assert spinner._stop_event.is_set() is True
-
-    def test_spinner_thread_flushes_output(self) -> None:
-        """ChatSpinnerThread flushes stdout after writing spinner."""
-        from holodeck.cli.commands.chat import ChatSpinnerThread
-
-        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
-        spinner = ChatSpinnerThread(progress)
-
-        with (
-            patch.object(progress, "get_spinner_line", return_value="⠋ Thinking..."),
-            patch("sys.stdout.write"),
-            patch("sys.stdout.flush"),
-        ):
-            spinner._stop_event.set()
-            spinner.run()
-
-            # Spinner completed successfully
-            assert spinner is not None
+        with patch("sys.stdout.write") as mock_write, patch("sys.stdout.flush"):
+            _clear_panel(3)
+        mock_write.assert_called_once()
+        written = mock_write.call_args.args[0]
+        # ANSI: CR + cursor up 3 + erase from cursor down
+        assert written == "\r\033[3A\033[J"

--- a/tests/unit/cli/commands/test_chat.py
+++ b/tests/unit/cli/commands/test_chat.py
@@ -775,36 +775,47 @@ class TestRemainingDrain:
         assert panel.snapshot() == []
 
 
-class TestPanelRenderer:
-    """Tests for ``_render_tools_panel`` and ``_clear_panel`` helpers."""
+class TestPaintPanelLoop:
+    """Tests for the ``_paint_panel_loop`` driver task."""
 
     @pytest.mark.asyncio
-    async def test_renderer_returns_immediately_when_not_tty(self) -> None:
-        from holodeck.cli.commands.chat import _render_tools_panel
+    async def test_loop_exits_promptly_when_stop_event_set(self) -> None:
+        from holodeck.chat.composer import LiveComposer
+        from holodeck.cli.commands.chat import _paint_panel_loop
 
         panel = ToolsPanel()
         progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
+        composer = LiveComposer()
         stop_event = asyncio.Event()
 
-        with patch("holodeck.cli.commands.chat.is_tty", return_value=False):
-            last_lines = await asyncio.wait_for(
-                _render_tools_panel(panel, progress, stop_event), timeout=1.0
-            )
-        assert last_lines == 0
+        await composer.begin()
+        task = asyncio.create_task(
+            _paint_panel_loop(panel, progress, composer, stop_event)
+        )
+        stop_event.set()
+        # Should return well within one paint interval + final paint.
+        await asyncio.wait_for(task, timeout=1.0)
+        await composer.end()
 
-    def test_clear_panel_emits_no_output_for_zero_lines(self) -> None:
-        from holodeck.cli.commands.chat import _clear_panel
+    @pytest.mark.asyncio
+    async def test_loop_pushes_panel_lines_to_composer(self) -> None:
+        from holodeck.chat.composer import LiveComposer
+        from holodeck.cli.commands.chat import _paint_panel_loop
 
-        with patch("sys.stdout.write") as mock_write, patch("sys.stdout.flush"):
-            _clear_panel(0)
-        mock_write.assert_not_called()
+        panel = ToolsPanel()
+        panel.apply(ToolEvent(kind="start", tool_name="Read", tool_use_id="tu_1"))
+        progress = ChatProgressIndicator(max_messages=50, quiet=False, verbose=False)
+        composer = LiveComposer()
+        composer.update_panel = AsyncMock()  # type: ignore[method-assign]
+        stop_event = asyncio.Event()
 
-    def test_clear_panel_writes_ansi_clear_for_positive_lines(self) -> None:
-        from holodeck.cli.commands.chat import _clear_panel
+        await composer.begin()
+        task = asyncio.create_task(
+            _paint_panel_loop(panel, progress, composer, stop_event)
+        )
+        # Let it tick once.
+        await asyncio.sleep(0.15)
+        stop_event.set()
+        await asyncio.wait_for(task, timeout=1.0)
 
-        with patch("sys.stdout.write") as mock_write, patch("sys.stdout.flush"):
-            _clear_panel(3)
-        mock_write.assert_called_once()
-        written = mock_write.call_args.args[0]
-        # ANSI: CR + cursor up 3 + erase from cursor down
-        assert written == "\r\033[3A\033[J"
+        assert composer.update_panel.await_count >= 1

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -42,6 +42,7 @@ from holodeck.models.claude_config import (
     ClaudeConfig,
     ExtendedThinkingConfig,
     PermissionMode,
+    SubagentSpec,
 )
 from holodeck.models.llm import LLMProvider, ProviderEnum
 from holodeck.models.observability import (
@@ -523,6 +524,191 @@ class TestBuildOptions:
 
         kwargs = mock_opts_cls.call_args[1]
         assert "ANTHROPIC_BASE_URL" not in kwargs["env"]
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_no_agents_omits_field(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """T004 (foundational): claude.agents is None → agents absent from opts.
+
+        Traces to FR-010.
+        """
+        agent = _make_agent(claude=ClaudeConfig())
+        build_options(
+            agent=agent,
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert "agents" not in kwargs
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_translates_three_named_subagents(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """T014a (US1): Three named subagents round-trip into AgentDefinition objects.
+
+        Traces to US1 acceptance scenario 1, SC-002.
+        """
+        from claude_agent_sdk.types import AgentDefinition as RealAgentDefinition
+
+        from holodeck.models.claude_config import SubagentSpec
+
+        claude = ClaudeConfig(
+            agents={
+                "researcher": SubagentSpec(
+                    description="Search the web for information.",
+                    prompt="You are a researcher. Search the web thoroughly.",
+                ),
+                "analyst": SubagentSpec(
+                    description="Analyze the findings.",
+                    prompt="You are a data analyst. Analyze findings carefully.",
+                ),
+                "writer": SubagentSpec(
+                    description="Write the final report.",
+                    prompt="You are a technical writer. Produce clear reports.",
+                ),
+            }
+        )
+        agent = _make_agent(claude=claude)
+        build_options(
+            agent=agent,
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        agents = kwargs["agents"]
+        assert len(agents) == 3
+        assert "researcher" in agents
+        assert "analyst" in agents
+        assert "writer" in agents
+        # Each value is an AgentDefinition
+        assert isinstance(agents["researcher"], RealAgentDefinition)
+        assert agents["researcher"].description == "Search the web for information."
+        assert (
+            agents["researcher"].prompt
+            == "You are a researcher. Search the web thoroughly."
+        )
+        assert agents["analyst"].description == "Analyze the findings."
+        assert agents["writer"].description == "Write the final report."
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_subagent_model_override_haiku(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """T014b (US1): model='haiku' → AgentDefinition(model='haiku').
+
+        Traces to US1 acceptance scenario 2, SC-002.
+        """
+        from holodeck.models.claude_config import SubagentSpec
+
+        claude = ClaudeConfig(
+            agents={
+                "fast-agent": SubagentSpec(
+                    description="A fast, lightweight agent.",
+                    prompt="You are a fast helper.",
+                    model="haiku",
+                ),
+            }
+        )
+        agent = _make_agent(claude=claude)
+        build_options(
+            agent=agent,
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["agents"]["fast-agent"].model == "haiku"
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_subagent_tools_allowlist(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """T014c (US1): tools list → AgentDefinition with that list.
+
+        Traces to US1 acceptance scenario 3, SC-003.
+        """
+        from holodeck.models.claude_config import SubagentSpec
+
+        claude = ClaudeConfig(
+            agents={
+                "web-researcher": SubagentSpec(
+                    description="Searches the web.",
+                    prompt="You are a web researcher.",
+                    tools=["WebSearch", "WebFetch"],
+                ),
+            }
+        )
+        agent = _make_agent(claude=claude)
+        build_options(
+            agent=agent,
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["agents"]["web-researcher"].tools == ["WebSearch", "WebFetch"]
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_subagent_tools_omitted_inherits_all(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """T014d (US1): Subagent with no tools produces AgentDefinition(tools=None).
+
+        Traces to US1 acceptance scenario 4, FR-007.
+        """
+        from holodeck.models.claude_config import SubagentSpec
+
+        claude = ClaudeConfig(
+            agents={
+                "omniscient": SubagentSpec(
+                    description="Has access to all parent tools.",
+                    prompt="You have access to all parent tools.",
+                ),
+            }
+        )
+        agent = _make_agent(claude=claude)
+        build_options(
+            agent=agent,
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["agents"]["omniscient"].tools is None
 
 
 # ---------------------------------------------------------------------------
@@ -2568,4 +2754,148 @@ class TestClaudeBackendTeardownToolCleanup:
         # Should not raise
         await backend.teardown()
 
-        assert backend._owned_tools == []
+
+# ---------------------------------------------------------------------------
+# T009 — build_options() AgentDefinition.tools translation (US2 / SC-003)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildOptionsSubagentTools:
+    """T009: build_options() translates SubagentSpec.tools → AgentDefinition.tools.
+
+    Traces to SC-003, FR-007, FR-009, data-model.md §2.
+    The three states (None, [], populated list) must pass through verbatim.
+    """
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_ac1_single_subagent_mcp_tools(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """AC-1: One subagent with MCP tools → AgentDefinition.tools matches exactly."""
+        claude = ClaudeConfig(
+            agents={
+                "db_analyst": SubagentSpec(
+                    description="Queries the database.",
+                    prompt="You are a database analyst.",
+                    tools=["mcp__db__query", "mcp__db__describe"],
+                ),
+            }
+        )
+        agent = _make_agent(claude=claude)
+        build_options(
+            agent=agent,
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert "agents" in kwargs
+        db_analyst = kwargs["agents"]["db_analyst"]
+        assert db_analyst.tools == ["mcp__db__query", "mcp__db__describe"]
+        assert isinstance(db_analyst.tools, list)
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_ac2_disjoint_isolation_two_subagents(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """AC-2: Two subagents with disjoint tools stay isolated from each other."""
+        claude = ClaudeConfig(
+            agents={
+                "db_analyst": SubagentSpec(
+                    description="Queries the database.",
+                    prompt="You are a database analyst.",
+                    tools=["mcp__db__query"],
+                ),
+                "researcher": SubagentSpec(
+                    description="Researches online.",
+                    prompt="You are a researcher.",
+                    tools=["WebSearch", "WebFetch"],
+                ),
+            }
+        )
+        agent = _make_agent(claude=claude)
+        build_options(
+            agent=agent,
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        agents = kwargs["agents"]
+        assert agents["db_analyst"].tools == ["mcp__db__query"]
+        assert agents["researcher"].tools == ["WebSearch", "WebFetch"]
+        assert "mcp__db__query" not in agents["researcher"].tools
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_fr007_inheritance_tools_none(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """FR-007: tools=None on subagent → AgentDefinition.tools is None."""
+        claude = ClaudeConfig(
+            agents={
+                "inheritor": SubagentSpec(
+                    description="Inherits all parent tools.",
+                    prompt="Use all parent tools.",
+                    tools=None,
+                ),
+            }
+        )
+        agent = _make_agent(claude=claude)
+        build_options(
+            agent=agent,
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["agents"]["inheritor"].tools is None
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_pure_reasoning_tools_empty_list(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """Pure-reasoning: tools=[] on subagent → AgentDefinition.tools == []."""
+        claude = ClaudeConfig(
+            agents={
+                "thinker": SubagentSpec(
+                    description="Pure reasoning agent.",
+                    prompt="Think step by step without tools.",
+                    tools=[],
+                ),
+            }
+        )
+        agent = _make_agent(claude=claude)
+        build_options(
+            agent=agent,
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["agents"]["thinker"].tools == []
+        assert kwargs["agents"]["thinker"].tools is not None

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -321,6 +321,79 @@ class TestBuildOptions:
 
     @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
     @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_sdk_extras_omitted_when_unset(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """Spec 026 FR-006: 4 SDK extras not passed when unset (preserve defaults)."""
+        build_options(
+            agent=_make_agent(claude=ClaudeConfig()),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert "effort" not in kwargs
+        assert "max_budget_usd" not in kwargs
+        assert "fallback_model" not in kwargs
+        assert "disallowed_tools" not in kwargs
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_sdk_extras_passed_when_set(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """Spec 026 FR-005: 4 SDK extras forwarded to ClaudeAgentOptions when set."""
+        claude = ClaudeConfig(
+            effort="high",
+            max_budget_usd=2.5,
+            fallback_model="haiku",
+            disallowed_tools=["Bash", "Write"],
+        )
+        build_options(
+            agent=_make_agent(claude=claude),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["effort"] == "high"
+        assert kwargs["max_budget_usd"] == 2.5
+        assert kwargs["fallback_model"] == "haiku"
+        assert kwargs["disallowed_tools"] == ["Bash", "Write"]
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_disallowed_tools_empty_list_omitted(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """Spec 026: disallowed_tools=[] is equivalent to omitted (SDK default [])."""
+        claude = ClaudeConfig(disallowed_tools=[])
+        build_options(
+            agent=_make_agent(claude=claude),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+            allow_side_effects=False,
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert "disallowed_tools" not in kwargs
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
     def test_build_options_env_merges_auth_and_otel(
         self,
         mock_resolve: MagicMock,

--- a/tests/unit/lib/backends/test_tool_hooks.py
+++ b/tests/unit/lib/backends/test_tool_hooks.py
@@ -2,6 +2,7 @@
 
 Tests for:
 - _build_tool_hooks() — PreToolUse, PostToolUse, PostToolUseFailure hooks
+- _maybe_emit_subagent_message() — subagent_message events from msg stream
 - ClaudeSession.tool_events — queue property
 - _TaskBoundSession.tool_events — passthrough property
 - AgentExecutor.tool_event_queue — passthrough property
@@ -15,7 +16,42 @@ from unittest.mock import MagicMock
 import pytest
 
 from holodeck.lib.backends.base import ToolEvent
-from holodeck.lib.backends.claude_backend import _build_tool_hooks
+from holodeck.lib.backends.claude_backend import (
+    _build_tool_hooks,
+    _maybe_emit_subagent_message,
+)
+
+# ---------------------------------------------------------------------------
+# Lightweight stand-ins for SDK message types — only the class name and the
+# attributes used by the production code are reproduced here.
+# ---------------------------------------------------------------------------
+
+
+class TextBlock:
+    """Stand-in for ``claude_agent_sdk.TextBlock``."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class AssistantMessage:
+    """Stand-in for ``claude_agent_sdk.AssistantMessage``."""
+
+    def __init__(
+        self,
+        content: list[object],
+        parent_tool_use_id: str | None = None,
+    ) -> None:
+        self.content = content
+        self.parent_tool_use_id = parent_tool_use_id
+
+
+class ResultMessage:
+    """Stand-in for ``claude_agent_sdk.ResultMessage``."""
+
+    def __init__(self, parent_tool_use_id: str | None = None) -> None:
+        self.parent_tool_use_id = parent_tool_use_id
+
 
 # ---------------------------------------------------------------------------
 # _build_tool_hooks
@@ -116,6 +152,55 @@ class TestBuildToolHooks:
         assert event.tool_name == "search"
         assert event.tool_use_id == "tu_456"
         assert event.error == "connection timeout"
+
+
+# ---------------------------------------------------------------------------
+# _maybe_emit_subagent_message
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeEmitSubagentMessage:
+    """Tests for the message-stream tap that surfaces subagent text."""
+
+    def test_pushes_subagent_message_event_when_parent_id_set(self) -> None:
+        queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
+        msg = AssistantMessage(
+            content=[TextBlock("Reading src/foo.py")],
+            parent_tool_use_id="task_42",
+        )
+
+        _maybe_emit_subagent_message(msg, queue)
+
+        evt = queue.get_nowait()
+        assert evt.kind == "subagent_message"
+        assert evt.tool_name == "Task"
+        assert evt.tool_use_id == "task_42"
+        assert evt.parent_tool_use_id == "task_42"
+        assert evt.text == "Reading src/foo.py"
+
+    def test_no_event_when_parent_id_missing(self) -> None:
+        queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
+        msg = AssistantMessage(content=[TextBlock("hi")], parent_tool_use_id=None)
+
+        _maybe_emit_subagent_message(msg, queue)
+
+        assert queue.empty()
+
+    def test_no_event_for_non_assistant_messages(self) -> None:
+        queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
+        msg = ResultMessage(parent_tool_use_id="task_1")
+
+        _maybe_emit_subagent_message(msg, queue)
+
+        assert queue.empty()
+
+    def test_no_event_for_empty_text(self) -> None:
+        queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
+        msg = AssistantMessage(content=[TextBlock("   \n  ")], parent_tool_use_id="t")
+
+        _maybe_emit_subagent_message(msg, queue)
+
+        assert queue.empty()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/models/fixtures/subagent_prompts/analyst.md
+++ b/tests/unit/models/fixtures/subagent_prompts/analyst.md
@@ -1,0 +1,1 @@
+You are a data analyst. Analyze data only — do not write code.

--- a/tests/unit/models/test_claude_config.py
+++ b/tests/unit/models/test_claude_config.py
@@ -6,14 +6,45 @@ import pytest
 from pydantic import ValidationError
 
 from holodeck.models.claude_config import (
+    KNOWN_BUILTIN_TOOLS,
     AuthProvider,
     BashConfig,
     ClaudeConfig,
     ExtendedThinkingConfig,
     FileSystemConfig,
     PermissionMode,
-    SubagentConfig,
+    SubagentSpec,
 )
+
+# ---------------------------------------------------------------------------
+# Foundational tests — T002 and T003 (written first, must FAIL before T008/T007)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFoundationalSubagentMigration:
+    """Foundational tests for SubagentSpec / ClaudeConfig.agents scaffolding."""
+
+    def test_legacy_subagents_block_rejected(self) -> None:
+        """T002: Loading claude.subagents produces a targeted migration error.
+
+        Traces to SC-005, FR-011.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            ClaudeConfig(**{"subagents": {"enabled": True}})
+        error_text = str(exc_info.value)
+        assert "claude.subagents" in error_text
+        assert "no longer supported" in error_text
+        assert "claude.agents" in error_text
+        assert "execution.parallel_test_cases" in error_text
+
+    def test_claude_config_agents_empty_map_normalized_to_none(self) -> None:
+        """T003: ClaudeConfig(agents={}).agents is None after normalization.
+
+        Traces to FR-010, edge case "empty agents map", research.md §5.
+        """
+        config = ClaudeConfig(agents={})
+        assert config.agents is None
 
 
 class TestAuthProvider:
@@ -155,46 +186,6 @@ class TestFileSystemConfig:
             FileSystemConfig(execute=True)
 
 
-class TestSubagentConfig:
-    """Tests for SubagentConfig model."""
-
-    def test_defaults(self) -> None:
-        """Test default values."""
-        config = SubagentConfig()
-        assert config.enabled is False
-        assert config.max_parallel == 4
-
-    def test_custom_max_parallel(self) -> None:
-        """Test with custom max_parallel."""
-        config = SubagentConfig(enabled=True, max_parallel=8)
-        assert config.max_parallel == 8
-
-    @pytest.mark.parametrize(
-        "max_parallel",
-        [0, 17],
-        ids=["below_min", "above_max"],
-    )
-    def test_max_parallel_out_of_range(self, max_parallel: int) -> None:
-        """Test that max_parallel outside 1-16 is rejected."""
-        with pytest.raises(ValidationError):
-            SubagentConfig(max_parallel=max_parallel)
-
-    @pytest.mark.parametrize(
-        "max_parallel",
-        [1, 16],
-        ids=["at_min", "at_max"],
-    )
-    def test_max_parallel_at_boundaries(self, max_parallel: int) -> None:
-        """Test that max_parallel at boundaries is accepted."""
-        config = SubagentConfig(max_parallel=max_parallel)
-        assert config.max_parallel == max_parallel
-
-    def test_extra_fields_rejected(self) -> None:
-        """Test that extra fields are rejected."""
-        with pytest.raises(ValidationError):
-            SubagentConfig(unknown="value")
-
-
 class TestClaudeConfig:
     """Tests for ClaudeConfig model."""
 
@@ -208,7 +199,7 @@ class TestClaudeConfig:
         assert config.web_search is False
         assert config.bash is None
         assert config.file_system is None
-        assert config.subagents is None
+        assert config.agents is None
         assert config.allowed_tools is None
         assert config.effort is None
         assert config.max_budget_usd is None
@@ -245,15 +236,6 @@ class TestClaudeConfig:
         assert config.file_system.write is True
         assert config.file_system.edit is True
 
-    def test_with_subagents(self) -> None:
-        """Test ClaudeConfig with subagents configured."""
-        config = ClaudeConfig(
-            subagents=SubagentConfig(enabled=True, max_parallel=8),
-        )
-        assert config.subagents is not None
-        assert config.subagents.enabled is True
-        assert config.subagents.max_parallel == 8
-
     def test_with_all_fields(self) -> None:
         """Test ClaudeConfig with all fields populated."""
         config = ClaudeConfig(
@@ -266,7 +248,6 @@ class TestClaudeConfig:
             web_search=True,
             bash=BashConfig(enabled=True, excluded_commands=["sudo"]),
             file_system=FileSystemConfig(read=True, write=True, edit=True),
-            subagents=SubagentConfig(enabled=True, max_parallel=16),
             allowed_tools=["bash", "file_read", "web_search"],
         )
         assert config.working_directory == "/home/user/workspace"
@@ -276,7 +257,6 @@ class TestClaudeConfig:
         assert config.web_search is True
         assert config.bash.enabled is True
         assert config.file_system.read is True
-        assert config.subagents.max_parallel == 16
         assert len(config.allowed_tools) == 3
 
     def test_max_turns_must_be_positive(self) -> None:
@@ -412,4 +392,173 @@ class TestClaudeConfig:
             ClaudeConfig(
                 effort="high",
                 extended_thinking=ExtendedThinkingConfig(enabled=False),
+            )
+
+
+# ---------------------------------------------------------------------------
+# US1 tests — T012 and T013 (SubagentSpec model round-trip + literal validation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSubagentSpec:
+    """US1 tests for SubagentSpec model fields and validation."""
+
+    def test_subagent_spec_round_trip_minimal(self) -> None:
+        """T012 (US1): SubagentSpec round-trips description and prompt correctly.
+
+        Traces to FR-001, FR-002, US1 acceptance scenario 1.
+        """
+        spec = SubagentSpec(description="x", prompt="y")
+        assert spec.description == "x"
+        assert spec.prompt == "y"
+        assert spec.tools is None
+        assert spec.model is None
+
+    @pytest.mark.parametrize(
+        "model_value",
+        ["sonnet", "opus", "haiku", "inherit", "claude-3-5-sonnet-20241022"],
+        ids=["sonnet", "opus", "haiku", "inherit", "full_model_id"],
+    )
+    def test_subagent_spec_model_passes_through(self, model_value: str) -> None:
+        """T013 (US1): SubagentSpec accepts any string for model and passes it through.
+
+        The SDK is the source of truth for valid model values; HoloDeck does not
+        gate on a fixed literal set so the surface stays compatible as the SDK
+        adds new model aliases. Traces to FR-008, US1 acceptance scenario 2.
+        """
+        spec = SubagentSpec(
+            description="agent", prompt="Do something.", model=model_value
+        )
+        assert spec.model == model_value
+
+    def test_subagent_spec_description_empty_rejected(self) -> None:
+        """description must be non-empty after strip (data-model.md rule 4)."""
+        with pytest.raises(ValidationError):
+            SubagentSpec(description="   ", prompt="Some prompt.")
+
+    def test_subagent_spec_extra_fields_rejected(self) -> None:
+        """SubagentSpec rejects unknown extra fields (extra='forbid')."""
+        with pytest.raises(ValidationError):
+            SubagentSpec(description="agent", prompt="Hello.", unknown_field="oops")
+
+    def test_subagent_spec_tools_list_accepted(self) -> None:
+        """SubagentSpec accepts a tools allowlist."""
+        spec = SubagentSpec(
+            description="researcher",
+            prompt="Search the web.",
+            tools=["WebSearch", "WebFetch"],
+        )
+        assert spec.tools == ["WebSearch", "WebFetch"]
+
+    def test_subagent_spec_tools_none_means_inherit(self) -> None:
+        """Omitting tools defaults to None (subagent inherits all parent tools).
+
+        Traces to FR-007.
+        """
+        spec = SubagentSpec(description="writer", prompt="Write the report.")
+        assert spec.tools is None
+
+
+# ---------------------------------------------------------------------------
+# KNOWN_BUILTIN_TOOLS constant (foundational — needed by US2 tool-name warnings)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestKnownBuiltinTools:
+    """KNOWN_BUILTIN_TOOLS module constant (data-model.md rule #5)."""
+
+    def test_known_builtin_tools_is_frozenset(self) -> None:
+        """KNOWN_BUILTIN_TOOLS must be a frozenset."""
+        assert isinstance(KNOWN_BUILTIN_TOOLS, frozenset)
+
+    def test_known_builtin_tools_exact_members(self) -> None:
+        """KNOWN_BUILTIN_TOOLS must match the canonical set from data-model.md."""
+        expected = frozenset(
+            {
+                "Read",
+                "Write",
+                "Edit",
+                "Bash",
+                "Glob",
+                "Grep",
+                "WebSearch",
+                "WebFetch",
+                "Task",
+                "TodoWrite",
+                "NotebookEdit",
+            }
+        )
+        assert expected == KNOWN_BUILTIN_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# T008 — SubagentSpec tool-name typo warning (US2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSubagentSpecToolWarning:
+    """T008: SubagentSpec emits UserWarning for unknown tool names.
+
+    Traces to data-model.md rule #5, research.md §3.
+    """
+
+    def test_no_warning_for_known_builtins(self) -> None:
+        """No warning when tools are valid built-in names (e.g. Read, WebSearch)."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            SubagentSpec(
+                description="analyst",
+                prompt="You are an analyst.",
+                tools=["Read", "WebSearch"],
+            )
+
+    def test_no_warning_for_mcp_prefix(self) -> None:
+        """No warning when all tools have the mcp__ prefix."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            SubagentSpec(
+                description="db analyst",
+                prompt="Query the database.",
+                tools=["mcp__db__query", "mcp__db__describe"],
+            )
+
+    def test_warning_for_unknown_bare_name(self) -> None:
+        """UserWarning is emitted for an unknown bare name (e.g. WebSerach — typo)."""
+        with pytest.warns(UserWarning) as rec:
+            SubagentSpec(
+                description="researcher",
+                prompt="Research the topic.",
+                tools=["WebSerach"],
+            )
+        messages = [str(w.message) for w in rec.list]
+        assert any("WebSerach" in m for m in messages)
+        # Warning must reference all three accepted patterns
+        combined = " ".join(messages)
+        assert "mcp__" in combined or "MCP" in combined or "mcp" in combined
+        assert any(
+            builtin in combined
+            for builtin in ("WebSearch", "Read", "Write", "Bash", "Glob")
+        )
+
+    def test_no_warning_when_tools_is_none(self) -> None:
+        """No warning when tools is None (FR-007 inheritance path)."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            SubagentSpec(
+                description="inheriting subagent",
+                prompt="Inherit all parent tools.",
+                tools=None,
+            )
+
+    def test_no_warning_when_tools_is_empty_list(self) -> None:
+        """No warning when tools is [] (pure-reasoning subagent per quickstart §7)."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            SubagentSpec(
+                description="pure reasoner",
+                prompt="Think carefully without tools.",
+                tools=[],
             )

--- a/tests/unit/models/test_claude_config.py
+++ b/tests/unit/models/test_claude_config.py
@@ -428,20 +428,32 @@ class TestSubagentSpec:
 
     @pytest.mark.parametrize(
         "model_value",
-        ["sonnet", "opus", "haiku", "inherit", "claude-3-5-sonnet-20241022"],
-        ids=["sonnet", "opus", "haiku", "inherit", "full_model_id"],
+        ["sonnet", "opus", "haiku", "inherit"],
     )
-    def test_subagent_spec_model_passes_through(self, model_value: str) -> None:
-        """T013 (US1): SubagentSpec accepts any string for model and passes it through.
+    def test_subagent_spec_model_accepts_sdk_literals(self, model_value: str) -> None:
+        """T013 (US1): SubagentSpec accepts the SDK's literal model aliases.
 
-        The SDK is the source of truth for valid model values; HoloDeck does not
-        gate on a fixed literal set so the surface stays compatible as the SDK
-        adds new model aliases. Traces to FR-008, US1 acceptance scenario 2.
+        Traces to FR-008, US1 acceptance scenario 2, data-model.md rule 3.
         """
         spec = SubagentSpec(
             description="agent", prompt="Do something.", model=model_value
         )
         assert spec.model == model_value
+
+    def test_subagent_spec_full_model_id_rejected(self) -> None:
+        """Full model IDs must fail at load time.
+
+        The Claude CLI silently drops AgentDefinitions whose ``model`` is not
+        in the SDK's literal set, so allowing them through would mean the
+        subagent never registers and the parent quietly falls back to the
+        general-purpose agent.
+        """
+        with pytest.raises(ValidationError):
+            SubagentSpec(
+                description="agent",
+                prompt="Do something.",
+                model="claude-haiku-4-5",
+            )
 
     def test_subagent_spec_description_empty_rejected(self) -> None:
         """description must be non-empty after strip (data-model.md rule 4)."""

--- a/tests/unit/models/test_claude_config.py
+++ b/tests/unit/models/test_claude_config.py
@@ -1,5 +1,7 @@
 """Tests for Claude-specific configuration models in holodeck.models.claude_config."""
 
+import warnings
+
 import pytest
 from pydantic import ValidationError
 
@@ -208,6 +210,10 @@ class TestClaudeConfig:
         assert config.file_system is None
         assert config.subagents is None
         assert config.allowed_tools is None
+        assert config.effort is None
+        assert config.max_budget_usd is None
+        assert config.fallback_model is None
+        assert config.disallowed_tools is None
 
     def test_with_extended_thinking(self) -> None:
         """Test ClaudeConfig with extended thinking configured."""
@@ -326,3 +332,84 @@ class TestClaudeConfig:
         """Test that extra fields are rejected."""
         with pytest.raises(ValidationError):
             ClaudeConfig(unknown_setting="value")
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "value", ["low", "medium", "high", "max"], ids=["low", "medium", "high", "max"]
+    )
+    def test_effort_valid_values(self, value: str) -> None:
+        """Test effort accepts the four SDK literal values."""
+        config = ClaudeConfig(effort=value)
+        assert config.effort == value
+
+    @pytest.mark.unit
+    def test_effort_invalid_value_rejected(self) -> None:
+        """Test effort rejects values outside the SDK literal set."""
+        with pytest.raises(ValidationError):
+            ClaudeConfig(effort="extreme")
+
+    @pytest.mark.unit
+    def test_max_budget_usd_positive_accepted(self) -> None:
+        """Test max_budget_usd accepts positive floats."""
+        config = ClaudeConfig(max_budget_usd=5.0)
+        assert config.max_budget_usd == 5.0
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "value", [0, -1.0, -0.01], ids=["zero", "negative_one", "negative_small"]
+    )
+    def test_max_budget_usd_non_positive_rejected(self, value: float) -> None:
+        """Test max_budget_usd rejects 0 and negative values."""
+        with pytest.raises(ValidationError):
+            ClaudeConfig(max_budget_usd=value)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "value",
+        ["haiku", "sonnet", "claude-haiku-4-5"],
+        ids=["literal_haiku", "literal_sonnet", "full_model_id"],
+    )
+    def test_fallback_model_accepts_any_string(self, value: str) -> None:
+        """Test fallback_model has no SDK-side literal restriction."""
+        config = ClaudeConfig(fallback_model=value)
+        assert config.fallback_model == value
+
+    @pytest.mark.unit
+    def test_disallowed_tools_list_accepted(self) -> None:
+        """Test disallowed_tools accepts a list of tool names."""
+        config = ClaudeConfig(disallowed_tools=["Bash", "Write"])
+        assert config.disallowed_tools == ["Bash", "Write"]
+
+    @pytest.mark.unit
+    def test_disallowed_tools_empty_list_accepted(self) -> None:
+        """Test disallowed_tools accepts [] (equivalent to omitted at SDK layer)."""
+        config = ClaudeConfig(disallowed_tools=[])
+        assert config.disallowed_tools == []
+
+    @pytest.mark.unit
+    def test_effort_with_extended_thinking_warns(self) -> None:
+        """FR-009: Setting both effort and extended_thinking emits a warning."""
+        with pytest.warns(UserWarning, match=r"effort.*extended_thinking"):
+            ClaudeConfig(
+                effort="high",
+                extended_thinking=ExtendedThinkingConfig(
+                    enabled=True, budget_tokens=20_000
+                ),
+            )
+
+    @pytest.mark.unit
+    def test_effort_alone_does_not_warn(self) -> None:
+        """effort without extended_thinking should not warn."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # Any warning becomes an error
+            ClaudeConfig(effort="high")
+
+    @pytest.mark.unit
+    def test_extended_thinking_disabled_does_not_warn(self) -> None:
+        """extended_thinking with enabled=False should not warn even with effort."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            ClaudeConfig(
+                effort="high",
+                extended_thinking=ExtendedThinkingConfig(enabled=False),
+            )

--- a/tests/unit/models/test_claude_config.py
+++ b/tests/unit/models/test_claude_config.py
@@ -1,10 +1,12 @@
 """Tests for Claude-specific configuration models in holodeck.models.claude_config."""
 
 import warnings
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
+from holodeck.config.context import agent_base_dir
 from holodeck.models.claude_config import (
     KNOWN_BUILTIN_TOOLS,
     AuthProvider,
@@ -24,6 +26,15 @@ from holodeck.models.claude_config import (
 @pytest.mark.unit
 class TestFoundationalSubagentMigration:
     """Foundational tests for SubagentSpec / ClaudeConfig.agents scaffolding."""
+
+    @pytest.mark.parametrize("value", ["", "   "], ids=["empty", "whitespace"])
+    def test_subagent_description_required_non_empty(self, value: str) -> None:
+        """T003a: description must be non-empty after strip with the spec'd message.
+
+        Traces to FR-004, SC-004, quickstart.md §5.
+        """
+        with pytest.raises(ValidationError, match="subagent requires description"):
+            SubagentSpec(description=value, prompt="x")
 
     def test_legacy_subagents_block_rejected(self) -> None:
         """T002: Loading claude.subagents produces a targeted migration error.
@@ -562,3 +573,94 @@ class TestSubagentSpecToolWarning:
                 prompt="Think carefully without tools.",
                 tools=[],
             )
+
+
+# ---------------------------------------------------------------------------
+# US3 tests — T010-T016 (prompt sourcing & validation)
+# ---------------------------------------------------------------------------
+
+
+_FIXTURE_PROMPTS_DIR = Path(__file__).parent / "fixtures" / "subagent_prompts"
+
+
+@pytest.mark.unit
+class TestSubagentPromptSourcing:
+    """US3: prompt / prompt_file sourcing and validation rules."""
+
+    def test_subagent_inline_prompt_loads(self) -> None:
+        """T010: Inline prompt round-trips and prompt_file stays None."""
+        spec = SubagentSpec(description="x", prompt="You are a financial analyst.")
+        assert spec.prompt == "You are a financial analyst."
+        assert spec.prompt_file is None
+
+    def test_subagent_inline_prompt_empty_after_strip_rejected(self) -> None:
+        """T011: Whitespace-only inline prompt is rejected."""
+        with pytest.raises(ValidationError):
+            SubagentSpec(description="x", prompt="   ")
+
+    def test_subagent_prompt_file_inlined(self) -> None:
+        """T012: prompt_file contents inline into prompt; prompt_file becomes None."""
+        token = agent_base_dir.set(str(_FIXTURE_PROMPTS_DIR))
+        try:
+            spec = SubagentSpec(description="x", prompt_file="./analyst.md")
+        finally:
+            agent_base_dir.reset(token)
+        expected = (_FIXTURE_PROMPTS_DIR / "analyst.md").read_text(encoding="utf-8")
+        assert spec.prompt == expected
+        assert spec.prompt_file is None
+
+    def test_subagent_prompt_file_resolves_relative_to_agent_base_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """T013: relative paths resolve under agent_base_dir; absolute paths pass."""
+        nested = tmp_path / "subdir"
+        nested.mkdir()
+        prompt_file = nested / "analyst.md"
+        prompt_file.write_text("nested prompt body", encoding="utf-8")
+
+        # Relative path under base_dir
+        token = agent_base_dir.set(str(tmp_path))
+        try:
+            spec_rel = SubagentSpec(description="x", prompt_file="subdir/analyst.md")
+        finally:
+            agent_base_dir.reset(token)
+        assert spec_rel.prompt == "nested prompt body"
+        assert spec_rel.prompt_file is None
+
+        # Absolute path is honoured even if base_dir is unrelated
+        unrelated_base = tmp_path / "unrelated"
+        unrelated_base.mkdir()
+        token = agent_base_dir.set(str(unrelated_base))
+        try:
+            spec_abs = SubagentSpec(description="x", prompt_file=str(prompt_file))
+        finally:
+            agent_base_dir.reset(token)
+        assert spec_abs.prompt == "nested prompt body"
+        assert spec_abs.prompt_file is None
+
+    def test_subagent_prompt_file_not_found_rejected(self, tmp_path: Path) -> None:
+        """T014: Missing prompt_file produces a ValidationError naming the path."""
+        token = agent_base_dir.set(str(tmp_path))
+        try:
+            with pytest.raises(ValidationError) as exc_info:
+                SubagentSpec(description="x", prompt_file="./does-not-exist.md")
+        finally:
+            agent_base_dir.reset(token)
+        message = str(exc_info.value)
+        assert "prompt_file not found" in message
+        assert "does-not-exist.md" in message
+
+    def test_subagent_prompt_and_prompt_file_mutually_exclusive(self) -> None:
+        """T015: Setting both prompt and prompt_file raises the documented error."""
+        with pytest.raises(
+            ValidationError, match="prompt and prompt_file are mutually exclusive"
+        ):
+            SubagentSpec(description="x", prompt="hi", prompt_file="./analyst.md")
+
+    def test_subagent_neither_prompt_nor_prompt_file_rejected(self) -> None:
+        """T016: Omitting both prompt and prompt_file raises the documented error."""
+        with pytest.raises(
+            ValidationError,
+            match="subagent requires either prompt or prompt_file",
+        ):
+            SubagentSpec(description="x")

--- a/tests/unit/models/test_eval_run_snapshot.py
+++ b/tests/unit/models/test_eval_run_snapshot.py
@@ -25,7 +25,6 @@ from holodeck.models.claude_config import (
     ExtendedThinkingConfig,
     FileSystemConfig,
     PermissionMode,
-    SubagentConfig,
 )
 from holodeck.models.eval_run import EvalRun, EvalRunMetadata, PromptVersion
 from holodeck.models.evaluation import (
@@ -402,7 +401,6 @@ class TestClaudeBlockRoundTrip:
                 allow_unsafe=False,
             ),
             file_system=FileSystemConfig(read=True, write=True, edit=False),
-            subagents=SubagentConfig(enabled=True, max_parallel=4),
             allowed_tools=["Read", "Write", "Bash"],
         )
         agent = Agent(
@@ -429,9 +427,6 @@ class TestClaudeBlockRoundTrip:
         assert snap.claude.file_system.read is True
         assert snap.claude.file_system.write is True
         assert snap.claude.file_system.edit is False
-        assert snap.claude.subagents is not None
-        assert snap.claude.subagents.enabled is True
-        assert snap.claude.subagents.max_parallel == 4
         assert snap.claude.allowed_tools == ["Read", "Write", "Bash"]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4980,11 +4980,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This branch lands three groups of changes that grew out of feature 029 (Claude subagent orchestration):

- **Subagent orchestration (US1–US3)** — `claude.agents` map in agent.yaml is wired through to `ClaudeAgentOptions.agents` as `AgentDefinition` instances. Inline `prompt` and file-backed `prompt_file` are both supported, with mutual-exclusion validation and at-config-load file inlining. `SubagentSpec.model` is restricted to the SDK's literal aliases (`sonnet | opus | haiku | inherit`) — full model IDs were silently dropped by the Claude CLI, causing parents to fall back to general-purpose.
- **Live chat tools panel** — `holodeck chat` now renders an in-flight panel above the response showing each active tool, its args, and any subagent status text. Subagent-spawned tools nest indented under their parent `Task[<type>]` entry. The panel is composited via a new `LiveComposer` that uses DECSC/DECRC cursor save/restore so it stays pinned during streaming. Includes the `claude/add-chat-tool-hooks-LwSP0` merge for PreToolUse/PostToolUse hook plumbing.
- **Docs replatform** — `docs/guides/llm-providers.md` is now a slim router page (~150 lines, down from ~1,088). Provider-specific content moved to two new pages: `docs/guides/claude-backend.md` and `docs/guides/semantic-kernel-backend.md`. The Claude Agent SDK Settings section in `agent-configuration.md` collapsed to a 3-line pointer. `mkdocs build --strict` is green.

## Test plan

- [ ] `pytest tests/unit -n auto` — 1,400+ unit tests pass locally.
- [ ] `pytest tests/unit/models/test_claude_config.py -n auto` — covers `SubagentSpec` validation (including the new strict-literal model check and full-model-ID rejection).
- [ ] `pytest tests/unit/chat/ tests/unit/cli/commands/test_chat.py -n auto` — covers `LiveComposer`, `ToolsPanel` (including parent-link nesting and pre/post-start race), and the chat paint loop.
- [ ] `pytest tests/unit/lib/backends/test_claude_backend.py tests/unit/lib/backends/test_tool_hooks.py -n auto` — covers `build_options` agents wiring, `_maybe_emit_subagent_message` parent-link emission, and PreToolUse/PostToolUse hook events.
- [ ] `mkdocs build --strict` — succeeds without warnings on the new docs.
- [ ] Manual smoke: run `holodeck chat sample/research/claude/research-team.yaml` with valid Anthropic credentials, dispatch a multi-subagent task, confirm the panel shows the parent `Task[researcher]` entry with nested `WebSearch`/`WebFetch` tool calls indented underneath.
- [ ] Manual smoke: ensure a subagent declared with a full model ID (e.g. `model: claude-haiku-4-5`) now fails with a clear `ValidationError` at config-load time instead of silently falling back to general-purpose at runtime.

## Out of scope

- `holodeck serve` and container deployment still do not support `provider: anthropic`. Tracked separately.
- `sample/research/claude/research-team.yaml` lives in the gitignored `sample/` tree and is not part of this PR; the canonical schema rules are documented in `docs/guides/claude-backend.md`.