### PR TITLE
feat(deploy): bundle tool sources & skip env substitution at build

### DIFF
--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -1960,6 +1960,16 @@
           "type": "object",
           "additionalProperties": { "type": "string" },
           "description": "Environment variables for the container"
+        },
+        "health_check_path": {
+          "type": "string",
+          "default": "/health",
+          "description": "HTTP path for health checks (e.g., /health, /healthz)"
+        },
+        "platform": {
+          "type": "string",
+          "default": "linux/amd64",
+          "description": "Target platform for container image (e.g., linux/amd64, linux/arm64)"
         }
       },
       "description": "Main deployment configuration for containerizing and deploying agents"

--- a/src/holodeck/cli/commands/deploy.py
+++ b/src/holodeck/cli/commands/deploy.py
@@ -163,9 +163,12 @@ def build(
         if not quiet:
             click.echo(f"Loading agent configuration from {agent_config}...")
 
-        # Load and validate agent using standard ConfigLoader
+        # Load and validate agent using standard ConfigLoader. The build is
+        # structural (it just needs the YAML shape — tools, deployment block,
+        # file paths); secrets aren't required, so skip env-var substitution
+        # to avoid forcing the operator to export every runtime var.
         loader = ConfigLoader()
-        agent = loader.load_agent_yaml(agent_config)
+        agent = loader.load_agent_yaml(agent_config, substitute_env=False)
         agent_name = agent.name
 
         # Get deployment configuration from agent (merged by ConfigLoader)
@@ -212,7 +215,10 @@ def build(
 
             # Show generated Dockerfile
             dockerfile_content = _generate_dockerfile_content(
-                agent, deployment_config, image_tag
+                agent,
+                deployment_config,
+                image_tag,
+                test_cases_file=_read_raw_test_cases_file(agent_path),
             )
             click.echo()
             click.secho("Generated Dockerfile:", bold=True)
@@ -531,10 +537,28 @@ def destroy(agent_config: str, force: bool, verbose: bool, quiet: bool) -> None:
         click.echo()
 
 
+def _read_raw_test_cases_file(agent_yaml_path: Path) -> str | None:
+    """Read the (unresolved) `test_cases_file` key from raw agent.yaml.
+
+    The loader inlines and discards this key, so it isn't visible on the
+    Agent model — we need the raw YAML to know which file to bundle.
+    """
+    import yaml
+
+    try:
+        with open(agent_yaml_path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+    ref = raw.get("test_cases_file")
+    return ref if isinstance(ref, str) and ref else None
+
+
 def _generate_dockerfile_content(
     agent: Agent,
     deployment_config: DeploymentConfig,
     version: str,
+    test_cases_file: str | None = None,
 ) -> str:
     """Generate Dockerfile content for the agent.
 
@@ -547,29 +571,47 @@ def _generate_dockerfile_content(
         Generated Dockerfile content
     """
     from holodeck.deploy.dockerfile import generate_dockerfile
-    from holodeck.models.tool import HierarchicalDocumentToolConfig, VectorstoreTool
+    from holodeck.models.tool import (
+        FunctionTool,
+        HierarchicalDocumentToolConfig,
+        VectorstoreTool,
+    )
 
-    # Collect instruction files
+    # Collect leaf files needing an identical `COPY src /app/src` directive:
+    # instructions, function tool Python files, single-file tool sources, and
+    # the test_cases_file (eagerly resolved by the loader at serve time).
     instruction_files: list[str] = []
     if agent.instructions.file:
         instruction_files.append(agent.instructions.file)
+    for tool in agent.tools or []:
+        if isinstance(tool, FunctionTool):
+            instruction_files.append(tool.file)
 
-    # Collect data directories (from vectorstore tools, etc.)
+    # Collect data directories (from vectorstore + hierarchical_document tools).
+    # Skip remote sources (az://, s3://) — those are fetched at runtime.
     data_directories: list[str] = []
+    data_files: list[str] = []
     if agent.tools:
         for tool in agent.tools:
-            if isinstance(tool, VectorstoreTool):
+            if isinstance(tool, VectorstoreTool | HierarchicalDocumentToolConfig):
                 source_path = tool.source
-                if source_path:
-                    # Get parent directory if it's a file
-                    path = Path(source_path)
-                    if path.suffix:
-                        # It's a file, add parent directory
-                        parent = str(path.parent)
-                        if parent and parent != ".":
-                            data_directories.append(parent + "/")
-                    else:
-                        data_directories.append(str(path) + "/")
+                if not source_path or "://" in source_path:
+                    continue
+                path = Path(source_path)
+                if path.suffix:
+                    # Single file source — copy the file directly.
+                    data_files.append(source_path)
+                else:
+                    data_directories.append(str(path) + "/")
+
+    # test_cases_file is resolved eagerly by the loader at serve time, so it
+    # has to be present in the image even though serve never uses it.
+    if test_cases_file and "://" not in test_cases_file:
+        data_files.append(test_cases_file)
+
+    # Treat data_files as instruction_files (same `COPY src /app/src` shape).
+    instruction_files.extend(data_files)
+    instruction_files = sorted(set(instruction_files))
 
     # Remove duplicates
     data_directories = list(set(data_directories))
@@ -579,12 +621,17 @@ def _generate_dockerfile_content(
 
     needs_nodejs = agent.model.provider == ProviderEnum.ANTHROPIC
 
-    # Detect required extras from agent config
+    # Detect required extras from agent config. Vector-store provider names
+    # match the optional-dependency group names in pyproject.toml 1:1.
+    vectorstore_extras = {"chromadb", "qdrant", "pinecone", "postgres"}
     extras: list[str] = []
     for tool in agent.tools or []:
         if isinstance(tool, VectorstoreTool | HierarchicalDocumentToolConfig):
-            if tool.database and getattr(tool.database, "provider", None) == "chromadb":
-                extras.append("chromadb")
+            provider = (
+                getattr(tool.database, "provider", None) if tool.database else None
+            )
+            if provider in vectorstore_extras:
+                extras.append(provider)
             if tool.source:
                 if tool.source.startswith("az://"):
                     extras.append("azure-blob")
@@ -624,41 +671,61 @@ def _prepare_build_context(
     Returns:
         Path to temporary build context directory
     """
-    from holodeck.models.tool import VectorstoreTool
+    from holodeck.models.tool import (
+        FunctionTool,
+        HierarchicalDocumentToolConfig,
+        VectorstoreTool,
+    )
 
     # Create temporary build directory
     build_dir = Path(tempfile.mkdtemp(prefix="holodeck-build-"))
 
     # Generate and write Dockerfile
-    dockerfile_content = _generate_dockerfile_content(agent, deployment_config, version)
+    test_cases_file = _read_raw_test_cases_file(agent_dir / "agent.yaml")
+    dockerfile_content = _generate_dockerfile_content(
+        agent, deployment_config, version, test_cases_file=test_cases_file
+    )
     (build_dir / "Dockerfile").write_text(dockerfile_content)
 
     # Copy agent.yaml
     shutil.copy2(agent_dir / "agent.yaml", build_dir / "agent.yaml")
 
-    # Copy instruction files
+    # Collect leaf files: instructions, function tool sources, single-file
+    # tool sources (hierarchical_document / vectorstore), and test_cases_file.
+    files_to_copy: list[str] = []
     if agent.instructions.file:
-        instruction_file = agent.instructions.file
-        src_path = agent_dir / instruction_file
+        files_to_copy.append(agent.instructions.file)
+    for tool in agent.tools or []:
+        if isinstance(tool, FunctionTool):
+            files_to_copy.append(tool.file)
+        elif isinstance(tool, VectorstoreTool | HierarchicalDocumentToolConfig):
+            source_path = tool.source
+            if source_path and "://" not in source_path and Path(source_path).suffix:
+                files_to_copy.append(source_path)
+    if test_cases_file and "://" not in test_cases_file:
+        files_to_copy.append(test_cases_file)
+
+    for rel_path in sorted(set(files_to_copy)):
+        src_path = agent_dir / rel_path
         if src_path.exists():
-            dst_path = build_dir / instruction_file
+            dst_path = build_dir / rel_path
             dst_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src_path, dst_path)
 
-    # Copy data directories
+    # Copy data directories (directory-typed tool sources)
     if agent.tools:
         for tool in agent.tools:
-            if isinstance(tool, VectorstoreTool):
+            if isinstance(tool, VectorstoreTool | HierarchicalDocumentToolConfig):
                 source_path = tool.source
-                if source_path:
+                if (
+                    source_path
+                    and "://" not in source_path
+                    and not Path(source_path).suffix
+                ):
                     src = agent_dir / source_path
-                    if src.exists():
+                    if src.exists() and src.is_dir():
                         dst = build_dir / source_path
-                        if src.is_dir():
-                            shutil.copytree(src, dst, dirs_exist_ok=True)
-                        else:
-                            dst.parent.mkdir(parents=True, exist_ok=True)
-                            shutil.copy2(src, dst)
+                        shutil.copytree(src, dst, dirs_exist_ok=True)
 
     # Create entrypoint script
     entrypoint_content = """#!/bin/bash

--- a/src/holodeck/config/loader.py
+++ b/src/holodeck/config/loader.py
@@ -108,7 +108,11 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> None:
             base[key] = override_value
 
 
-def _resolve_test_cases_file(agent_config: dict[str, Any], base_dir: Path) -> None:
+def _resolve_test_cases_file(
+    agent_config: dict[str, Any],
+    base_dir: Path,
+    substitute_env: bool = True,
+) -> None:
     """Resolve an external `test_cases_file` reference into inline `test_cases`.
 
     Loads the referenced YAML (relative to the agent.yaml directory), applies
@@ -142,7 +146,9 @@ def _resolve_test_cases_file(agent_config: dict[str, Any], base_dir: Path) -> No
     if not ref_path.is_absolute():
         ref_path = (base_dir / ref_path).resolve()
     try:
-        payload = _read_yaml_with_env_substitution(ref_path)
+        payload = _read_yaml_with_env_substitution(
+            ref_path, substitute_env=substitute_env
+        )
     except OSError as e:
         raise ConfigError(
             "test_cases_file",
@@ -170,14 +176,21 @@ def _resolve_test_cases_file(agent_config: dict[str, Any], base_dir: Path) -> No
     agent_config["test_cases"] = cases
 
 
-def _read_yaml_with_env_substitution(path: Path) -> dict[str, Any] | None:
-    """Read a YAML file with environment variable substitution.
+def _read_yaml_with_env_substitution(
+    path: Path, substitute_env: bool = True
+) -> dict[str, Any] | None:
+    """Read a YAML file, optionally substituting environment variables.
 
-    Reads raw text, substitutes env vars, then parses YAML once.
-    Avoids the lossy dict→YAML→regex→dict roundtrip.
+    Reads raw text, substitutes env vars (when enabled), then parses YAML
+    once. Avoids the lossy dict→YAML→regex→dict roundtrip.
 
     Args:
         path: Path to YAML file
+        substitute_env: When True (default), `${VAR}` references are resolved
+            against the process environment and missing vars raise
+            ``ConfigError``. When False, the raw `${VAR}` literal is kept —
+            useful for structural-only consumers (e.g. ``holodeck deploy
+            build``) that don't need runtime values.
 
     Returns:
         Parsed dictionary or None if empty
@@ -185,11 +198,13 @@ def _read_yaml_with_env_substitution(path: Path) -> dict[str, Any] | None:
     Raises:
         OSError: If file cannot be read
         yaml.YAMLError: If YAML parsing fails
-        ConfigError: If env var substitution fails
+        ConfigError: If env var substitution fails (only when
+            ``substitute_env`` is True)
     """
     raw_text = path.read_text(encoding="utf-8")
-    substituted = substitute_env_vars(raw_text)
-    content = yaml.safe_load(substituted)
+    if substitute_env:
+        raw_text = substitute_env_vars(raw_text)
+    content = yaml.safe_load(raw_text)
     return content if content else None
 
 
@@ -298,7 +313,7 @@ class ConfigLoader:
                 f"Failed to parse YAML file {file_path}: {str(e)}",
             ) from e
 
-    def load_agent_yaml(self, file_path: str) -> Agent:
+    def load_agent_yaml(self, file_path: str, substitute_env: bool = True) -> Agent:
         """Load and validate an agent configuration from YAML.
 
         This method:
@@ -316,6 +331,11 @@ class ConfigLoader:
 
         Args:
             file_path: Path to agent.yaml file
+            substitute_env: When True (default), ``${VAR}`` references in both
+                the agent YAML and any referenced ``test_cases_file`` are
+                resolved against the process environment. When False, the raw
+                ``${VAR}`` literal is preserved — used by structural consumers
+                like ``holodeck deploy build`` that don't need runtime secrets.
 
         Returns:
             Validated Agent instance
@@ -327,7 +347,9 @@ class ConfigLoader:
         """
         path = Path(file_path)
         try:
-            agent_config = _read_yaml_with_env_substitution(path)
+            agent_config = _read_yaml_with_env_substitution(
+                path, substitute_env=substitute_env
+            )
         except OSError as e:
             raise FileNotFoundError(
                 file_path,
@@ -355,7 +377,9 @@ class ConfigLoader:
         # Resolve external test_cases_file reference (if any) into inline
         # `test_cases` before schema validation. Agent model uses
         # `extra="forbid"`, so the key must be removed from the dict.
-        _resolve_test_cases_file(merged_config, path.parent)
+        _resolve_test_cases_file(
+            merged_config, path.parent, substitute_env=substitute_env
+        )
 
         # Expose the agent directory on ``sys.path`` so ``CodeMetric``'s
         # grader resolver (``importlib.import_module``) can locate user-land

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -630,6 +630,30 @@ class TestLoadAgentYaml:
         assert agent.model.api_key is not None
         assert agent.model.api_key.get_secret_value() == "sk-test-12345"
 
+    def test_load_agent_yaml_substitute_env_false_keeps_literal(
+        self, temp_dir: Path, monkeypatch: Any
+    ) -> None:
+        """substitute_env=False preserves ${VAR} literals — no env var needed."""
+        monkeypatch.delenv("MISSING_AT_BUILD_TIME", raising=False)
+
+        agent_yaml = temp_dir / "agent.yaml"
+        agent_content = {
+            "name": "test-agent",
+            "model": {
+                "provider": "openai",
+                "name": "gpt-4o",
+                "api_key": "${MISSING_AT_BUILD_TIME}",
+            },
+            "instructions": {"inline": "Test."},
+        }
+        agent_yaml.write_text(yaml.dump(agent_content))
+
+        loader = ConfigLoader()
+        agent = loader.load_agent_yaml(str(agent_yaml), substitute_env=False)
+
+        assert agent.model.api_key is not None
+        assert agent.model.api_key.get_secret_value() == "${MISSING_AT_BUILD_TIME}"
+
     def test_load_agent_yaml_with_global_config_merge(
         self, temp_dir: Path, monkeypatch: Any
     ) -> None:

--- a/tests/unit/deploy/test_dockerfile.py
+++ b/tests/unit/deploy/test_dockerfile.py
@@ -886,3 +886,134 @@ class TestExtrasDetection:
         content = _generate_dockerfile_content(agent, agent.deployment, "test")
 
         assert "holodeck-ai[" not in content
+
+    def test_qdrant_provider_detected(self, tmp_path: Path) -> None:
+        """qdrant database provider triggers the qdrant extra."""
+        from holodeck.cli.commands.deploy import _generate_dockerfile_content
+        from holodeck.config.loader import ConfigLoader
+
+        agent_yaml = tmp_path / "agent.yaml"
+        agent_yaml.write_text(
+            "name: extras-test\n"
+            "model:\n"
+            "  provider: openai\n"
+            "  name: gpt-4o\n"
+            "instructions:\n"
+            '  inline: "Test"\n'
+            "tools:\n"
+            "  - name: search_docs\n"
+            "    type: vectorstore\n"
+            "    description: Search docs\n"
+            "    source: ./data\n"
+            "    database:\n"
+            "      provider: qdrant\n"
+            "      connection_string: http://stub:6333\n"
+            "      collection: test\n"
+            "deployment:\n"
+            "  registry:\n"
+            "    url: ghcr.io\n"
+            "    repository: test/extras\n"
+            "    tag_strategy: latest\n"
+            "  target:\n"
+            "    provider: aws\n"
+            "    aws:\n"
+            "      region: us-east-1\n"
+            "      cpu: 1\n"
+            "      memory: 2048\n"
+        )
+        loader = ConfigLoader()
+        agent = loader.load_agent_yaml(str(agent_yaml))
+        content = _generate_dockerfile_content(agent, agent.deployment, "test")
+
+        assert "qdrant" in content
+
+
+class TestBuildContextFileCopying:
+    """Tests for _prepare_build_context bundling tool sources + test_cases_file."""
+
+    def _write_agent(self, tmp_path: Path, *, with_tool_file: bool) -> Path:
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "instructions").mkdir()
+        (agent_dir / "instructions" / "sys.md").write_text("System prompt.")
+        (agent_dir / "tools").mkdir()
+        (agent_dir / "tools" / "my_tools.py").write_text("def f(): return 1\n")
+        (agent_dir / "data").mkdir()
+        (agent_dir / "data" / "cases.yaml").write_text("- input: hi\n")
+
+        tools_block = (
+            (
+                "tools:\n"
+                "  - name: f\n"
+                "    type: function\n"
+                "    description: f\n"
+                "    file: tools/my_tools.py\n"
+                "    function: f\n"
+            )
+            if with_tool_file
+            else ""
+        )
+
+        (agent_dir / "agent.yaml").write_text(
+            "name: bundling-test\n"
+            "model:\n"
+            "  provider: openai\n"
+            "  name: gpt-4o\n"
+            "instructions:\n"
+            "  file: instructions/sys.md\n"
+            + tools_block
+            + "test_cases_file: data/cases.yaml\n"
+            "deployment:\n"
+            "  registry:\n"
+            "    url: ghcr.io\n"
+            "    repository: test/bundling\n"
+            "    tag_strategy: latest\n"
+            "  target:\n"
+            "    provider: aws\n"
+            "    aws:\n"
+            "      region: us-east-1\n"
+            "      cpu: 1\n"
+            "      memory: 2048\n"
+        )
+        return agent_dir
+
+    def test_function_tool_and_test_cases_file_bundled(self, tmp_path: Path) -> None:
+        """Function tool .py + test_cases_file land in the build context."""
+        import shutil
+
+        from holodeck.cli.commands.deploy import _prepare_build_context
+        from holodeck.config.loader import ConfigLoader
+
+        agent_dir = self._write_agent(tmp_path, with_tool_file=True)
+        loader = ConfigLoader()
+        agent = loader.load_agent_yaml(
+            str(agent_dir / "agent.yaml"), substitute_env=False
+        )
+
+        build_dir = _prepare_build_context(agent, agent.deployment, agent_dir, "v1")
+        try:
+            assert (build_dir / "agent.yaml").is_file()
+            assert (build_dir / "instructions" / "sys.md").is_file()
+            assert (build_dir / "tools" / "my_tools.py").is_file()
+            assert (build_dir / "data" / "cases.yaml").is_file()
+            assert (build_dir / "entrypoint.sh").is_file()
+            assert (build_dir / "Dockerfile").read_text().startswith("# HoloDeck")
+        finally:
+            shutil.rmtree(build_dir, ignore_errors=True)
+
+    def test_read_raw_test_cases_file_returns_unresolved_ref(
+        self, tmp_path: Path
+    ) -> None:
+        """_read_raw_test_cases_file pulls the YAML key directly."""
+        from holodeck.cli.commands.deploy import _read_raw_test_cases_file
+
+        agent_dir = self._write_agent(tmp_path, with_tool_file=False)
+        assert _read_raw_test_cases_file(agent_dir / "agent.yaml") == "data/cases.yaml"
+
+    def test_read_raw_test_cases_file_missing_returns_none(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing or unreadable file returns None instead of raising."""
+        from holodeck.cli.commands.deploy import _read_raw_test_cases_file
+
+        assert _read_raw_test_cases_file(tmp_path / "nope.yaml") is None


### PR DESCRIPTION
## Summary

Three independent improvements to `holodeck deploy build`, surfaced while wiring up a real-world Azure Container Apps deployment for `sample/financial-assistant/claude`.

### 1. Build context now bundles all tool sources

Previously the build context only copied the agent's instruction file and `VectorstoreTool` source directories. That left containers missing:
- `FunctionTool.file` (Python tool sources, e.g. `tools/financial_tools.py`)
- Single-file hierarchical_document / vectorstore sources (e.g. a PDF)
- The unresolved `test_cases_file` — the loader resolves this **eagerly** at serve time, so the file has to ship in the image even though serve never uses it. Without this, a container with a `test_cases_file:` reference fails immediately on startup with `FileNotFoundError`.

### 2. Extras detection generalized

Was hard-coded to `chromadb`; now covers `{chromadb, qdrant, pinecone, postgres}` — the names match the optional-dependency groups in `pyproject.toml` 1:1, so any new vector-store extra is auto-picked-up. Fixes the runtime warning `Missing dependencies for vector store provider 'qdrant'. Falling back to in-memory storage.`

### 3. Skip env-var substitution at build time

`ConfigLoader.load_agent_yaml` gains `substitute_env: bool = True`, threaded through to `_read_yaml_with_env_substitution` and `_resolve_test_cases_file`. `holodeck deploy build` now passes `False` because the build is **structural** — it only needs the YAML shape (tool list, deployment block, file paths), not runtime secrets. Operators no longer need to export stub values just to build:

```bash
# Before
QDRANT_URL=stub OTEL_EXPORTER_OTLP_ENDPOINT=stub AZURE_OPENAI_…=stub \
  holodeck deploy build sample/financial-assistant/claude/agent.yaml
# After
holodeck deploy build sample/financial-assistant/claude/agent.yaml
```

`deploy run`/`status`/`destroy` still use the default `substitute_env=True` (they hit cloud APIs and need real values).

### 4. Schema sync

`schemas/agent.schema.json` — added `platform` and `health_check_path` under `DeploymentConfig`. Both already exist on the Pydantic model; the JSON schema was simply out of date.

## Test plan

- [x] `pytest tests/unit/config tests/unit/deploy -n auto` — 385 passed
- [x] `holodeck deploy build` with zero env vars exported — builds & dry-runs successfully
- [x] End-to-end on `sample/financial-assistant/claude`: builds arm64 image → pushes to `ghcr.io` → runs with `--env-file .env` → container reaches Qdrant (`172.19.0.2:6333`) and Aspire OTLP (`172.17.0.2:18889`) cleanly; no `Missing dependencies` warning; `/health` 200