### PR TITLE
perf(hierarchical_document): native-hybrid lazy init + qdrant source_path index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,67 @@ Always `source .venv/bin/activate` before Python commands.
 6. Implement with Claude tasks.
 7. Run `make format`, `make lint`, `make type-check`, `make security` after each task.
 
+## End-to-End Deploy Validation Loop
+
+**Run only when the user explicitly asks** (e.g. "run the deploy validation loop", "do the local base + deploy build + deploy run validation"). **Do NOT run automatically** after every change — it builds a docker image, pushes to GHCR, and rolls a live Azure Container Apps revision. Unit tests are the default contract; this loop is reserved for verifying that a fix actually takes effect end-to-end (the `FROM ghcr.io/justinbarias/holodeck-base:latest` chain pins the published wheel by default, so local source changes are invisible until baked into the base).
+
+The default sample for this loop is `sample/financial-assistant/claude` (qdrant cloud + Aspire OTEL + Azure Container Apps). Substitute the path if the user names a different agent.
+
+### Sequence
+
+```bash
+# 1. Build local wheel (reflects working-tree source)
+rm -rf dist && uv build --wheel
+
+# 2. Build local base image with the wheel baked in.
+#    docker/Dockerfile.local exists for this — it installs from dist/*.whl
+#    instead of PyPI. --no-cache is required because docker buildx will
+#    happily reuse the layer that did the PyPI install.
+docker buildx build --platform linux/amd64 --no-cache \
+    -f docker/Dockerfile.local \
+    -t ghcr.io/justinbarias/holodeck-base:latest --load .
+
+# Verify the base actually carries the local wheel:
+docker run --rm --entrypoint python ghcr.io/justinbarias/holodeck-base:latest \
+    -c "import holodeck; print(holodeck.__version__)"
+# Expect a dev version (e.g. 0.6.35.dev1), NOT the published release.
+
+# 3. Temporarily disable the pull=True in src/holodeck/deploy/builder.py
+#    (search for `pull=True,  # Always pull base image`). Otherwise
+#    `holodeck deploy build` re-pulls the registry base and clobbers
+#    your locally tagged image. Revert this edit before committing.
+
+# 4. Build + push the agent image.
+cd sample/financial-assistant/claude
+holodeck deploy build
+docker push ghcr.io/justinbarias/holodeck-financial-assistant:<tag>
+# Tag is `git_sha` by default — first 7 chars of HEAD. Confirm via
+# the build output's "Image:" line.
+
+# 5. Deploy to Azure Container Apps.
+holodeck deploy run
+
+# 6. Wait until /health is up, then exercise the AG-UI endpoint with
+#    a known-good query and confirm a 200 + sensible content. For the
+#    financial-assistant sample, a single ConvFinQA turn (e.g. ALXN/2007
+#    rental payments) covers ingestion + hybrid search + tool-loop.
+URL=https://financial-assistant.nicemoss-50caf9f5.eastus.azurecontainerapps.io
+until curl -sf -o /dev/null --max-time 5 "$URL/health"; do sleep 3; done
+curl -sS -X POST "$URL/awp" -H 'content-type: application/json' \
+    -d '{"threadId":"v","runId":"r","state":{},"messages":[{"id":"m1","role":"user","content":"<your query>"}],"tools":[],"context":[],"forwardedProps":{}}' \
+    --max-time 180
+
+# 7. Revert the builder.py edit (re-enable pull=True) before committing.
+```
+
+### Caveats
+
+- **`pull=True` clobbering**: `holodeck deploy build` calls Docker SDK with `pull=True` so it gets the right platform — but this overrides your local tag with whatever's on GHCR. Either flip the flag temporarily (step 3) or accept that the local base won't be used.
+- **arm64 vs amd64**: Container Apps run amd64. Build the base + agent for `linux/amd64` even on Apple Silicon (use `--platform linux/amd64`). For local docker-network testing, arm64 is fine.
+- **Tag re-use**: Image tag stays `<git_sha>` across iterations, but each rebuild produces a new digest. ACA picks up the new digest on `deploy run` (it inspects the image rather than caching by tag).
+- **Cold-start latency**: First post-deploy query is 40–70s (image pull + tool init + first ingestion check). Subsequent queries are sub-10s.
+- **Validation queries should be deterministic**: prefer questions with a single grounded answer from the corpus (e.g. a specific filing's table value) so a regression is unambiguous.
+
 ## Git Commits
 
 - Do NOT attribute Claude Code or include "Generated with Claude Code".

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -1,0 +1,57 @@
+# Local-source variant of docker/Dockerfile.
+# Installs HoloDeck from a wheel built from the current working tree
+# (../dist/*.whl) instead of PyPI. Tag the resulting image with the same
+# name as the published base so `holodeck deploy build` picks it up
+# locally before reaching for ghcr.io.
+#
+# Build (from repo root):
+#   uv build --wheel
+#   docker buildx build --platform linux/arm64 \
+#     -f docker/Dockerfile.local \
+#     -t ghcr.io/justinbarias/holodeck-base:latest \
+#     --load .
+
+FROM python:3.10-slim
+
+LABEL org.opencontainers.image.title="HoloDeck Base Image (local)"
+LABEL com.holodeck.managed="true"
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    HOLODECK_PORT=8080 \
+    HOLODECK_PROTOCOL=rest \
+    HOLODECK_AGENT_CONFIG=/app/agent.yaml
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && mv /root/.local/bin/uv /usr/local/bin/uv \
+    && chmod +x /usr/local/bin/uv
+
+RUN groupadd --gid 1000 holodeck \
+    && useradd --uid 1000 --gid 1000 --shell /bin/bash --create-home holodeck
+
+WORKDIR /app
+
+COPY dist/*.whl /tmp/wheels/
+RUN uv pip install --system --no-cache --prerelease=allow /tmp/wheels/*.whl \
+    && rm -rf /tmp/wheels
+
+COPY docker/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+RUN chown -R holodeck:holodeck /app
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:${HOLODECK_PORT}/health || exit 1
+
+USER holodeck
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/src/holodeck/lib/keyword_search.py
+++ b/src/holodeck/lib/keyword_search.py
@@ -758,6 +758,20 @@ class HybridSearchExecutor:
         # Store chunk map for ID-based lookups
         self._chunk_map = {c.id: c for c in chunks}
 
+        # Native-hybrid providers (qdrant) handle the keyword leg inside the
+        # vector store at query time (see _native_hybrid_search_*). The
+        # in-process BM25/OpenSearch index would never be read, so skip the
+        # tokenize-and-build pass entirely. _chunk_map is still useful as a
+        # cache for get_chunks() lookups; it just doesn't need to be the
+        # source of truth for the keyword index.
+        if self.strategy == KeywordSearchStrategy.NATIVE_HYBRID:
+            logger.debug(
+                "Skipping in-process keyword index build for native-hybrid "
+                f"provider '{self.provider}' "
+                f"(strategy={self.strategy.value})"
+            )
+            return
+
         # Convert chunks to structured keyword documents
         docs = [_chunk_to_keyword_document(c) for c in chunks]
 
@@ -826,6 +840,18 @@ class HybridSearchExecutor:
             The DocumentChunk if found, or None.
         """
         return self._chunk_map.get(chunk_id)
+
+    def cache_chunk(self, chunk: DocumentChunk) -> None:
+        """Insert a chunk into the in-memory cache by id.
+
+        Used by the native-hybrid path (qdrant) which lazily fetches chunks
+        on cache miss instead of preloading the entire corpus at startup.
+        Subsequent ``get_chunk`` calls for the same id resolve locally.
+
+        Args:
+            chunk: The DocumentChunk to cache. Indexed by ``chunk.id``.
+        """
+        self._chunk_map[chunk.id] = chunk
 
     async def keyword_search(
         self, query: str, top_k: int = 10

--- a/src/holodeck/lib/keyword_search.py
+++ b/src/holodeck/lib/keyword_search.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from collections.abc import Callable
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, TypedDict, runtime_checkable
 
@@ -700,6 +701,7 @@ class HybridSearchExecutor:
         keyword_weight: float = 0.3,
         rrf_k: int = 60,
         keyword_index_config: KeywordIndexConfig | None = None,
+        chunk_decoder: Callable[[dict[str, Any]], DocumentChunk] | None = None,
     ) -> None:
         """Initialize the hybrid search executor.
 
@@ -711,6 +713,12 @@ class HybridSearchExecutor:
             rrf_k: RRF ranking constant (default 60)
             keyword_index_config: Keyword index backend configuration.
                 If None, defaults to in-memory BM25.
+            chunk_decoder: Optional callback to reconstruct a
+                ``DocumentChunk`` from a raw payload dict. Required for
+                native-hybrid providers — search pulls payloads inline
+                and the executor populates ``_chunk_map`` so the caller
+                can resolve ids via ``get_chunk`` without a second
+                round-trip. Unused by the BM25 fallback path.
         """
         self.provider = provider
         self.collection = collection
@@ -719,6 +727,7 @@ class HybridSearchExecutor:
         self.keyword_weight = keyword_weight
         self.rrf_k = rrf_k
         self.keyword_index_config = keyword_index_config
+        self._chunk_decoder = chunk_decoder
         self._keyword_index: (
             InMemoryBM25KeywordProvider | OpenSearchKeywordProvider | None
         ) = None
@@ -840,18 +849,6 @@ class HybridSearchExecutor:
             The DocumentChunk if found, or None.
         """
         return self._chunk_map.get(chunk_id)
-
-    def cache_chunk(self, chunk: DocumentChunk) -> None:
-        """Insert a chunk into the in-memory cache by id.
-
-        Used by the native-hybrid path (qdrant) which lazily fetches chunks
-        on cache miss instead of preloading the entire corpus at startup.
-        Subsequent ``get_chunk`` calls for the same id resolve locally.
-
-        Args:
-            chunk: The DocumentChunk to cache. Indexed by ``chunk.id``.
-        """
-        self._chunk_map[chunk.id] = chunk
 
     async def keyword_search(
         self, query: str, top_k: int = 10
@@ -975,7 +972,30 @@ class HybridSearchExecutor:
             async for result in search_results.results:
                 record = result.record if hasattr(result, "record") else result[0]
                 score = result.score if hasattr(result, "score") else result[1]
-                results.append((record.id, float(score)))
+                # SK records are HierarchicalDocumentRecord instances — feed
+                # them through chunk_decoder so the tool can resolve via
+                # get_chunk(id) without a second round-trip. Decoder is
+                # tolerant of either a dict or a record-with-fields, since
+                # different SK backends shape the record differently.
+                if self._chunk_decoder is not None:
+                    try:
+                        payload: dict[str, Any]
+                        if hasattr(record, "__dict__"):
+                            payload = {
+                                k: v
+                                for k, v in record.__dict__.items()
+                                if not k.startswith("_")
+                            }
+                        elif isinstance(record, dict):
+                            payload = dict(record)
+                        else:
+                            payload = {}
+                        payload.setdefault("id", str(record.id))
+                        chunk = self._chunk_decoder(payload)
+                        self._chunk_map[chunk.id] = chunk
+                    except Exception as e:
+                        logger.debug(f"chunk_decoder failed for id={record.id}: {e}")
+                results.append((str(record.id), float(score)))
 
         return results
 
@@ -1042,11 +1062,26 @@ class HybridSearchExecutor:
                 prefetch=prefetch,
                 query=qm.FusionQuery(fusion=qm.Fusion.RRF),
                 limit=top_k,
-                with_payload=False,
+                with_payload=self._chunk_decoder is not None,
                 with_vectors=False,
             )
 
-        return [(str(p.id), float(p.score)) for p in response.points]
+        # Inline-decode payloads so the tool can resolve ids via
+        # get_chunk() without a follow-up retrieve. Native-hybrid skips
+        # the startup corpus reload, so _chunk_map is otherwise empty.
+        results: list[tuple[str, float]] = []
+        for p in response.points:
+            chunk_id = str(p.id)
+            if self._chunk_decoder is not None and p.payload:
+                payload = dict(p.payload)
+                payload.setdefault("id", chunk_id)
+                try:
+                    chunk = self._chunk_decoder(payload)
+                    self._chunk_map[chunk.id] = chunk
+                except Exception as e:  # decoder failures shouldn't sink the query
+                    logger.debug(f"chunk_decoder failed for id={chunk_id}: {e}")
+            results.append((chunk_id, float(p.score)))
+        return results
 
     async def _fallback_hybrid_search(
         self,

--- a/src/holodeck/tools/hierarchical_document_tool.py
+++ b/src/holodeck/tools/hierarchical_document_tool.py
@@ -585,51 +585,6 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
             logger.warning(f"Failed to load chunks from store: {e}")
             return []
 
-    async def _fetch_chunks_by_ids(self, chunk_ids: list[str]) -> list[DocumentChunk]:
-        """Lazily retrieve chunks by id from the vector store.
-
-        Used by the native-hybrid search path (qdrant) which skips the
-        startup corpus reload: search returns ids, then this batches a
-        single retrieve call so the per-query overhead is one round-trip.
-
-        Currently qdrant-only — the only provider in NATIVE_HYBRID_PROVIDERS
-        today. Other providers can be added when they grow native hybrid
-        support.
-        """
-        if not chunk_ids or self._collection is None:
-            return []
-
-        if self._provider != "qdrant":
-            logger.debug(
-                f"Lazy chunk fetch not implemented for provider '{self._provider}'"
-            )
-            return []
-
-        try:
-            async with self._collection as collection:
-                if not await collection.collection_exists():
-                    return []
-
-                client = collection.qdrant_client
-                points = await client.retrieve(
-                    collection_name=collection.collection_name,
-                    ids=chunk_ids,
-                    with_payload=True,
-                    with_vectors=False,
-                )
-
-                records: list[dict[str, Any]] = []
-                for point in points:
-                    payload = dict(point.payload) if point.payload else {}
-                    payload.setdefault("id", str(point.id))
-                    records.append(payload)
-
-                return [self._chunk_from_record(r) for r in records]
-
-        except Exception as e:
-            logger.warning(f"Failed to lazy-fetch chunks by id: {e}")
-            return []
-
     async def _convert_to_markdown(self, file_path: str) -> str:
         """Convert a file to markdown using FileProcessor.
 
@@ -975,7 +930,16 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
         client = collection.qdrant_client
         coll_name = collection.collection_name
 
-        keyword_fields = ("section_id", "defined_term", "defined_term_normalized")
+        # source_path is filtered by _check_if_already_ingested and
+        # _delete_file_records; qdrant >=1.18 rejects un-indexed filter fields
+        # with a 400, causing those methods to silently fall through and
+        # re-ingest the corpus (+ orphan stale chunks) on every cold start.
+        keyword_fields = (
+            "section_id",
+            "defined_term",
+            "defined_term_normalized",
+            "source_path",
+        )
         for field_name in keyword_fields:
             try:
                 await client.create_payload_index(
@@ -1121,6 +1085,11 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
             keyword_weight=self.config.keyword_weight,
             rrf_k=self.config.rrf_k,
             keyword_index_config=self.config.keyword_index,
+            # Native-hybrid providers pull payloads inline and need to
+            # reconstruct chunks from raw qdrant/SK payloads. Inject the
+            # decoder so the executor can populate _chunk_map as it
+            # ranks results — no separate retrieve call required.
+            chunk_decoder=self._chunk_from_record,
         )
 
     async def _build_hybrid_indices(self) -> None:
@@ -1172,23 +1141,12 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
             logger.warning("Hybrid executor not initialized, using semantic search")
             return await self._semantic_search(query_embedding, top_k)
 
-        # Get fused results from hybrid executor
+        # Get fused results from hybrid executor. Native-hybrid paths
+        # populate _chunk_map inline from the qdrant/SK payload, so the
+        # lookup below is a pure dict hit — no follow-up retrieve needed.
         fused_results = await self._hybrid_executor.search(
             query, query_embedding, top_k
         )
-
-        # Resolve any chunk_ids the executor doesn't have cached. Native-hybrid
-        # providers skip the startup corpus reload, so _chunk_map starts empty;
-        # batch-fetch missing chunks in a single round-trip.
-        missing_ids = [
-            chunk_id
-            for chunk_id, _ in fused_results
-            if self._hybrid_executor.get_chunk(chunk_id) is None
-        ]
-        if missing_ids:
-            fetched = await self._fetch_chunks_by_ids(missing_ids)
-            for fetched_chunk in fetched:
-                self._hybrid_executor.cache_chunk(fetched_chunk)
 
         # Convert to SearchResult objects via executor's chunk map
         results: list[SearchResult] = []

--- a/src/holodeck/tools/hierarchical_document_tool.py
+++ b/src/holodeck/tools/hierarchical_document_tool.py
@@ -505,20 +505,65 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
 
         return deleted_count
 
+    @staticmethod
+    def _chunk_from_record(record: dict[str, Any]) -> DocumentChunk:
+        """Reconstruct a DocumentChunk from a stored payload record.
+
+        Centralizes the JSON-field parsing + ChunkType coercion shared by
+        the full-corpus reload path and the per-id lazy-fetch path.
+        """
+        from holodeck.lib.structured_chunker import DocumentChunk
+
+        try:
+            parent_chain = json.loads(record.get("parent_chain") or "[]")
+        except (json.JSONDecodeError, TypeError):
+            parent_chain = []
+
+        try:
+            cross_references = json.loads(record.get("cross_references") or "[]")
+        except (json.JSONDecodeError, TypeError):
+            cross_references = []
+
+        try:
+            subsection_ids = json.loads(record.get("subsection_ids") or "[]")
+        except (json.JSONDecodeError, TypeError):
+            subsection_ids = []
+
+        try:
+            chunk_type = ChunkType(record.get("chunk_type"))
+        except (ValueError, KeyError):
+            chunk_type = ChunkType.CONTENT
+
+        return DocumentChunk(
+            id=record["id"],
+            source_path=record.get("source_path", ""),
+            chunk_index=record.get("chunk_index", 0),
+            content=record.get("content", ""),
+            parent_chain=parent_chain,
+            section_id=record.get("section_id", ""),
+            chunk_type=chunk_type,
+            cross_references=cross_references,
+            heading_level=0,
+            contextualized_content=record.get("contextualized_content") or "",
+            mtime=float(record.get("mtime") or 0.0),
+            defined_term=record.get("defined_term") or "",
+            defined_term_normalized=record.get("defined_term_normalized") or "",
+            subsection_ids=subsection_ids,
+        )
+
     async def _load_chunks_from_store(self) -> list[DocumentChunk]:
         """Load all document chunks from the vector store.
 
         Reconstructs DocumentChunk objects from stored records, enabling
         BM25 index rebuild on startup when files are unchanged (skipped
         via mtime check). This is necessary because the BM25 index is
-        in-memory only and does not survive restarts.
+        in-memory only and does not survive restarts. Native-hybrid
+        providers (qdrant) skip this path entirely — see ``initialize``.
 
         Returns:
             List of reconstructed DocumentChunk objects, or empty list
             if collection doesn't exist or an error occurs.
         """
-        from holodeck.lib.structured_chunker import DocumentChunk
-
         if self._collection is None:
             return []
 
@@ -532,62 +577,57 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
                 if not records:
                     return []
 
-                chunks: list[DocumentChunk] = []
-                for record in records:
-                    # Parse JSON fields with graceful fallback
-                    try:
-                        parent_chain = json.loads(record.get("parent_chain") or "[]")
-                    except (json.JSONDecodeError, TypeError):
-                        parent_chain = []
-
-                    try:
-                        cross_references = json.loads(
-                            record.get("cross_references") or "[]"
-                        )
-                    except (json.JSONDecodeError, TypeError):
-                        cross_references = []
-
-                    try:
-                        subsection_ids = json.loads(
-                            record.get("subsection_ids") or "[]"
-                        )
-                    except (json.JSONDecodeError, TypeError):
-                        subsection_ids = []
-
-                    # Map chunk_type string to ChunkType enum
-                    try:
-                        chunk_type = ChunkType(record.get("chunk_type"))
-                    except (ValueError, KeyError):
-                        chunk_type = ChunkType.CONTENT
-
-                    chunks.append(
-                        DocumentChunk(
-                            id=record["id"],
-                            source_path=record.get("source_path", ""),
-                            chunk_index=record.get("chunk_index", 0),
-                            content=record.get("content", ""),
-                            parent_chain=parent_chain,
-                            section_id=record.get("section_id", ""),
-                            chunk_type=chunk_type,
-                            cross_references=cross_references,
-                            heading_level=0,
-                            contextualized_content=record.get("contextualized_content")
-                            or "",
-                            mtime=float(record.get("mtime") or 0.0),
-                            defined_term=record.get("defined_term") or "",
-                            defined_term_normalized=record.get(
-                                "defined_term_normalized"
-                            )
-                            or "",
-                            subsection_ids=subsection_ids,
-                        )
-                    )
-
+                chunks = [self._chunk_from_record(r) for r in records]
                 logger.info(f"Loaded {len(chunks)} chunks from vector store")
                 return chunks
 
         except Exception as e:
             logger.warning(f"Failed to load chunks from store: {e}")
+            return []
+
+    async def _fetch_chunks_by_ids(self, chunk_ids: list[str]) -> list[DocumentChunk]:
+        """Lazily retrieve chunks by id from the vector store.
+
+        Used by the native-hybrid search path (qdrant) which skips the
+        startup corpus reload: search returns ids, then this batches a
+        single retrieve call so the per-query overhead is one round-trip.
+
+        Currently qdrant-only — the only provider in NATIVE_HYBRID_PROVIDERS
+        today. Other providers can be added when they grow native hybrid
+        support.
+        """
+        if not chunk_ids or self._collection is None:
+            return []
+
+        if self._provider != "qdrant":
+            logger.debug(
+                f"Lazy chunk fetch not implemented for provider '{self._provider}'"
+            )
+            return []
+
+        try:
+            async with self._collection as collection:
+                if not await collection.collection_exists():
+                    return []
+
+                client = collection.qdrant_client
+                points = await client.retrieve(
+                    collection_name=collection.collection_name,
+                    ids=chunk_ids,
+                    with_payload=True,
+                    with_vectors=False,
+                )
+
+                records: list[dict[str, Any]] = []
+                for point in points:
+                    payload = dict(point.payload) if point.payload else {}
+                    payload.setdefault("id", str(point.id))
+                    records.append(payload)
+
+                return [self._chunk_from_record(r) for r in records]
+
+        except Exception as e:
+            logger.warning(f"Failed to lazy-fetch chunks by id: {e}")
             return []
 
     async def _convert_to_markdown(self, file_path: str) -> str:
@@ -1060,20 +1100,20 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
         results.sort(key=lambda r: r.fused_score, reverse=True)
         return results
 
-    async def _build_hybrid_indices(self) -> None:
-        """Build hybrid search indices (BM25 and exact match).
+    def _setup_hybrid_executor(self) -> None:
+        """Create the HybridSearchExecutor (idempotent).
 
-        Creates the HybridSearchExecutor with BM25 fallback index
-        and exact match index from the stored chunks. This enables
-        keyword search, exact match, and hybrid search modes.
+        Splits executor construction from keyword-index building so
+        native-hybrid providers (e.g. qdrant) can route search through
+        the executor without paying for an in-process BM25/OpenSearch
+        index build. Safe to call multiple times — second call is a
+        no-op.
         """
         from holodeck.lib.keyword_search import HybridSearchExecutor
 
-        if not self._chunks:
-            logger.debug("No chunks to build hybrid indices from")
+        if self._hybrid_executor is not None:
             return
 
-        # Create hybrid search executor with configured weights
         self._hybrid_executor = HybridSearchExecutor(
             self._provider,
             self._collection,
@@ -1083,7 +1123,25 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
             keyword_index_config=self.config.keyword_index,
         )
 
-        # Build keyword index (executor now owns chunk data)
+    async def _build_hybrid_indices(self) -> None:
+        """Build hybrid search indices (BM25 and exact match).
+
+        Ensures the HybridSearchExecutor exists, then populates the
+        in-process keyword index (BM25 fallback or OpenSearch) from
+        the stored chunks. For native-hybrid providers, the executor
+        skips the index build internally — the retrieval store owns
+        the keyword leg.
+        """
+        if not self._chunks:
+            logger.debug("No chunks to build hybrid indices from")
+            return
+
+        self._setup_hybrid_executor()
+        if self._hybrid_executor is None:  # defensive — _setup_ already sets it
+            return
+
+        # Build keyword index (no-op for native-hybrid providers — they
+        # bypass the in-process index at query time).
         await self._hybrid_executor.build_keyword_index(self._chunks)
 
         logger.info(
@@ -1118,6 +1176,19 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
         fused_results = await self._hybrid_executor.search(
             query, query_embedding, top_k
         )
+
+        # Resolve any chunk_ids the executor doesn't have cached. Native-hybrid
+        # providers skip the startup corpus reload, so _chunk_map starts empty;
+        # batch-fetch missing chunks in a single round-trip.
+        missing_ids = [
+            chunk_id
+            for chunk_id, _ in fused_results
+            if self._hybrid_executor.get_chunk(chunk_id) is None
+        ]
+        if missing_ids:
+            fetched = await self._fetch_chunks_by_ids(missing_ids)
+            for fetched_chunk in fetched:
+                self._hybrid_executor.cache_chunk(fetched_chunk)
 
         # Convert to SearchResult objects via executor's chunk map
         results: list[SearchResult] = []
@@ -1242,17 +1313,34 @@ class HierarchicalDocumentTool(EmbeddingServiceMixin, DatabaseConfigMixin):
             force_ingest=force_ingest, progress_callback=progress_callback
         )
 
-        # Rebuild BM25 index from stored chunks when files were skipped.
-        # The BM25 index is in-memory only and doesn't survive restarts.
-        # For persistent providers (Qdrant, Postgres, etc.), we need to
-        # reload chunks from the store to rebuild keyword search indices.
-        # Skip for in-memory provider: collections don't survive restarts,
-        # so _needs_reingest() returns True for all files (nothing skipped).
-        if skipped_files > 0 and self._provider != "in-memory":
+        # Always set up the hybrid executor — search routes through it.
+        self._setup_hybrid_executor()
+
+        # Decide whether to reload the corpus and rebuild the in-process
+        # keyword index. Only the in-process BM25 fallback actually needs
+        # this: it's ephemeral and dies with the process. For native-hybrid
+        # providers (qdrant), keyword retrieval happens inside the store —
+        # the in-process index is never read, so loading every chunk into
+        # Python on every restart is pure waste. For in-memory providers,
+        # the collection itself is reseeded by _ingest_documents (nothing
+        # is "skipped"), so there's no reload to do.
+        from holodeck.lib.keyword_search import NATIVE_HYBRID_PROVIDERS
+
+        is_native_hybrid = self._provider in NATIVE_HYBRID_PROVIDERS
+        needs_corpus_reload = (
+            skipped_files > 0 and self._provider != "in-memory" and not is_native_hybrid
+        )
+
+        if needs_corpus_reload:
             stored_chunks = await self._load_chunks_from_store()
             if stored_chunks:
                 self._chunks = stored_chunks
                 await self._build_hybrid_indices()
+        elif is_native_hybrid:
+            logger.debug(
+                "Skipped startup corpus reload for native-hybrid provider "
+                f"'{self._provider}'; lazy chunk fetch on miss."
+            )
 
         self._initialized = True
         logger.info(

--- a/tests/unit/lib/test_keyword_search.py
+++ b/tests/unit/lib/test_keyword_search.py
@@ -928,25 +928,86 @@ class TestNativeHybridIndexBuild:
         assert executor._keyword_index is not None
 
 
-class TestCacheChunk:
-    """cache_chunk supports the lazy-fetch path for native-hybrid providers."""
+class TestNativeHybridInlineChunkDecode:
+    """Native-hybrid populates _chunk_map inline from query payloads."""
 
-    def test_cache_chunk_inserts_by_id(self) -> None:
+    @pytest.mark.asyncio
+    async def test_qdrant_search_decodes_payloads_into_chunk_map(self) -> None:
+        from types import SimpleNamespace
+
         from holodeck.lib.keyword_search import HybridSearchExecutor
         from holodeck.lib.structured_chunker import DocumentChunk
 
-        executor = HybridSearchExecutor("qdrant", MagicMock())
-        chunk = DocumentChunk(
-            id="lazy_id",
-            source_path="/test.md",
-            chunk_index=0,
-            content="lazy",
-            contextualized_content="lazy",
+        def decoder(payload: dict[str, object]) -> DocumentChunk:
+            return DocumentChunk(
+                id=str(payload["id"]),
+                source_path=str(payload.get("source_path", "")),
+                chunk_index=0,
+                content=str(payload.get("content", "")),
+                contextualized_content=str(payload.get("content", "")),
+            )
+
+        qdrant_client = AsyncMock()
+        qdrant_client.query_points.return_value = SimpleNamespace(
+            points=[
+                SimpleNamespace(
+                    id="chunk_a",
+                    score=0.9,
+                    payload={"content": "hello", "source_path": "/a.md"},
+                ),
+                SimpleNamespace(
+                    id="chunk_b",
+                    score=0.7,
+                    payload={"content": "world", "source_path": "/b.md"},
+                ),
+            ]
         )
 
-        assert executor.get_chunk("lazy_id") is None
-        executor.cache_chunk(chunk)
-        assert executor.get_chunk("lazy_id") is chunk
+        coll_ctx = AsyncMock()
+        coll_ctx.__aenter__.return_value = SimpleNamespace(
+            qdrant_client=qdrant_client,
+            collection_name="test",
+        )
+        coll_ctx.__aexit__.return_value = None
+
+        executor = HybridSearchExecutor("qdrant", coll_ctx, chunk_decoder=decoder)
+        results = await executor._native_hybrid_search_qdrant(
+            query="hello world",
+            query_embedding=[0.1, 0.2],
+            top_k=2,
+        )
+
+        qdrant_client.query_points.assert_called_once()
+        kwargs = qdrant_client.query_points.call_args.kwargs
+        assert kwargs["with_payload"] is True
+        assert results == [("chunk_a", 0.9), ("chunk_b", 0.7)]
+        # _chunk_map populated inline so the caller can resolve ids
+        # without a follow-up retrieve call.
+        assert executor.get_chunk("chunk_a") is not None
+        assert executor.get_chunk("chunk_a").content == "hello"
+        assert executor.get_chunk("chunk_b").source_path == "/b.md"
+
+    @pytest.mark.asyncio
+    async def test_qdrant_search_skips_payload_when_no_decoder(self) -> None:
+        from types import SimpleNamespace
+
+        from holodeck.lib.keyword_search import HybridSearchExecutor
+
+        qdrant_client = AsyncMock()
+        qdrant_client.query_points.return_value = SimpleNamespace(points=[])
+        coll_ctx = AsyncMock()
+        coll_ctx.__aenter__.return_value = SimpleNamespace(
+            qdrant_client=qdrant_client,
+            collection_name="test",
+        )
+        coll_ctx.__aexit__.return_value = None
+
+        executor = HybridSearchExecutor("qdrant", coll_ctx, chunk_decoder=None)
+        await executor._native_hybrid_search_qdrant(
+            query="hello", query_embedding=[0.1], top_k=2
+        )
+        kwargs = qdrant_client.query_points.call_args.kwargs
+        assert kwargs["with_payload"] is False
 
 
 class TestTokenizeQdrantQuery:

--- a/tests/unit/lib/test_keyword_search.py
+++ b/tests/unit/lib/test_keyword_search.py
@@ -1009,6 +1009,113 @@ class TestNativeHybridInlineChunkDecode:
         kwargs = qdrant_client.query_points.call_args.kwargs
         assert kwargs["with_payload"] is False
 
+    @pytest.mark.asyncio
+    async def test_qdrant_decoder_failure_does_not_drop_result(self) -> None:
+        """A misbehaving decoder is logged + skipped; the (id, score) still flows."""
+        from types import SimpleNamespace
+
+        from holodeck.lib.keyword_search import HybridSearchExecutor
+
+        def broken_decoder(payload: dict[str, object]) -> object:
+            raise RuntimeError("boom")
+
+        qdrant_client = AsyncMock()
+        qdrant_client.query_points.return_value = SimpleNamespace(
+            points=[SimpleNamespace(id="chunk_x", score=0.5, payload={"id": "chunk_x"})]
+        )
+        coll_ctx = AsyncMock()
+        coll_ctx.__aenter__.return_value = SimpleNamespace(
+            qdrant_client=qdrant_client,
+            collection_name="test",
+        )
+        coll_ctx.__aexit__.return_value = None
+
+        executor = HybridSearchExecutor(
+            "qdrant", coll_ctx, chunk_decoder=broken_decoder
+        )
+        results = await executor._native_hybrid_search_qdrant(
+            query="hi", query_embedding=[0.1], top_k=1
+        )
+        assert results == [("chunk_x", 0.5)]
+        assert executor.get_chunk("chunk_x") is None  # decode failed, not cached
+
+    @pytest.mark.asyncio
+    async def test_sk_path_decodes_record_into_chunk_map(self) -> None:
+        """Non-qdrant native-hybrid (SK hybrid_search) feeds records through decoder."""
+        from types import SimpleNamespace
+
+        from holodeck.lib.keyword_search import HybridSearchExecutor
+        from holodeck.lib.structured_chunker import DocumentChunk
+
+        def decoder(payload: dict[str, object]) -> DocumentChunk:
+            return DocumentChunk(
+                id=str(payload["id"]),
+                source_path=str(payload.get("source_path", "")),
+                chunk_index=0,
+                content=str(payload.get("content", "")),
+                contextualized_content=str(payload.get("content", "")),
+            )
+
+        # SK record + result shape: result.record and result.score.
+        record = SimpleNamespace(id="sk_chunk", content="hi", source_path="/sk.md")
+        result = SimpleNamespace(record=record, score=0.8)
+
+        async def aiter_results():
+            yield result
+
+        search_results = SimpleNamespace(results=aiter_results())
+
+        coll_inner = MagicMock()
+        coll_inner.hybrid_search = AsyncMock(return_value=search_results)
+        coll_ctx = AsyncMock()
+        coll_ctx.__aenter__.return_value = coll_inner
+        coll_ctx.__aexit__.return_value = None
+
+        executor = HybridSearchExecutor(
+            "azure-ai-search", coll_ctx, chunk_decoder=decoder
+        )
+        results = await executor._native_hybrid_search(
+            query="hi", query_embedding=[0.1], top_k=1
+        )
+
+        assert results == [("sk_chunk", 0.8)]
+        cached = executor.get_chunk("sk_chunk")
+        assert cached is not None
+        assert cached.content == "hi"
+        assert cached.source_path == "/sk.md"
+
+    @pytest.mark.asyncio
+    async def test_sk_path_decoder_failure_does_not_drop_result(self) -> None:
+        """SK-path decoder exceptions are logged; (id, score) still returned."""
+        from types import SimpleNamespace
+
+        from holodeck.lib.keyword_search import HybridSearchExecutor
+
+        def broken_decoder(payload: dict[str, object]) -> object:
+            raise RuntimeError("boom")
+
+        record = SimpleNamespace(id="sk_x", content="x")
+        result = SimpleNamespace(record=record, score=0.4)
+
+        async def aiter_results():
+            yield result
+
+        search_results = SimpleNamespace(results=aiter_results())
+        coll_inner = MagicMock()
+        coll_inner.hybrid_search = AsyncMock(return_value=search_results)
+        coll_ctx = AsyncMock()
+        coll_ctx.__aenter__.return_value = coll_inner
+        coll_ctx.__aexit__.return_value = None
+
+        executor = HybridSearchExecutor(
+            "weaviate", coll_ctx, chunk_decoder=broken_decoder
+        )
+        results = await executor._native_hybrid_search(
+            query="x", query_embedding=[0.1], top_k=1
+        )
+        assert results == [("sk_x", 0.4)]
+        assert executor.get_chunk("sk_x") is None
+
 
 class TestTokenizeQdrantQuery:
     """Tests for the Qdrant-side tokenizer used by the native-hybrid path."""

--- a/tests/unit/lib/test_keyword_search.py
+++ b/tests/unit/lib/test_keyword_search.py
@@ -866,6 +866,89 @@ class TestHybridSearchExecutor:
         assert len(results) > 0
 
 
+class TestNativeHybridIndexBuild:
+    """build_keyword_index skips in-process indexing for native-hybrid providers."""
+
+    @pytest.mark.asyncio
+    async def test_native_hybrid_skips_in_process_index_build(self) -> None:
+        """Qdrant + friends own keyword retrieval in-store; no BM25 to build."""
+        from holodeck.lib.keyword_search import HybridSearchExecutor
+        from holodeck.lib.structured_chunker import DocumentChunk
+
+        mock_collection = MagicMock()
+        executor = HybridSearchExecutor("qdrant", mock_collection)
+
+        chunks = [
+            DocumentChunk(
+                id="chunk_a",
+                source_path="/test.md",
+                chunk_index=0,
+                content="alpha",
+                contextualized_content="alpha",
+            ),
+            DocumentChunk(
+                id="chunk_b",
+                source_path="/test.md",
+                chunk_index=1,
+                content="beta",
+                contextualized_content="beta",
+            ),
+        ]
+
+        await executor.build_keyword_index(chunks)
+
+        # No in-process keyword index materialized.
+        assert executor._keyword_index is None
+        # _chunk_map is still populated so cached lookups work for any
+        # callers that pre-warm the cache or feed chunks in directly.
+        assert executor.get_chunk("chunk_a") is chunks[0]
+        assert executor.get_chunk("chunk_b") is chunks[1]
+
+    @pytest.mark.asyncio
+    async def test_fallback_provider_still_builds_in_process_index(self) -> None:
+        """Regression: non-native-hybrid path still builds the index."""
+        from holodeck.lib.keyword_search import HybridSearchExecutor
+        from holodeck.lib.structured_chunker import DocumentChunk
+
+        mock_collection = MagicMock()
+        executor = HybridSearchExecutor("chromadb", mock_collection)
+
+        chunks = [
+            DocumentChunk(
+                id="chunk_a",
+                source_path="/test.md",
+                chunk_index=0,
+                content="alpha",
+                contextualized_content="alpha",
+            ),
+        ]
+
+        await executor.build_keyword_index(chunks)
+
+        assert executor._keyword_index is not None
+
+
+class TestCacheChunk:
+    """cache_chunk supports the lazy-fetch path for native-hybrid providers."""
+
+    def test_cache_chunk_inserts_by_id(self) -> None:
+        from holodeck.lib.keyword_search import HybridSearchExecutor
+        from holodeck.lib.structured_chunker import DocumentChunk
+
+        executor = HybridSearchExecutor("qdrant", MagicMock())
+        chunk = DocumentChunk(
+            id="lazy_id",
+            source_path="/test.md",
+            chunk_index=0,
+            content="lazy",
+            contextualized_content="lazy",
+        )
+
+        assert executor.get_chunk("lazy_id") is None
+        executor.cache_chunk(chunk)
+        assert executor.get_chunk("lazy_id") is chunk
+
+
 class TestTokenizeQdrantQuery:
     """Tests for the Qdrant-side tokenizer used by the native-hybrid path."""
 

--- a/tests/unit/tools/test_hierarchical_document_tool.py
+++ b/tests/unit/tools/test_hierarchical_document_tool.py
@@ -17,7 +17,6 @@ semantic_kernel library is not available in the test environment.
 
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Save original modules before mocking (these will be restored after import)
@@ -3015,77 +3014,6 @@ class TestInitializeRebuild:
             assert result == 1  # One file discovered, one skipped
 
 
-class TestFetchChunksByIds:
-    """Lazy chunk-fetch path used by native-hybrid providers."""
-
-    @pytest.mark.asyncio
-    async def test_fetch_chunks_by_ids_qdrant_retrieves_and_reconstructs(
-        self, tmp_path: Path
-    ) -> None:
-        """Qdrant lazy fetch issues a single retrieve(ids=...) and rebuilds chunks."""
-        config = create_config(tmp_path)
-        tool = HierarchicalDocumentTool(config)
-        tool._provider = "qdrant"
-
-        fake_point = SimpleNamespace(
-            id="chunk_x",
-            payload={
-                "id": "chunk_x",
-                "source_path": "/src.md",
-                "chunk_index": 3,
-                "content": "lazy content",
-                "parent_chain": "[]",
-                "section_id": "s",
-                "chunk_type": "content",
-                "cross_references": "[]",
-                "subsection_ids": "[]",
-                "contextualized_content": "",
-                "mtime": 0.0,
-                "defined_term": "",
-                "defined_term_normalized": "",
-            },
-        )
-        fake_client = MagicMock()
-        fake_client.retrieve = AsyncMock(return_value=[fake_point])
-
-        fake_collection_ctx = MagicMock()
-        fake_collection_ctx.qdrant_client = fake_client
-        fake_collection_ctx.collection_name = "test_collection"
-        fake_collection_ctx.collection_exists = AsyncMock(return_value=True)
-
-        cm = MagicMock()
-        cm.__aenter__ = AsyncMock(return_value=fake_collection_ctx)
-        cm.__aexit__ = AsyncMock(return_value=None)
-        tool._collection = cm
-
-        chunks = await tool._fetch_chunks_by_ids(["chunk_x"])
-
-        fake_client.retrieve.assert_awaited_once_with(
-            collection_name="test_collection",
-            ids=["chunk_x"],
-            with_payload=True,
-            with_vectors=False,
-        )
-        assert len(chunks) == 1
-        assert chunks[0].id == "chunk_x"
-        assert chunks[0].content == "lazy content"
-        assert chunks[0].chunk_index == 3
-
-    @pytest.mark.asyncio
-    async def test_fetch_chunks_by_ids_skips_non_qdrant_providers(
-        self, tmp_path: Path
-    ) -> None:
-        """Only qdrant supports lazy fetch today; other providers return []."""
-        config = create_config(tmp_path)
-        tool = HierarchicalDocumentTool(config)
-        tool._provider = "chromadb"
-        tool._collection = MagicMock()
-
-        result = await tool._fetch_chunks_by_ids(["any_id"])
-
-        assert result == []
-
-
 class TestEnsureQdrantPayloadIndexes:
     """Tests for the qdrant payload-index workaround.
 
@@ -3116,8 +3044,9 @@ class TestEnsureQdrantPayloadIndexes:
 
         await tool._ensure_qdrant_payload_indexes(collection)
 
-        # 3 keyword fields + 1 full-text field = 4 calls
-        assert client.create_payload_index.await_count == 4
+        # 4 keyword fields (incl. source_path used by _check_if_already_ingested
+        # and _delete_file_records) + 1 full-text field = 5 calls
+        assert client.create_payload_index.await_count == 5
         called_fields = {
             kwargs["field_name"]
             for _, kwargs in client.create_payload_index.await_args_list
@@ -3126,6 +3055,7 @@ class TestEnsureQdrantPayloadIndexes:
             "section_id",
             "defined_term",
             "defined_term_normalized",
+            "source_path",
             "searchable_text",
         }
         assert tool._qdrant_indexes_ensured is True
@@ -3185,7 +3115,7 @@ class TestEnsureQdrantPayloadIndexes:
         # Doesn't raise even though every call fails.
         await tool._ensure_qdrant_payload_indexes(collection)
 
-        # All four attempts were made.
-        assert client.create_payload_index.await_count == 4
+        # All five attempts were made.
+        assert client.create_payload_index.await_count == 5
         # Flag still set (idempotency works even on failures).
         assert tool._qdrant_indexes_ensured is True

--- a/tests/unit/tools/test_hierarchical_document_tool.py
+++ b/tests/unit/tools/test_hierarchical_document_tool.py
@@ -17,6 +17,7 @@ semantic_kernel library is not available in the test environment.
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Save original modules before mocking (these will be restored after import)
@@ -2851,12 +2852,18 @@ class TestInitializeRebuild:
 
     @pytest.mark.asyncio
     async def test_initialize_rebuilds_when_files_skipped(self, tmp_path: Path) -> None:
-        """Test rebuild when provider is persistent and files were skipped."""
+        """Persistent non-native-hybrid provider reloads + rebuilds on skip.
+
+        Uses chromadb (in-process BM25 fallback path) because the in-memory
+        BM25 index dies with the process and must be rebuilt from the store
+        on restart. Native-hybrid providers (qdrant) skip this path — see
+        ``test_initialize_skips_reload_for_native_hybrid``.
+        """
         from holodeck.lib.structured_chunker import DocumentChunk
 
         config = create_config(tmp_path)
         tool = HierarchicalDocumentTool(config)
-        tool._provider = "qdrant"
+        tool._provider = "chromadb"
 
         stored_chunks = [
             DocumentChunk(
@@ -2893,6 +2900,48 @@ class TestInitializeRebuild:
             mock_load.assert_called_once()
             mock_build.assert_called_once()
             assert tool._chunks == stored_chunks
+            assert tool._initialized is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_skips_reload_for_native_hybrid(
+        self, tmp_path: Path
+    ) -> None:
+        """Native-hybrid providers (qdrant) skip the startup corpus reload.
+
+        Keyword retrieval happens inside the vector store, so the in-process
+        BM25/OpenSearch index is never read — loading every chunk into Python
+        on every restart is pure waste. Chunk lookup is lazy on query miss.
+        """
+        config = create_config(tmp_path)
+        tool = HierarchicalDocumentTool(config)
+        tool._provider = "qdrant"
+
+        with (
+            patch.object(tool, "_setup_collection"),
+            patch.object(
+                tool,
+                "_ingest_documents",
+                new_callable=AsyncMock,
+                return_value=2,  # files skipped — pre-fix this triggered reload
+            ),
+            patch.object(
+                tool,
+                "_load_chunks_from_store",
+                new_callable=AsyncMock,
+            ) as mock_load,
+            patch.object(
+                tool,
+                "_build_hybrid_indices",
+                new_callable=AsyncMock,
+            ) as mock_build,
+            patch.object(tool, "_setup_hybrid_executor") as mock_setup_executor,
+        ):
+            await tool.initialize()
+
+            mock_load.assert_not_called()
+            mock_build.assert_not_called()
+            # Executor is still set up (search routes through it)
+            mock_setup_executor.assert_called_once()
             assert tool._initialized is True
 
     @pytest.mark.asyncio
@@ -2964,6 +3013,77 @@ class TestInitializeRebuild:
             result = await tool._ingest_documents(force_ingest=False)
 
             assert result == 1  # One file discovered, one skipped
+
+
+class TestFetchChunksByIds:
+    """Lazy chunk-fetch path used by native-hybrid providers."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_chunks_by_ids_qdrant_retrieves_and_reconstructs(
+        self, tmp_path: Path
+    ) -> None:
+        """Qdrant lazy fetch issues a single retrieve(ids=...) and rebuilds chunks."""
+        config = create_config(tmp_path)
+        tool = HierarchicalDocumentTool(config)
+        tool._provider = "qdrant"
+
+        fake_point = SimpleNamespace(
+            id="chunk_x",
+            payload={
+                "id": "chunk_x",
+                "source_path": "/src.md",
+                "chunk_index": 3,
+                "content": "lazy content",
+                "parent_chain": "[]",
+                "section_id": "s",
+                "chunk_type": "content",
+                "cross_references": "[]",
+                "subsection_ids": "[]",
+                "contextualized_content": "",
+                "mtime": 0.0,
+                "defined_term": "",
+                "defined_term_normalized": "",
+            },
+        )
+        fake_client = MagicMock()
+        fake_client.retrieve = AsyncMock(return_value=[fake_point])
+
+        fake_collection_ctx = MagicMock()
+        fake_collection_ctx.qdrant_client = fake_client
+        fake_collection_ctx.collection_name = "test_collection"
+        fake_collection_ctx.collection_exists = AsyncMock(return_value=True)
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=fake_collection_ctx)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        tool._collection = cm
+
+        chunks = await tool._fetch_chunks_by_ids(["chunk_x"])
+
+        fake_client.retrieve.assert_awaited_once_with(
+            collection_name="test_collection",
+            ids=["chunk_x"],
+            with_payload=True,
+            with_vectors=False,
+        )
+        assert len(chunks) == 1
+        assert chunks[0].id == "chunk_x"
+        assert chunks[0].content == "lazy content"
+        assert chunks[0].chunk_index == 3
+
+    @pytest.mark.asyncio
+    async def test_fetch_chunks_by_ids_skips_non_qdrant_providers(
+        self, tmp_path: Path
+    ) -> None:
+        """Only qdrant supports lazy fetch today; other providers return []."""
+        config = create_config(tmp_path)
+        tool = HierarchicalDocumentTool(config)
+        tool._provider = "chromadb"
+        tool._collection = MagicMock()
+
+        result = await tool._fetch_chunks_by_ids(["any_id"])
+
+        assert result == []
 
 
 class TestEnsureQdrantPayloadIndexes:


### PR DESCRIPTION
## Summary

Three related fixes to `HierarchicalDocumentTool` on the qdrant native-hybrid path, discovered while validating the financial-assistant sample against Qdrant Cloud + Azure Container Apps.

- **Skip startup corpus reload** for `NATIVE_HYBRID_PROVIDERS` (qdrant, etc.). Pre-fix, every container start pulled every chunk into Python (~290 chunks here) just to populate `_chunk_map` — but native-hybrid never reads BM25 in-process. `_chunks` and the chunk_map start empty; init completes fast.
- **Inline-decode chunks from the native-hybrid query payload** instead of doing a follow-up `client.retrieve(ids=...)`. With the reload skip, the cache was perpetually empty, so every first query paid two qdrant calls. Plumb a `chunk_decoder` callback into `HybridSearchExecutor`; `_native_hybrid_search_qdrant` now uses `with_payload=True` and populates `_chunk_map` inline. `_fetch_chunks_by_ids` and `cache_chunk` deleted (net delete).
- **Index `source_path` as a qdrant payload field**. `_check_if_already_ingested` and `_delete_file_records` both filter on it, but it was missing from `_ensure_qdrant_payload_indexes`. Qdrant ≥1.18 rejects un-indexed filter fields with `400 Index required but not found`; both callers swallow the 400 and silently re-ingest + orphan chunks on every cold start. Discovered when cloud logs surfaced `POST /points/scroll → 400 Bad Request`.

Plus: a CLAUDE.md section codifying the end-to-end deploy validation loop (wheel → local base → deploy build → push → deploy run → AWP query → revert builder edit), and `docker/Dockerfile.local` which the loop relies on.

## Behavior change

| | Before | After |
|---|---|---|
| Cold-start reload | 290 chunks loaded from qdrant | 0 chunks (lazy) |
| BM25 build for native-hybrid | yes (unused) | skipped |
| First-query round-trips | 2 (search + retrieve) | 1 (search with_payload) |
| Steady-state round-trips | 1 | 1 |
| Reingestion check on qdrant ≥1.18 | 400 → re-ingest every restart | 200 → skip when up-to-date |

## Test plan

- [x] Unit tests: 224 pass (`pytest tests/unit/lib/test_keyword_search.py tests/unit/tools/test_hierarchical_document_tool.py -n auto`)
- [x] Pre-commit (black + ruff + mypy) clean
- [x] End-to-end against Azure Container Apps + Qdrant Cloud (financial-assistant sample): `/health` 200, ALXN/2007 rental query returned correct answer (`\$3,200 thousand`), `source_path` index now present in collection schema (`['defined_term', 'defined_term_normalized', 'searchable_text', 'section_id', 'source_path']`), `points_count=145` (no orphan accumulation), no `400 Bad Request` on `/points/scroll`
- [x] Cold-start latency on the redeployed cloud instance: 46s (was 66s on the previous revision — the saved round-trip per first-query is observable)

## Notes

- `Dockerfile.local` is a developer artifact for the validation loop, not part of any runtime path. It installs holodeck from `dist/*.whl` instead of PyPI so the loop can verify un-released source changes against the cloud.
- OpenSearch wipe-and-rebuild-every-startup (Phase 2) is still deferred to a follow-up PR — that one requires incremental indexing during `_ingest_documents`.