### PR TITLE
chore(deps): bump qdrant-client to 1.18 + ensure payload indexes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ postgres = [
     "psycopg[binary,pool]~=3.2",
 ]
 qdrant = [
-    "qdrant-client~=1.9",
+    "qdrant-client>=1.18,<2.0",
 ]
 chromadb = [
     "chromadb>=0.5,<1.1",
@@ -93,7 +93,7 @@ chromadb = [
 vectorstores = [
     "pinecone[asyncio,grpc]~=7.0",
     "psycopg[binary,pool]~=3.2",
-    "qdrant-client~=1.9",
+    "qdrant-client>=1.18,<2.0",
     "chromadb>=0.5,<1.1",
 ]
 

--- a/src/holodeck/tools/hierarchical_document_tool.py
+++ b/src/holodeck/tools/hierarchical_document_tool.py
@@ -145,6 +145,7 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
         self._collection: Any = None
         self._provider: str = "in-memory"
         self._embedding_dimensions: int | None = None
+        self._qdrant_indexes_ensured: bool = False
 
         # Lazily constructed FileProcessor (see _get_file_processor)
         self._file_processor: FileProcessor | None = None
@@ -899,10 +900,77 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
         async with self._collection as collection:
             if not await collection.collection_exists():
                 await collection.ensure_collection_exists()
+            await self._ensure_qdrant_payload_indexes(collection)
             await collection.upsert(records)
 
         logger.debug(f"Stored {len(records)} chunks")
         return len(records)
+
+    async def _ensure_qdrant_payload_indexes(self, collection: Any) -> None:
+        """Create payload indexes on qdrant for filter-required fields.
+
+        Semantic Kernel's qdrant connector (`ensure_collection_exists`) only
+        configures vectors; it never translates ``is_indexed=True`` /
+        ``is_full_text_indexed=True`` field flags into qdrant payload-index
+        API calls. Qdrant <=1.17 silently fell back to a brute-force payload
+        scan for un-indexed fields; qdrant >=1.18 rejects such filters with
+        ``400 Index required but not found``.
+
+        This patches over the gap by explicitly creating the indexes
+        declared on ``HierarchicalDocumentRecord`` (see
+        ``holodeck/lib/vector_store.py``: ``section_id``, ``defined_term``,
+        ``defined_term_normalized`` as keyword; ``searchable_text`` as
+        full-text). ``create_payload_index`` is idempotent for matching
+        params, so a no-op on subsequent ingests.
+
+        Args:
+            collection: An SK ``QdrantCollection`` already entered as
+                an async context manager (so ``qdrant_client`` is live).
+        """
+        if self._provider != "qdrant" or self._qdrant_indexes_ensured:
+            return
+
+        from qdrant_client.http import models
+
+        client = collection.qdrant_client
+        coll_name = collection.collection_name
+
+        keyword_fields = ("section_id", "defined_term", "defined_term_normalized")
+        for field_name in keyword_fields:
+            try:
+                await client.create_payload_index(
+                    collection_name=coll_name,
+                    field_name=field_name,
+                    field_schema=models.KeywordIndexParams(
+                        type=models.KeywordIndexType.KEYWORD,
+                    ),
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Qdrant payload-index create failed for '{field_name}' "
+                    f"on '{coll_name}': {e}"
+                )
+
+        try:
+            await client.create_payload_index(
+                collection_name=coll_name,
+                field_name="searchable_text",
+                field_schema=models.TextIndexParams(
+                    type="text",
+                    tokenizer=models.TokenizerType.WORD,
+                    min_token_len=2,
+                    max_token_len=20,
+                    lowercase=True,
+                ),
+            )
+        except Exception as e:
+            logger.warning(
+                f"Qdrant full-text index create failed for 'searchable_text' "
+                f"on '{coll_name}': {e}"
+            )
+
+        self._qdrant_indexes_ensured = True
+        logger.info(f"Ensured qdrant payload indexes on collection '{coll_name}'")
 
     async def _embed_query(self, query: str) -> list[float]:
         """Generate embedding for a query string.

--- a/tests/unit/tools/test_hierarchical_document_tool.py
+++ b/tests/unit/tools/test_hierarchical_document_tool.py
@@ -2964,3 +2964,108 @@ class TestInitializeRebuild:
             result = await tool._ingest_documents(force_ingest=False)
 
             assert result == 1  # One file discovered, one skipped
+
+
+class TestEnsureQdrantPayloadIndexes:
+    """Tests for the qdrant payload-index workaround.
+
+    SK's qdrant connector doesn't translate ``is_indexed`` /
+    ``is_full_text_indexed`` field flags into payload-index API calls.
+    Qdrant >=1.18 then rejects MatchText / keyword filters on those fields
+    with ``400 Index required but not found``. The tool patches over the
+    gap by explicitly calling ``create_payload_index`` after
+    ``ensure_collection_exists``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_creates_keyword_and_text_indexes_for_qdrant(
+        self, tmp_path: Path
+    ) -> None:
+        """Qdrant provider gets indexes on the four declared fields."""
+        from holodeck.tools.hierarchical_document_tool import HierarchicalDocumentTool
+
+        tool = HierarchicalDocumentTool.__new__(HierarchicalDocumentTool)
+        tool._provider = "qdrant"
+        tool._qdrant_indexes_ensured = False
+
+        client = MagicMock()
+        client.create_payload_index = AsyncMock()
+        collection = MagicMock()
+        collection.qdrant_client = client
+        collection.collection_name = "test-coll"
+
+        await tool._ensure_qdrant_payload_indexes(collection)
+
+        # 3 keyword fields + 1 full-text field = 4 calls
+        assert client.create_payload_index.await_count == 4
+        called_fields = {
+            kwargs["field_name"]
+            for _, kwargs in client.create_payload_index.await_args_list
+        }
+        assert called_fields == {
+            "section_id",
+            "defined_term",
+            "defined_term_normalized",
+            "searchable_text",
+        }
+        assert tool._qdrant_indexes_ensured is True
+
+    @pytest.mark.asyncio
+    async def test_skip_for_non_qdrant_providers(self, tmp_path: Path) -> None:
+        """In-memory / other providers don't get qdrant index calls."""
+        from holodeck.tools.hierarchical_document_tool import HierarchicalDocumentTool
+
+        tool = HierarchicalDocumentTool.__new__(HierarchicalDocumentTool)
+        tool._provider = "in-memory"
+        tool._qdrant_indexes_ensured = False
+
+        client = MagicMock()
+        client.create_payload_index = AsyncMock()
+        collection = MagicMock()
+        collection.qdrant_client = client
+
+        await tool._ensure_qdrant_payload_indexes(collection)
+
+        client.create_payload_index.assert_not_called()
+        assert tool._qdrant_indexes_ensured is False  # left untouched
+
+    @pytest.mark.asyncio
+    async def test_idempotent_after_first_call(self, tmp_path: Path) -> None:
+        """Second call is a no-op (flag prevents re-issuing API calls)."""
+        from holodeck.tools.hierarchical_document_tool import HierarchicalDocumentTool
+
+        tool = HierarchicalDocumentTool.__new__(HierarchicalDocumentTool)
+        tool._provider = "qdrant"
+        tool._qdrant_indexes_ensured = True  # already done
+
+        client = MagicMock()
+        client.create_payload_index = AsyncMock()
+        collection = MagicMock()
+        collection.qdrant_client = client
+
+        await tool._ensure_qdrant_payload_indexes(collection)
+
+        client.create_payload_index.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_index_failure_is_logged_not_raised(self, tmp_path: Path) -> None:
+        """If qdrant rejects a single index, the rest still proceed."""
+        from holodeck.tools.hierarchical_document_tool import HierarchicalDocumentTool
+
+        tool = HierarchicalDocumentTool.__new__(HierarchicalDocumentTool)
+        tool._provider = "qdrant"
+        tool._qdrant_indexes_ensured = False
+
+        client = MagicMock()
+        client.create_payload_index = AsyncMock(side_effect=RuntimeError("boom"))
+        collection = MagicMock()
+        collection.qdrant_client = client
+        collection.collection_name = "test-coll"
+
+        # Doesn't raise even though every call fails.
+        await tool._ensure_qdrant_payload_indexes(collection)
+
+        # All four attempts were made.
+        assert client.create_payload_index.await_count == 4
+        # Flag still set (idempotency works even on failures).
+        assert tool._qdrant_indexes_ensured is True

--- a/uv.lock
+++ b/uv.lock
@@ -2318,8 +2318,8 @@ requires-dist = [
     { name = "python-frontmatter", specifier = ">=1.1,<2.0" },
     { name = "python-ulid", specifier = ">=3.1.0,<4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
-    { name = "qdrant-client", marker = "extra == 'qdrant'", specifier = "~=1.9" },
-    { name = "qdrant-client", marker = "extra == 'vectorstores'", specifier = "~=1.9" },
+    { name = "qdrant-client", marker = "extra == 'qdrant'", specifier = ">=1.18,<2.0" },
+    { name = "qdrant-client", marker = "extra == 'vectorstores'", specifier = ">=1.18,<2.0" },
     { name = "rank-bm25", specifier = ">=0.2.2,<0.3.0" },
     { name = "requests", specifier = ">=2.32.5,<3.0.0" },
     { name = "rouge-score", specifier = ">=0.1.2,<0.2.0" },
@@ -6350,7 +6350,7 @@ wheels = [
 
 [[package]]
 name = "qdrant-client"
-version = "1.16.1"
+version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
@@ -6362,9 +6362,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/68/fec3816a223c0b73b0e0036460be45c61ce2770ffb9197ac371e4f615ddc/qdrant_client-1.16.1.tar.gz", hash = "sha256:676c7c10fd4d4cb2981b8fcb32fd764f5f661b04b7334d024034d07212f971fd", size = 332130, upload-time = "2025-11-25T04:31:54.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/45/5b1bdd15a3c7730eefb9c113600829e20d689b82b5a23f9e07d107094004/qdrant_client-1.18.0.tar.gz", hash = "sha256:52e8ece1a7d40519801bf0b70713bfa0f6b7ae28c7275bbe0b0286fbed7f6db4", size = 352580, upload-time = "2026-05-11T14:12:38.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/e2/60a20d04b0595c641516463168909c5bbcc192d3d6eacb637c1677109c6a/qdrant_client-1.16.1-py3-none-any.whl", hash = "sha256:1eefe89f66e8a468ba0de1680e28b441e69825cfb62e8fb2e457c15e24ce5e3b", size = 378481, upload-time = "2025-11-25T04:31:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/10/c437bd2ac41ef30d3019063e6ce537dc111e9214473b337ee88f7fa6359a/qdrant_client-1.18.0-py3-none-any.whl", hash = "sha256:093aa8cf8a420ee3ad2a68b007e1378d7992b2600e0b53c193fc172674f659cd", size = 398126, upload-time = "2026-05-11T14:12:36.998Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `qdrant-client` from `~=1.9` to `>=1.18,<2.0` (in both `qdrant` and `vectorstores` extras) to match the Qdrant Cloud 1.18 server, eliminating the client/server version-mismatch warning.
- Adds `_ensure_qdrant_payload_indexes` in `HierarchicalDocumentTool` so payload indexes are created explicitly after `ensure_collection_exists()`. The SK 1.39 qdrant connector only sets `vectors_config` and never calls `create_payload_index`, so filtered searches against a Qdrant 1.18 server fail with `400 Bad Request — Index required but not found for "<field>"`. Qdrant 1.17 silently fell back to a brute-force scan, which is why this only surfaced after moving from the local 1.17.1 container to Qdrant Cloud 1.18.

Indexes created (idempotent, per-field error-tolerant):
- `section_id`, `defined_term`, `defined_term_normalized` — `keyword`
- `searchable_text` — `text` (WORD tokenizer, min_token_len=2, max_token_len=20, lowercase)

## Test plan
- [x] `pytest tests/unit/tools/test_hierarchical_document_tool.py -n auto` — 126 passed (includes 4 new `TestEnsureQdrantPayloadIndexes` cases).
- [x] End-to-end verified against the live Qdrant Cloud 1.18 cluster: empty `payload_schema` → 4 indexes created; the previously-failing MatchText filter on `searchable_text` now returns cleanly.
- [ ] `make ci` green in CI.