### PR TITLE
spec-034 P4: hybrid sessions + active-turn semaphore + llms.txt

### DIFF
--- a/docs/guides/claude-backend.md
+++ b/docs/guides/claude-backend.md
@@ -330,6 +330,99 @@ tools:
     source: ./data/research/
 ```
 
+## Production considerations: memory and concurrency
+
+The Claude backend runs each turn through a fresh Claude CLI **Node.js subprocess** spawned by `claude-agent-sdk` (see [Anthropic's hosting guide](https://docs.anthropic.com/en/api/agent-sdk/hosting)). This is the dominant memory cost in production and the binding constraint on concurrency. If you're deploying with `holodeck serve` to a container with a fixed memory limit (Azure Container Apps, Cloud Run, ECS Fargate, Kubernetes), the defaults below have been calibrated against real OOM data — but the right number for *your* agent depends on the tools it carries.
+
+### The model in one diagram
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Parent Python process (HoloDeck serve)                         │
+│  ┌─────────────────────┐    in-process MCP server               │
+│  │  AG-UI / REST API   │◄──── tool calls (vectorstore,          │
+│  │  + session store    │      hierarchical_document, function)  │
+│  └─────────────────────┘                                         │
+│        │ spawn (per turn)                                        │
+│        ▼                                                          │
+│  ┌─────────────────────┐    ┌─────────────────────┐              │
+│  │ Node CLI subprocess │    │ Node CLI subprocess │  …N turns    │
+│  │   (~300 MiB)        │    │   (~300 MiB)        │              │
+│  └─────────────────────┘    └─────────────────────┘              │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Two things to notice:
+
+1. **Tools run in the parent.** `create_sdk_mcp_server` hosts HoloDeck tools in the Python process and routes calls back to the subprocess via IPC. A heavy `hierarchical_document` tool with a qdrant client and a chunked corpus inflates the *parent* baseline, not the subprocess.
+2. **Subprocesses are per-turn, not per-session.** Spec 034 P4 ("Hybrid Sessions") tears the subprocess down at turn end and persists transcripts as JSONL on disk. Idle sessions cost ~30 MiB each (Python object + JSONL handle); concurrent **active turns** cost the full subprocess.
+
+This is why the concurrency cap is keyed on active turns, not open sessions.
+
+### Memory budget defaults
+
+| Component                          | Default | Configurable via                                  |
+|-----------------------------------|---------|---------------------------------------------------|
+| Parent baseline (server + tools + OTEL) | 400 MiB | (library constant)                          |
+| Per concurrent active turn        | 500 MiB | `claude.session_memory_estimate_mib`             |
+| Open session ceiling (idle slots) | 1000    | (library constant)                                |
+
+The active-turn cap is derived from the replica's cgroup memory limit:
+
+```
+max_concurrent_turns = (memory_limit - baseline) / per_turn_estimate
+```
+
+The 500 MiB default covers the ~300 MiB Node CLI steady state plus the simultaneous-startup spike (when N turns hit `serve` at once, V8 initial heap allocation peaks together) plus parent-side transient work during the turn (hybrid search, rerank, context generation). It was calibrated against the spec 034 P4 cloud validation where a 2 GiB Azure Container Apps replica OOM-killed at 4 concurrent turns and ran cleanly at 3 — `(2048-400)/500 = 3` matches that.
+
+### Sizing your replica
+
+| Replica memory | Derived turn cap | Notes                                           |
+|---------------|------------------|--------------------------------------------------|
+| 1 GiB         | 1                | Bare minimum; one turn at a time                 |
+| 2 GiB         | 3                | Default sample (financial-assistant) target     |
+| 4 GiB         | 7                | Comfortable production tier                      |
+| 8 GiB         | 15               | High-concurrency tier                            |
+
+If you need higher concurrency, scale horizontally (more replicas) rather than vertically — the SDK subprocess model means each turn is independent, so adding replicas linearly increases capacity.
+
+### Tuning `session_memory_estimate_mib`
+
+The default targets the median tool-heavy agent. Adjust it when:
+
+| Situation                                                       | Direction | Suggested override |
+|----------------------------------------------------------------|-----------|--------------------|
+| Thin agent — no vectorstore, no hierarchical_document, no MCP  | Lower     | `300` (yields cap=5 on 2 GiB) |
+| Heavy retrieval — large hybrid index, in-process rerank        | Default   | `500`              |
+| Embedded models — local rerank model, ONNX, sentence-transformers | Higher | `700–900`         |
+| Multiple MCP servers with persistent state                     | Higher    | `600–700`          |
+
+```yaml
+claude:
+  session_memory_estimate_mib: 700   # tune for your agent's tool footprint
+```
+
+### Excess-capacity behaviour
+
+When concurrent active turns exceed the cap, the serve layer immediately returns HTTP 429 with a `Retry-After` body. It does **not** queue requests — Anthropic's hosting guidance recommends shedding load over buffering, because subprocess startup is expensive and a queued request that times out at the upstream is worse than a fast 429 that the client can retry with backoff.
+
+### Observability
+
+When OpenTelemetry is enabled (`observability.enabled: true`), the serve layer emits:
+
+- `holodeck.serve.active_turns` (gauge) — current in-flight count
+- `holodeck.serve.turn_rejections_total` (counter) — 429s due to the cap
+- `holodeck.serve.session_count` (gauge) — open sessions (idle + active)
+
+Alert on `turn_rejections_total` rate > 0 sustained for more than a minute — it indicates either undersized replicas or a need to scale horizontally.
+
+!!! warning "Azure WorkingSetBytes is 1-minute averaged"
+    Cloud-provider memory metrics typically report 1-minute averages, which mask the instantaneous peak during simultaneous turn startup. If you're sizing from Azure metrics, expect the real peak to be 1.5–2× the average. The 500 MiB default already accounts for this; if you're tuning from your own observed averages, multiply by ~1.7 before dividing into headroom.
+
+### Anthropic's own guidance
+
+Anthropic's [SDK hosting documentation](https://docs.anthropic.com/en/api/agent-sdk/hosting) recommends **1 GiB RAM per agent instance** as a conservative starting point — that includes the parent process. HoloDeck's 400 MiB parent baseline + 500 MiB per turn lands right on that number for cap=1 and scales linearly from there. There is no "shared subprocess pool" pattern documented in the SDK; each turn gets its own subprocess by design.
+
 ## Configuration reference
 
 ### `model.*` fields
@@ -357,6 +450,8 @@ tools:
 | `file_system`        | object         | -             | `{ read: bool, write: bool, edit: bool }`                                |
 | `agents`             | map<str, spec> | -             | Named subagents (see Subagents above)                                    |
 | `allowed_tools`      | list of strings | all tools    | Explicit tool allowlist                                                  |
+| `session_memory_estimate_mib` | int (50–2000) | `500`  | Per-active-turn memory budget; drives the concurrency cap (see [Production considerations](#production-considerations-memory-and-concurrency)) |
+| `max_concurrent_sessions` | int (1–500) | derived    | Hard cap on concurrent active turns; auto-derived from cgroup memory when omitted |
 
 ### Available models
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,38 @@ plugins:
               - "!^_"  # private
             show_root_heading: true
             show_root_full_path: false
+  - llmstxt:
+      markdown_description: |
+        HoloDeck is an open-source, no-code platform for building, testing,
+        and deploying AI agents via YAML. This index points LLMs at the
+        canonical docs for the CLI, agent schema, backends (Claude / SK),
+        tools (vectorstore, MCP, hierarchical_document), evaluations,
+        and the agent server.
+      full_output: llms-full.txt
+      sections:
+        Getting Started:
+          - getting-started/installation.md
+          - getting-started/quickstart.md
+        Guides:
+          - guides/agent-configuration.md
+          - guides/llm-providers.md
+          - guides/claude-backend.md
+          - guides/semantic-kernel-backend.md
+          - guides/tools.md
+          - guides/mcp-cli.md
+          - guides/vector-stores.md
+          - guides/evaluations.md
+          - guides/dashboard.md
+          - guides/global-config.md
+          - guides/file-references.md
+          - guides/serve.md
+          - guides/deployment.md
+          - guides/observability.md
+        API Reference:
+          - api/*.md
+        Developer:
+          - contributing.md
+          - CHANGELOG.md
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "detect-secrets>=1.4.0",
     "types-PyYAML>=6.0.12",
     "mkdocstrings[python]>=0.25.0",
+    "mkdocs-llmstxt>=0.4",
 ]
 
 # Vector store providers (install only what you need)

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -218,6 +218,19 @@
           "minimum": 1,
           "description": "Maximum agent loop iterations (null = SDK default)"
         },
+        "max_concurrent_sessions": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100,
+          "description": "Maximum concurrent Claude SDK subprocesses per serve instance. When unset, the serve layer derives the cap from the replica's cgroup memory limit divided by session_memory_estimate_mib (spec 034 P1a)."
+        },
+        "session_memory_estimate_mib": {
+          "type": "integer",
+          "minimum": 50,
+          "maximum": 2000,
+          "default": 200,
+          "description": "Estimated resident memory (MiB) per active Claude SDK subprocess, used to derive max_concurrent_sessions from the replica's cgroup memory limit. Default 200 MiB (spec 034 P1a)."
+        },
         "extended_thinking": {
           "$ref": "#/$defs/ExtendedThinkingConfig",
           "description": "Extended reasoning (deep thinking) configuration"

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -263,6 +263,11 @@
           "type": ["array", "null"],
           "items": { "type": "string" },
           "description": "Tools that must never be used; takes precedence over allowed_tools"
+        },
+        "i_understand_this_is_unsafe": {
+          "type": "boolean",
+          "default": false,
+          "description": "Acknowledge that permission_mode=acceptAll disables the Claude SDK permission system entirely, allowing any tool (including Bash, Write, Edit, WebFetch) to execute without restriction. Required to use permission_mode=acceptAll. Prefer declaring specific tools via bash, file_system, web_search, or allowed_tools instead."
         }
       },
       "description": "Claude Agent SDK-specific settings. All capabilities default to disabled (least-privilege)."

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -221,7 +221,7 @@
         "max_concurrent_sessions": {
           "type": ["integer", "null"],
           "minimum": 1,
-          "maximum": 100,
+          "maximum": 500,
           "description": "Maximum concurrent Claude SDK subprocesses per serve instance. When unset, the serve layer derives the cap from the replica's cgroup memory limit divided by session_memory_estimate_mib (spec 034 P1a)."
         },
         "session_memory_estimate_mib": {

--- a/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
+++ b/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
@@ -98,7 +98,7 @@ P1 is one focused PR (and probably ships under a feature branch within days). P2
 
 | Phase | Status | Branch / PR | Notes |
 |-------|--------|-------------|-------|
-| P1a — OOM stability | ✅ shipped | `feature/034-p1-stability-permissions` (commits `a391c7d`, `b344684`) | ACA defaults bumped, memory-derived session cap, 429 backpressure, readiness probe. Memory derivation (not CPU) confirmed in ACA via `Claude cgroup memory limit: 2147483648 bytes` startup log. |
+| P1a — OOM stability | ✅ shipped | `feature/034-p1-stability-permissions` (commits `a391c7d`, `b344684`, `777ece1`) | ACA defaults bumped, memory-derived session cap, 429 backpressure, readiness probe. Memory derivation (not CPU) confirmed in ACA via `Claude cgroup memory limit: 2147483648 bytes` startup log. `max_concurrent_sessions` upper bound widened to 500 as an explicit-override escape hatch for warm-only workloads (P4 makes this a concurrent-turn cap). |
 | P1b — Permission posture | ✅ shipped | same branch | `manual → acceptEdits` mapping in serve, auto-disallow risky built-ins, `i_understand_this_is_unsafe` gate on `acceptAll`, silent test-mode escalation removed. |
 | P2a — Container hardening | ⏳ not started | — | — |
 | P2b — Prompt-injection defenses | ⏳ not started | — | — |

--- a/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
+++ b/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
@@ -1,0 +1,713 @@
+# Production Hardening for Claude-Backed Agents — Design
+
+**Status:** Draft for review
+**Date:** 2026-05-18
+**Author:** justinbarias (with Claude)
+**Related:** `specs/021-claude-agent-sdk`, `specs/024-claude-serve-deploy`, `specs/028-yaml-hooks-system`
+**External refs:** [Anthropic — Hosting the Agent SDK](https://code.claude.com/docs/en/agent-sdk/hosting), [Anthropic — Securely Deploying AI Agents](https://code.claude.com/docs/en/agent-sdk/secure-deployment)
+
+## Motivation
+
+HoloDeck ships a Claude backend that wraps the Claude Agent SDK and exposes it over AG-UI for chat and over REST for evaluation. In practice, the SDK is not a stateless API call — it spawns a long-running Claude Code CLI subprocess per session, holds shell state, and consumes ~150–300 MiB resident per process. We have been sizing and securing it as if it were a stateless API call.
+
+The financial-assistant sample exposed three failure modes in production:
+
+1. **Stability.** Two concurrent AG-UI sessions on a 1 GiB / 0.5 CPU replica are enough to cgroup-OOM the container. Each session spawns its own SDK subprocess and `WorkingSetBytes` spikes faster than ACA's 1-minute metric resolution can observe. We had been treating this as a transient bug; it is structural.
+2. **Permission posture.** HoloDeck's `permission_mode: acceptAll` maps to the SDK's `bypassPermissions`, which disables the SDK permission system entirely. The agent has Bash, Write, Edit, WebFetch available by default. A prompt-injection payload in any document the agent reads can — today — issue arbitrary shell commands inside the container.
+3. **Credential surface.** OAuth token, Azure key, Qdrant JWT live in container env vars and are inherited by every SDK subprocess and every tool subprocess. There is no credential boundary; there is no egress allowlist; there is no redaction on tool outputs that enter the model context or OTel traces.
+
+Anthropic's [hosting guide](https://code.claude.com/docs/en/agent-sdk/hosting) and [secure-deployment guide](https://code.claude.com/docs/en/agent-sdk/secure-deployment) describe the patterns and isolation primitives needed to fix all three. This spec aligns HoloDeck with those guides and ships secure-by-default container deployments.
+
+The design is structured in four phases so that the parts that stop the bleeding ship first, and the parts that require multi-week infra work are scoped and isolated.
+
+The key constraints driving the design:
+
+1. **Stability fix is non-negotiable and ships first.** Everything else waits behind the OOM fix.
+2. **Secure-by-default, opt-out for permissive.** Operators inherit a permission posture that fails closed. The escape hatch exists, but its name signals risk and the warning is loud.
+3. **No required user YAML changes for P1 and P2.** New defaults are inferred from existing fields. Operators who want to override get a new schema field; they do not have to use it.
+4. **Defense in depth.** Container hardening, permission allowlists, hook-based redaction, and an opt-in egress proxy each address a different layer. None replaces the others.
+5. **The egress-proxy / hardened-profile work is genuinely larger.** It is gated behind `deployment.security_profile: hardened` so the simpler P1/P2 work can ship without waiting on it.
+
+## What's broken today (concrete)
+
+| Layer | Today | What that means |
+|---|---|---|
+| Replica sizing | ACA defaults from operator YAML; financial-assistant sample is `cpu: 0.5 / memory: 1Gi` | Two concurrent SDK subprocesses can exceed the cgroup memory limit between metric samples; exit-137 with no metric warning |
+| Concurrent session cap | Static default `10` in `server.py:121` | Decoupled from replica resources; cap doesn't help small replicas and doesn't scale with large ones |
+| `max_turns` | Defaults to whatever the SDK does when not set | SDK hosting FAQ explicitly recommends bounding this |
+| Permission mode | `acceptAll` → `bypassPermissions` (`validators.py:307`) | Permission system disabled entirely; Bash/Write/Edit/WebFetch unconditionally allowed |
+| Built-in tool allowlist | Whatever the SDK ships with by default | The SDK ships with Bash/Write/Edit/WebFetch; we do not restrict them |
+| Container user | `holodeck` UID 1000 (non-root) ✓ | Good — keep |
+| Container fs | RW root, RW agent corpus | Agent can persist changes anywhere under `/app`; no read-only enforcement |
+| Container caps | Default | No `--cap-drop ALL`; no `no-new-privileges` |
+| Node.js | Always installed in generated Dockerfile | SDK ships its own bundled CLI; the only reason to install Node.js is for stdio MCP servers that need it |
+| Readiness | Liveness only | Replica accepts traffic before tool init completes; first request races init |
+| Ingress | `ingress_external` per YAML; samples set `true` | Easy to leave external by accident; no warning at deploy time |
+| Hooks | YAML hook surface exists (spec 028); no HoloDeck-provided defaults | Prompt-injection defenses are entirely on the operator |
+| Credentials | All in container env, inherited by every subprocess | No proxy; no allowlist; no redaction layer |
+| OTel | `capture_content: true` captures everything including any credential-shaped strings in tool outputs | Traces leak whatever the tool returned |
+
+The plan replaces each row of "Today" with a specific change, grouped into four phases.
+
+## Phase overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ P1 — Stop the OOM                              (days, ships first)  │
+│   • ACA defaults: 1 CPU / 2 GiB for Claude agents                   │
+│   • max_concurrent_sessions = floor(cpu_cores × 2)                  │
+│   • 429 with Retry-After on overflow                                │
+│   • max_turns = 20 when unset                                       │
+│   • Readiness probe distinct from liveness                          │
+│   • Echo resolved limits at `deploy run`                            │
+├─────────────────────────────────────────────────────────────────────┤
+│ P1 — Permission posture                        (days, ships with ↑) │
+│   • auto-disallow Bash/Write/Edit/WebFetch unless declared          │
+│   • manual → SDK `plan` mode in serve context                       │
+│   • deprecate acceptAll; require explicit unsafe opt-in             │
+│   • new `claude.permissions` schema field                           │
+├─────────────────────────────────────────────────────────────────────┤
+│ P2 — Container runtime                         (1–2 sprints)        │
+│   • generated Dockerfile drops Node.js when not needed              │
+│   • read-only corpus dirs; writable scratch via tmpfs               │
+│   • ACA securityContext: drop caps, readOnlyRootFilesystem          │
+│   • ingress defaults to internal; opt-in for external               │
+├─────────────────────────────────────────────────────────────────────┤
+│ P2 — Prompt-injection defenses                 (1–2 sprints)        │
+│   • PreToolUse Bash AST deny list (HoloDeck-provided hook)          │
+│   • PostToolUse credential redaction in tool outputs                │
+│   • OTel attribute redaction independent of hooks                   │
+├─────────────────────────────────────────────────────────────────────┤
+│ P3 — Credential boundary, opt-in               (multi-week)         │
+│   • `deployment.security_profile: hardened`                         │
+│   • Envoy sidecar holds credentials; agent has none                 │
+│   • Domain allowlist derived from agent.yaml                        │
+│   • ANTHROPIC_BASE_URL → localhost sidecar                          │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+P1 is one focused PR (and probably ships under a feature branch within days). P2 and P3 land independently after P1 stabilises trunk.
+
+## Phase 1a — Stop the OOM
+
+### Architecture: sizing follows the SDK's documented unit
+
+The hosting guide is explicit: "Recommended: 1 GiB RAM, 5 GiB of disk, and 1 CPU. Vary this based on your task as needed." That recommendation describes one SDK instance, not one container. With Pattern 2 (long-running, multi-process) — which is what HoloDeck does today — the container has to fit one or more SDK subprocesses plus the serve process plus tool subprocesses. The financial-assistant 0.5 CPU / 1 GiB sizing is below the documented per-instance minimum, before you even count the serve overhead.
+
+The fix is to make sizing-driven decisions the default:
+
+```
+replica_cpu (from agent.yaml or ACA default)
+       │
+       ▼
+default replica_memory = max(2 GiB, 2 × replica_cpu Gi)   # ACA constraint
+       │
+       ▼
+default max_concurrent_sessions = max(1, floor(replica_cpu × 2))
+       │
+       ▼
+echo resolved values at `holodeck deploy run` time
+```
+
+For a 1 CPU replica → 2 GiB memory, 2 concurrent sessions max. For a 2 CPU replica → 4 GiB, 4 sessions. The "× 2" is calibrated against the ~300 MiB-per-subprocess observation from the financial-assistant investigation, plus headroom for the serve process and tool subprocesses. If real-world numbers diverge materially the multiplier is one constant to tune.
+
+### Why "× 2" and not something smarter
+
+The right answer is a per-replica memory accountant that reads cgroup pressure and gates new sessions. That is a separate feature. For now, "× 2" is honest: it is a heuristic, it is documented, and it is checkable at deploy time because we echo the resolved cap.
+
+### Backpressure: 429 with Retry-After
+
+Today the serve layer accepts a request, forwards to `agui.py:_get_or_create_session()`, and if a new SDK subprocess can't be created the failure surfaces as an OOM mid-request. The fix is an `asyncio.Semaphore(max_concurrent_sessions)` wrapping session creation. When the cap is hit:
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 5
+Content-Type: application/problem+json
+
+{
+  "type": "https://holodeck.dev/errors/session-cap-exceeded",
+  "title": "Session limit reached",
+  "status": 429,
+  "detail": "This replica is serving the maximum of 2 concurrent sessions. Retry shortly.",
+  "session_cap": 2,
+  "in_flight_sessions": 2
+}
+```
+
+The semaphore is per-replica. ACA's autoscaler ramps replicas; the operator sees backpressure as 429s, not OOM crashes.
+
+### `max_turns` default
+
+The hosting FAQ: *"An agent session will not timeout, but consider setting a 'maxTurns' property to prevent Claude from getting stuck in a loop."* When unset, we default to 20 in `build_options()`. Operators can override per-agent. The number is conservative enough that legitimate multi-step ConvFinQA reasoning is unaffected and low enough to bound runaway tool-call loops.
+
+### Readiness probe distinct from liveness
+
+Today the generated ACA template emits a single HTTP probe at `/health` used for both liveness and readiness implicitly. Tool init (qdrant connection, payload index check, OpenSearch wipe-and-rebuild for relevant providers) runs at startup before any traffic should be routed.
+
+The change:
+
+- Liveness probe stays at `/health` — confirms the process is alive.
+- New readiness probe at `/ready` — returns 200 only after `tool_init_manager.py` reports all tools initialized.
+
+ACA routes traffic only to ready replicas. First requests no longer race tool init.
+
+### Operator-visible verification
+
+`holodeck deploy run` prints the resolved limits:
+
+```
+Deploying financial-assistant to Container App 'financial-assistant'
+  Replica: 1.0 CPU / 2 GiB memory
+  Concurrent sessions per replica: 2 (derived from CPU)
+  Max turns per session: 20 (default)
+  Ingress: internal
+  Readiness probe: /ready (initial delay 5s)
+```
+
+If the operator's sizing is silently below the SDK guidance — e.g. they set `cpu: 0.25` — we emit a warning:
+
+```
+WARNING: replica CPU (0.25) is below Anthropic's recommended minimum of 1 CPU per SDK instance.
+  Concurrent sessions will be capped at 1. Consider increasing `deployment.target.azure.cpu`.
+```
+
+### What "stop the OOM" does *not* fix
+
+- Burst traffic past `max_replicas × max_concurrent_sessions`. The 429 surfaces this honestly; raising replica count is on the operator.
+- One absurdly large prompt that single-handedly OOMs a replica. The semaphore caps process count, not per-process memory.
+- Cold-start latency. P1 surfaces a readiness probe but doesn't make init faster. That's separate work folded into P2.
+
+## Phase 1b — Permission posture
+
+### The current default is unsafe
+
+`validators.py:_build_permission_mode()` maps:
+
+| HoloDeck mode | SDK literal | Meaning |
+|---|---|---|
+| `manual` | `default` | SDK prompts the user before each tool call |
+| `acceptEdits` | `acceptEdits` | SDK auto-approves edits, prompts for others |
+| `acceptAll` | `bypassPermissions` | SDK permission system disabled entirely |
+
+In `serve` mode there is no operator at the terminal, so `manual` → `default` effectively wedges the SDK on the first tool call. That has pushed operators toward `acceptAll`, which disables permissions entirely. The current path of least resistance is the least safe one.
+
+### The fix
+
+```
+                  ┌───────────────────────────────────┐
+                  │ HoloDeck permission_mode          │
+                  └───────────────────────────────────┘
+                            │
+        ┌───────────────────┼────────────────────────┐
+        │                   │                        │
+        ▼                   ▼                        ▼
+   `manual`            `acceptEdits`             `acceptAll`
+        │                   │                        │
+   serve mode?              ▼                   has top-level
+        ├─ yes → SDK   SDK `acceptEdits`        `claude.i_understand_
+        │  `plan`                                this_is_unsafe: true`?
+        └─ no  → SDK                            ┌─ yes → SDK `bypassPermissions`
+           `default`                            │        + loud warning at load
+                                                └─ no  → load fails with migration error
+```
+
+In parallel, regardless of `permission_mode`, we auto-populate `disallowed_tools` with `{Bash, Write, Edit, WebFetch}` for any not declared in `agent.tools`. The SDK ships with these tools available; HoloDeck removes them unless the operator explicitly asked for them.
+
+### New `claude.permissions` schema block
+
+Operators who want explicit control get a typed field instead of having to read the validator source to learn what's auto-derived:
+
+```yaml
+claude:
+  permissions:
+    allowed_tools: [Read, Grep]
+    disallowed_tools: [Bash, Write, Edit, WebFetch]
+    permission_mode: plan         # plan | acceptEdits | manual
+  # Legacy escape hatch — required when permission_mode resolves to bypassPermissions
+  i_understand_this_is_unsafe: true
+```
+
+When `claude.permissions.*` is set, the explicit values win over the auto-derivation. When the block is absent, the auto-derivation runs.
+
+### Migration path
+
+The change is breaking for one specific case: an agent that today uses `acceptAll` and does not declare its built-in tools. On load:
+
+```
+ERROR loading agent 'my-agent':
+  permission_mode 'acceptAll' is deprecated because it disables the Claude SDK
+  permission system entirely. This is the most direct path from prompt-injection
+  to arbitrary tool execution.
+
+  To migrate:
+    1. List the tools your agent actually needs in `agent.tools` (recommended), or
+    2. Add `claude.i_understand_this_is_unsafe: true` to keep the legacy behavior.
+
+  See: docs/security/permissions.md
+```
+
+The legacy escape hatch keeps working; using it requires opting in by name.
+
+### What permission posture does *not* fix
+
+- The SDK still runs with whatever filesystem and network the container gives it. Permissions are an SDK-level allowlist, not an OS-level sandbox. Container hardening (P2) and the egress proxy (P3) layer in on top.
+- Prompt-injection payloads that target the *allowed* tools (e.g. an agent that legitimately has `Read` and gets instructed to read `/etc/passwd`) are not stopped by the allowlist. The hook layer (P2) is the next line of defense.
+
+## Phase 2a — Container runtime hardening
+
+### Generated Dockerfile changes
+
+`src/holodeck/deploy/dockerfile.py` produces the per-agent Dockerfile that `holodeck deploy build` consumes. The current template:
+
+- Always installs Node.js (40–80 MiB image bloat).
+- COPYs the agent corpus owned by `holodeck:holodeck` with default permissions, so the runtime user can write to it.
+- Sets `WORKDIR /app` with no explicit read-only enforcement.
+
+The hosting doc is explicit: *"Both SDK packages bundle a native Claude Code binary for the host platform, so no separate Claude Code or Node.js install is needed for the spawned CLI."* The only reason HoloDeck needs Node.js is when an MCP server's `command` requires it (typically `node` or `npx`).
+
+Changes:
+
+```dockerfile
+# Conditional: omit when agent.yaml has no Node-requiring stdio MCP server
+RUN apt-get update && apt-get install -y nodejs npm   # ← gated
+
+# Corpus dirs become root-owned and writable only via tmpfs scratch
+COPY --chown=root:root data /app/data
+COPY --chown=root:root instructions /app/instructions
+RUN chmod -R a-w /app/data /app/instructions
+
+# SDK scratch directory — writable, mounted as tmpfs by ACA
+RUN mkdir -p /var/holodeck/work && chown holodeck:holodeck /var/holodeck/work
+```
+
+The runtime user (`holodeck`) can read corpus files but not modify them. Anything the SDK or its tools need to write goes under `/var/holodeck/work`, which ACA mounts as tmpfs.
+
+### ACA template changes
+
+`src/holodeck/deploy/deployers/azure_containerapps.py` emits the Container App spec. Today it sets `cpu`/`memory`/`min_replicas`/`max_replicas` from agent.yaml. The new template adds:
+
+```python
+container_spec = {
+    "name": agent_name,
+    "image": image_ref,
+    "resources": {"cpu": cpu, "memory": memory},
+    "probes": [
+        {"type": "Liveness",   "httpGet": {"path": "/health"}, ...},
+        {"type": "Readiness",  "httpGet": {"path": "/ready"},  ...},  # NEW
+    ],
+    # NEW securityContext block — degrades gracefully to what ACA supports
+    "securityContext": {
+        "runAsNonRoot": True,
+        "readOnlyRootFilesystem": True,
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+    },
+    # NEW writable volumes mounted as tmpfs by ACA
+    "volumeMounts": [
+        {"volumeName": "tmp",         "mountPath": "/tmp"},
+        {"volumeName": "sdk-scratch", "mountPath": "/var/holodeck/work"},
+    ],
+}
+```
+
+ACA's surface is a subset of full Kubernetes; not every property maps 1:1. Where ACA degrades gracefully (e.g. `capabilities.drop`), we use the supported form. Where ACA doesn't expose a primitive (e.g. seccomp profiles), we document the gap and accept it. The opt-in `security_profile: hardened` path (P3) covers the cases ACA can't, by adding an Envoy sidecar.
+
+### Ingress defaults to internal
+
+Today `deployment.target.azure.ingress_external` defaults to whatever the operator writes. Sample agents set it to `true`. New default:
+
+```
+ingress_external: false
+```
+
+If the operator sets it to `true`, `holodeck deploy run` emits:
+
+```
+WARNING: deploying with PUBLIC ingress (ingress_external: true).
+  This Container App will be reachable from the public internet at:
+    https://<fqdn>
+  If this was unintentional, set `deployment.target.azure.ingress_external: false`
+  in agent.yaml and redeploy.
+```
+
+The warning is non-fatal; it just makes the choice deliberate.
+
+## Phase 2b — Prompt-injection defenses
+
+### The hook surface is already there
+
+Spec 028 (`yaml-hooks-system`) shipped the YAML surface for user-defined hooks. `_options_with_hooks()` in `claude_backend.py:601` merges them into `ClaudeAgentOptions.hooks`. P2 plumbs HoloDeck-provided default hooks into that pipeline ahead of any user hooks.
+
+```
+SDK PreToolUse event
+   │
+   ▼
+┌────────────────────────────────────┐
+│ HoloDeck default hooks (this spec) │
+│  • Bash AST deny list              │
+└────────────────────────────────────┘
+   │
+   ▼
+┌────────────────────────────────────┐
+│ User-defined hooks (spec 028)       │
+└────────────────────────────────────┘
+   │
+   ▼
+Tool call proceeds (or is denied)
+```
+
+The default hook chain is opt-out via `claude.disable_default_hooks: true`. We do not let it be silently disabled — disabling it emits a load-time warning naming the agent and the hooks being disabled.
+
+### Default hook 1 — Bash AST deny list (PreToolUse)
+
+The secure-deployment doc describes the SDK's built-in command parsing: *"Before executing bash commands, Claude Code parses them into an AST and matches the result against your permission rules."* HoloDeck adds a default rule set:
+
+| Pattern | Reason |
+|---|---|
+| `eval` (always requires approval per SDK) | We emit a structured rejection rather than letting the SDK prompt |
+| Piped `curl ... | sh`, `curl ... | bash`, `wget ... | sh` | Remote-code-execution vector |
+| `bash -c` with command substitution `$(...)` or backticks | Dynamic command construction defeats the deny list |
+| Raw `sudo` | No legitimate use inside a non-root container; defends against suid bugs |
+| `nc`, `ncat`, `socat` | Reverse-shell vector |
+
+When the AST matches, the hook returns a structured rejection that surfaces in OTel as a `tool.denied` span with the matched pattern:
+
+```json
+{
+  "decision": "block",
+  "reason": "Bash command rejected by HoloDeck default deny list",
+  "matched_rule": "curl_pipe_sh",
+  "stop_reason": "default_hook"
+}
+```
+
+This is opt-out, not configurable in-depth. Operators who need a different rule set use the user-hook surface (spec 028) and set `claude.disable_default_hooks: true`.
+
+### Default hook 2 — Credential redaction (PostToolUse)
+
+Tool outputs flow back into the model context. Today nothing redacts them. The default PostToolUse hook scans `tool_result.content` for credential-shaped patterns and replaces them with `[REDACTED:<kind>]`:
+
+| Pattern | Replaced with |
+|---|---|
+| `sk-ant-api03-…` | `[REDACTED:anthropic-key]` |
+| `AKIA[0-9A-Z]{16}` | `[REDACTED:aws-access-key]` |
+| `ghp_[A-Za-z0-9]{36}` | `[REDACTED:github-token]` |
+| JWT (`eyJ…\.…\.…`) | `[REDACTED:jwt]` |
+| `Bearer [A-Za-z0-9_\-\.]+` in HTTP headers | `Bearer [REDACTED]` |
+
+These are heuristics — a false positive risk exists. Operators can opt out per-tool or globally via the user-hook surface. The patterns themselves are a versioned constant; we don't expose them as configuration in v1.
+
+### OTel attribute redaction (independent of hooks)
+
+The hook above only protects the model context. OTel traces with `capture_content: true` capture tool outputs separately, before any hook fires. We add a redaction pass inside `otel_bridge.py` that applies the same patterns to span attributes whose names start with `tool.output` or `tool.input`.
+
+This is independent of `disable_default_hooks` — operators cannot accidentally disable trace redaction by disabling hooks.
+
+### What hooks do *not* fix
+
+- A determined attacker who base64-encodes their payload defeats both the Bash deny list (no AST match) and the credential redaction (no pattern match). Defense in depth means the next layer (P3 egress proxy) is what stops the post-exploitation step.
+- A legitimate tool output that contains a credential-shaped string the agent needs. Operators with this case opt out per-tool or move to the hardened profile (P3) where the credential never enters the agent in the first place.
+
+## Phase 3 — Credential boundary (opt-in)
+
+### When this phase applies
+
+Phases 1–2 close the most common failure modes for single-tenant deployments. They do not move credentials out of the agent's environment. The secure-deployment doc's "proxy pattern" is the answer when:
+
+- The agent processes content from multiple tenants in the same container.
+- The agent reads untrusted documents whose contents could include prompt-injection payloads designed to exfiltrate credentials.
+- Compliance requires that credentials never appear in the agent's process environment.
+
+Operators who don't have those constraints stay on the default profile.
+
+### Architecture
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ Azure Container App (single revision)                          │
+│                                                                │
+│  ┌─────────────────────┐         ┌──────────────────────────┐ │
+│  │ agent container      │         │ envoy sidecar             │ │
+│  │  • holodeck serve    │         │  • credential_injector    │ │
+│  │  • no creds in env   │  HTTP   │  • domain allowlist       │ │
+│  │  • ANTHROPIC_BASE_URL├────────►│  • secret-mounted          │ │
+│  │    = localhost:8081  │ localhost│   credentials             │ │
+│  │  • HTTP_PROXY=       │         │                           │ │
+│  │    localhost:8081    │         │                           │ │
+│  └─────────────────────┘         └────────────┬──────────────┘ │
+│                                                │                │
+└────────────────────────────────────────────────┼────────────────┘
+                                                 ▼
+                                       api.anthropic.com
+                                       configured MCP HTTP endpoints
+                                       embedding provider endpoint
+                                       (everything else: rejected)
+```
+
+The agent container has zero secret-bearing env vars. The Envoy sidecar holds them (mounted as Azure Container App secrets, mounted only to the sidecar). The sidecar enforces a domain allowlist derived from the agent.yaml at deploy time:
+
+- `api.anthropic.com` (always)
+- Embedding provider endpoint (from `agent.embedding_provider.endpoint`)
+- Each MCP server's HTTP endpoint (from `agent.tools[*].connection_url` for MCP HTTP/SSE)
+- Nothing else
+
+### Opt-in: `deployment.security_profile`
+
+```yaml
+deployment:
+  security_profile: hardened       # default | hardened
+  target:
+    provider: azure
+    azure:
+      cpu: 1.0
+      memory: 2Gi
+```
+
+When `security_profile: hardened`, `holodeck deploy run`:
+
+1. Reads the agent.yaml and builds the domain allowlist.
+2. Emits an Envoy config (`envoy.yaml`) as a Container App config map.
+3. Provisions the Container App with two containers (agent + envoy sidecar) sharing localhost.
+4. Moves credentials from agent container env to Container App secrets mounted only to the sidecar.
+5. Sets `ANTHROPIC_BASE_URL=http://localhost:<envoy-port>` and `HTTPS_PROXY=http://localhost:<envoy-port>` in the agent container.
+
+The Claude backend, on detecting `security_profile: hardened`, requires `ANTHROPIC_BASE_URL` to be set — there is no silent fallback to direct Anthropic API calls.
+
+### What the proxy pattern does *not* fix
+
+- **TLS interception of arbitrary HTTPS.** The doc is clear: for non-Anthropic HTTPS without a TLS-terminating proxy, the sidecar only sees opaque TLS tunnels. We don't ship a CA-injection setup in v1. MCP servers needed at the application layer are handled via the `custom tool` pattern from the secure-deployment doc — they expose an HTTP endpoint inside the sidecar and the agent calls them via plain HTTP.
+- **Multi-tenant-per-container isolation.** This profile assumes one tenant per replica. Multiple end-customers concurrently inside the same container with hard isolation between them is a separate spec (would require per-session ephemeral containers, Pattern 1 in the hosting doc).
+
+## What we are deliberately *not* doing in v1
+
+- **Per-session ephemeral containers (Pattern 1).** That's the strongest isolation pattern in the hosting doc but requires a new deployer (Modal, Fly Machines, etc.) and per-session billing infrastructure. Documented as a follow-up spec.
+- **gVisor / Firecracker runtime.** ACA doesn't support gVisor. Self-hosted Docker users could opt into `runsc`, but we don't template it.
+- **SDK process pooling across sessions.** The hosting doc's Pattern 4 ("multiple Claude Agent SDK processes in one global container") is what we already do; *reusing* one warm process across multiple sessions would let one container serve >N concurrent threads. Real win, but it's a redesign of `claude_backend.py`'s session model — separate spec.
+- **Statistical anomaly detection on tool calls.** Out of scope; the hook layer is the right abstraction for layering this later.
+- **Auto-derived domain allowlist from prompt content.** P3 derives the allowlist from explicit YAML fields. Inferring it from prompt text or runtime behavior is brittle and is not what the secure-deployment doc recommends.
+- **Per-tool credential mapping in default profile.** P3 moves credentials behind the sidecar. The default profile keeps the existing env-var model; we don't try to half-implement credential separation.
+- **Replacing the existing YAML hook surface.** Spec 028 stays as-is. P2's defaults plug into the same chain.
+
+## Cost reality
+
+P1 changes are nearly free at runtime: a semaphore acquisition, a probe endpoint, a default in `build_options()`. Operator-visible cost is the bumped replica spec (1 CPU → 2 GiB), which roughly doubles the per-replica ACA bill from ~$0.05/hr to ~$0.10/hr on consumption profile. ACA scale-to-zero is preserved.
+
+P2 changes are also free at runtime: dropping Node.js shrinks the image (~50 MiB → faster pulls, faster cold starts), hook execution is a few microseconds per tool call, and OTel redaction is a regex pass per span attribute.
+
+P3 adds the Envoy sidecar to every replica, roughly doubling per-replica memory (~50–80 MiB for Envoy) and adding ~1 ms latency per upstream request. This is why it is opt-in.
+
+## How HoloDeck's structure changes
+
+### Schema additions
+
+New fields under `claude:`:
+
+```yaml
+claude:
+  permissions:                    # NEW (P1b)
+    allowed_tools: [...]
+    disallowed_tools: [...]
+    permission_mode: plan | acceptEdits | manual
+  disable_default_hooks: false    # NEW (P2b)
+  i_understand_this_is_unsafe: false  # NEW (P1b) — required for bypassPermissions
+  max_concurrent_sessions: null   # existing — default now derived from CPU
+```
+
+New field under `deployment:`:
+
+```yaml
+deployment:
+  security_profile: default | hardened   # NEW (P3)
+```
+
+Reuses spec 028's `claude.hooks` surface for user-defined hooks; no new field needed.
+
+### Backend changes
+
+| File | Change |
+|---|---|
+| `src/holodeck/lib/backends/claude_backend.py` | `build_options()` derives `disallowed_tools` from `agent.tools`; sets `max_turns` default; plumbs default hooks |
+| `src/holodeck/lib/backends/validators.py` | `_build_permission_mode()` rewritten per the decision tree above; emits migration error for legacy `acceptAll` without opt-in |
+| `src/holodeck/lib/backends/claude_hooks.py` | NEW — bundled default hooks (Bash AST deny, credential redaction) |
+| `src/holodeck/lib/backends/otel_bridge.py` | Add redaction pass on `tool.input`/`tool.output` attributes |
+
+### Serve changes
+
+| File | Change |
+|---|---|
+| `src/holodeck/serve/server.py` | `max_concurrent_sessions` default becomes `max(1, floor(cpu_cores × 2))` derived from replica env (`HOLODECK_REPLICA_CPU` env var emitted by deployer) |
+| `src/holodeck/serve/protocols/agui.py` | Wrap `_get_or_create_session()` in `asyncio.Semaphore`; return 429 on overflow |
+| `src/holodeck/serve/server.py` | Add `/ready` endpoint distinct from `/health`; returns 200 only after `tool_init_manager` reports ready |
+
+### Deploy changes
+
+| File | Change |
+|---|---|
+| `src/holodeck/deploy/dockerfile.py` | Conditional Node.js install; chown corpus to root + chmod a-w; create `/var/holodeck/work` |
+| `src/holodeck/deploy/deployers/azure_containerapps.py` | Emit `securityContext`; readiness probe; `ingress_external` defaults to `false`; echo resolved limits at deploy time |
+| `src/holodeck/deploy/deployers/azure_containerapps.py` | When `security_profile: hardened`, emit two containers + Envoy config + Container App secrets |
+| `src/holodeck/deploy/envoy.py` | NEW — generate Envoy config from agent.yaml allowlist |
+
+### Model changes
+
+| File | Change |
+|---|---|
+| `src/holodeck/models/claude_config.py` | Add `permissions: ClaudePermissionsConfig`, `disable_default_hooks`, `i_understand_this_is_unsafe`; remove the implicit `acceptAll` mapping |
+| `src/holodeck/models/deployment.py` | Add `security_profile`; default Azure `cpu`/`memory` to `1.0`/`2Gi` for Claude agents; default `ingress_external` to `false` |
+
+## Validation at startup
+
+Phases 1–2 add the following load-time checks. Phase 3 adds two more.
+
+1. Existing agent.yaml validation (unchanged).
+2. **(P1b)** If `permission_mode: acceptAll` and `i_understand_this_is_unsafe: false`: load fails with migration error.
+3. **(P1b)** If `claude.permissions` and any legacy permission fields are both set on the same agent: load fails with a "choose one" error.
+4. **(P2b)** If `claude.disable_default_hooks: true`: load succeeds with a loud warning naming the agent.
+5. **(P3)** If `security_profile: hardened` and any credential-bearing env var is set on the agent container: load fails — the operator has half-migrated.
+6. **(P3)** If `security_profile: hardened` and `agent.embedding_provider.endpoint` or any MCP HTTP endpoint is missing: load fails — the allowlist would be incomplete.
+
+All validation errors collected in a single pass, surfaced together.
+
+## CLI surface
+
+No new top-level subcommands. Two existing commands grow output:
+
+```
+$ holodeck deploy run sample/financial-assistant/claude
+Building image…                              done (32s)
+Pushing to ghcr.io/justinbarias/...          done (12s)
+Resolving deployment configuration:
+  Replica: 1.0 CPU / 2 GiB memory
+  Concurrent sessions per replica: 2
+  Max turns per session: 20
+  Permission mode: plan (auto-mapped from `manual` in serve context)
+  Disallowed tools (auto): Bash, Write, Edit, WebFetch
+  Default hooks: enabled
+  Ingress: internal
+  Security profile: default
+Deploying to Azure Container Apps…           done (28s)
+Container App URL (internal):
+  https://financial-assistant.internal.nicemoss-50caf9f5.eastus.azurecontainerapps.io
+```
+
+When the security profile is hardened, the resolution block expands:
+
+```
+  Security profile: hardened
+    Envoy sidecar: enabled
+    Domain allowlist:
+      • api.anthropic.com
+      • holodeckai.openai.azure.com
+      • <qdrant-cluster>.qdrant.tech
+    Credentials in agent container: none
+    Credentials in envoy sidecar: 3 (CLAUDE_CODE_OAUTH_TOKEN, AZURE_OPENAI_API_KEY, QDRANT_REMOTE_URL)
+```
+
+```
+$ holodeck serve agent.yaml
+Loading agent…
+  Permission mode: plan (auto-mapped from `manual`)
+  Disallowed tools (auto): Bash, Write, Edit, WebFetch
+  Max concurrent sessions: 2 (derived from CPU=1.0)
+  Max turns per session: 20
+  Default hooks: enabled
+Listening on 0.0.0.0:8080…
+```
+
+## Phase-by-phase ship criteria
+
+| Phase | Ship criteria |
+|---|---|
+| **P1a — OOM** | Financial-assistant sample handles 3 concurrent AG-UI sessions on default sizing without exit-137; overflow returns 429 with Retry-After; replica trace IDs stay constant. Unit tests for the semaphore + 429 path; integration test against a real ACA deploy. |
+| **P1b — Permissions** | Default-built agents cannot Bash unless declared; loading an agent with legacy `acceptAll` fails closed unless explicit opt-in; new `claude.permissions` schema documented in `docs/`. Unit tests on the decision tree; CI grep-test asserting no code path maps to `bypassPermissions` except the explicit opt-in. |
+| **P2a — Container** | Generated Dockerfile omits Node.js for agents without Node-needing MCP servers; ACA template emits `securityContext` and dual probes; ingress defaults to internal. Unit tests on Dockerfile generation + ACA template generation. |
+| **P2b — Hooks** | Default hooks ship enabled; synthetic prompt-injection test case verifies Bash deny + credential redaction in both context and OTel; opt-out emits warning. Integration test against a real AG-UI session. |
+| **P3 — Hardened** | Hardened profile deploys two containers; agent container env has zero credential-bearing vars; calls to non-allowlisted domains rejected by sidecar with structured error. End-to-end test against a real ACA deploy with the hardened profile. |
+
+Each phase merges independently. P1 is one PR. P2a and P2b can be parallel PRs. P3 is a sequence (Envoy generator → ACA deployer changes → backend integration).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Existing agents break on the new `disallowed_tools` defaults | Auto-derivation emits a warning at load time naming the auto-disallowed tools and pointing at the new schema; sample agents updated as part of P1b |
+| Operators flip `i_understand_this_is_unsafe: true` to dodge the migration | The flag's name signals risk; load-time warning is loud; `holodeck serve` and `deploy run` echo the flag's effect in their resolved-config output |
+| `floor(cpu_cores × 2)` is wrong for some workloads | Override remains available via `claude.max_concurrent_sessions`; we surface the resolved value at deploy time so operators can tune |
+| Readiness probe wedged → ACA replaces replicas in a loop | Tool init has its own timeout from spec 025; readiness reflects but doesn't change that timeout |
+| Default hooks block a legitimate command (false positive) | Opt-out per-agent via `disable_default_hooks: true`; users-hooks surface still available for finer control |
+| Default hooks redact a credential the agent genuinely needs in context | Same as above — opt-out path is explicit |
+| `security_profile: hardened` rejects a domain the agent needs | Allowlist is derived from explicit YAML fields; if a tool needs an undeclared domain, the operator declares it; if a domain is not declarable in YAML, the operator opens an issue rather than disabling the proxy |
+| Envoy sidecar fails to start → replica unhealthy | Liveness probe on the agent container fails fast; ACA replaces; operator sees normal ACA failure mode |
+| Phases ship out of order and create inconsistent defaults | Phase gates: P2 cannot ship without P1; P3 cannot ship without P2a (container hardening is a prerequisite for the sidecar's volume model) |
+
+## Out of scope for v1
+
+| Out-of-scope | Why deferred | Path forward |
+|---|---|---|
+| SDK subprocess pooling across sessions | Significant redesign of `claude_backend.py` session model; requires a way to inject conversation history per turn into a warm process | Separate spec (`spec-XXX-sdk-process-pool`); biggest perf lever after P1 |
+| Ephemeral per-session containers (Pattern 1) | New deployer (Modal / Fly Machines) + per-session billing | Separate spec; the right pattern for hostile multi-tenant workloads |
+| gVisor runtime templating | ACA doesn't support it; self-hosted users can adopt without HoloDeck help | Docs note in `docs/security/` |
+| TLS-terminating proxy with CA injection | Significant cert management; only needed for arbitrary HTTPS service auth | Follow-up to P3; document the custom-tool pattern for now |
+| Per-replica memory accountant gating sessions on cgroup pressure | Better than `floor(cpu × 2)` but requires reading cgroup pressure | v2 of P1a; static heuristic is honest enough for v1 |
+| Auto-discovery of required MCP domains | Hard to do correctly without false positives | Stays explicit in YAML |
+| Per-tool credential mapping in default profile | Half-implementing the credential boundary is worse than not having one | Operators who need credential isolation opt into P3 |
+| Statistical-anomaly detection on tool call patterns | Useful but unbounded scope | Hook surface is the right abstraction; out of v1 |
+
+## Open questions resolved during design
+
+1. **Default replica sizing for non-Claude agents?** No change. SK-backed agents (OpenAI/Azure/Ollama) don't spawn per-session subprocesses and don't have the same memory footprint. The 1 CPU / 2 GiB default applies only when `model.provider` routes to the Claude backend.
+2. **What about agents that legitimately need Bash?** Declare it in `agent.tools` like any other tool. The auto-disallow only fires for tools not declared.
+3. **What about `manual` permission mode in non-serve contexts (e.g. `holodeck test run`)?** Unchanged. The mapping to `plan` only fires when running in `serve` mode where there's no operator at the terminal. `holodeck test run` and `holodeck chat` keep SDK `default` (interactive).
+4. **Do the default hooks count toward the user's `claude.hooks` slot count?** No. They run as a separate, earlier stage and are not visible in `claude.hooks` config.
+5. **Where do credentials in P3 actually live?** Azure Container App secrets, mounted only to the sidecar via the ACA `volumes` mechanism. Not in the image, not in the agent container env, not in the cluster's general secret store.
+6. **What if an agent uses both stdio MCP servers (needing Node) and `security_profile: hardened`?** Node still installs for stdio MCP servers; the sidecar still proxies HTTPS egress. They are orthogonal axes.
+
+## v1 contract
+
+- Five named phases, ship-independent: **P1a (OOM)**, **P1b (permissions)**, **P2a (container)**, **P2b (hooks)**, **P3 (hardened profile)**.
+- One new schema field per phase, all gated behind explicit YAML keys.
+- No required user YAML changes for P1 and P2; defaults are inferred from existing fields.
+- One escape hatch for legacy `acceptAll` permission mode (`i_understand_this_is_unsafe`), keyed by a name that signals risk.
+- One opt-in for credential boundary (`security_profile: hardened`), gated behind the multi-week egress-proxy work.
+- Resolved limits and security posture echoed at `serve` and `deploy run` time so operators can see what's actually in effect.
+- All validation errors surfaced together at load time.
+- No changes to evaluation runs (`holodeck test run`) except inheriting P1 permission defaults.
+
+## Implementation surface — modules to create / modify
+
+**New modules:**
+
+- `src/holodeck/lib/backends/claude_hooks.py` — bundled default hooks (Bash AST deny, credential redaction).
+- `src/holodeck/deploy/envoy.py` — Envoy config generator for the hardened profile.
+
+**Modified modules:**
+
+- `src/holodeck/lib/backends/claude_backend.py` — `build_options()` derives defaults; plumbs default hooks.
+- `src/holodeck/lib/backends/validators.py` — `_build_permission_mode()` decision tree; migration errors.
+- `src/holodeck/lib/backends/otel_bridge.py` — credential redaction on span attributes.
+- `src/holodeck/serve/server.py` — `/ready` endpoint; CPU-derived `max_concurrent_sessions` default.
+- `src/holodeck/serve/protocols/agui.py` — semaphore + 429 on overflow.
+- `src/holodeck/deploy/dockerfile.py` — conditional Node.js; corpus read-only; tmpfs scratch dir.
+- `src/holodeck/deploy/deployers/azure_containerapps.py` — securityContext; dual probes; ingress default; hardened-profile sidecar.
+- `src/holodeck/models/claude_config.py` — `ClaudePermissionsConfig`; `disable_default_hooks`; `i_understand_this_is_unsafe`.
+- `src/holodeck/models/deployment.py` — `security_profile`; new Azure defaults.
+- `src/holodeck/cli/commands/deploy.py` — echo resolved limits and security posture.
+- `src/holodeck/cli/commands/serve.py` — same.
+
+**Tests:**
+
+- `tests/unit/serve/test_session_semaphore.py` — overflow → 429 with Retry-After; semaphore correctness.
+- `tests/unit/serve/test_readiness_probe.py` — `/ready` only returns 200 after tool init completes.
+- `tests/unit/lib/backends/test_permissions.py` — decision tree; auto-disallow; migration error.
+- `tests/unit/lib/backends/test_default_hooks.py` — Bash deny patterns; credential redaction patterns.
+- `tests/unit/lib/backends/test_otel_redaction.py` — span attribute redaction.
+- `tests/unit/deploy/test_dockerfile_generation.py` — conditional Node.js; corpus permissions; tmpfs paths.
+- `tests/unit/deploy/test_aca_template.py` — securityContext; dual probes; ingress default; resolved-config output.
+- `tests/unit/deploy/test_envoy_generator.py` — allowlist derivation; sidecar config; credential mounts.
+- `tests/integration/security/test_bash_deny_e2e.py` — synthetic prompt-injection test against a live AG-UI endpoint.
+- `tests/integration/security/test_hardened_profile_e2e.py` — agent container has no creds; non-allowlisted domain rejected; allowlisted domain works.
+
+## Dependencies to add
+
+- No new Python deps.
+- New runtime image dep (P3 only): Envoy. Pulled as a separate Container App container image (`envoyproxy/envoy:v1.31-latest`), not bundled into the agent image.

--- a/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
+++ b/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
@@ -103,7 +103,7 @@ P1 is one focused PR (and probably ships under a feature branch within days). P2
 | P2a — Container hardening | ⏳ not started | — | — |
 | P2b — Prompt-injection defenses | ⏳ not started | — | — |
 | P3 — Credential boundary | ⏳ not started | — | — |
-| P4 — Hybrid sessions / pooling | ⏳ design only (see Phase 4 below) | — | Spike `query(resume=…)` latency vs. persistent `ClaudeSDKClient` first; MCP server reinit cost is the binary risk. |
+| P4 — Hybrid sessions / pooling | 🟢 spikes complete, ready to implement | — | Both binary risks resolved 2026-05-19: per-turn `query(resume=)` latency is *faster* than persistent `ClaudeSDKClient` (-2.32s/turn over 5 turns), and the transcript replay faithfully restores user/assistant/tool-use/tool-result blocks across spawned subprocesses. Streaming-mode prompts mandatory (string mode deadlocks SDK MCP callbacks). See Phase 4 risks table for spike data. |
 
 ## Phase 1a — Stop the OOM
 
@@ -533,13 +533,41 @@ For typical chat duty cycle (sessions spend ≥90% of wall time waiting on the u
 
 ### Risks to validate before committing
 
-| Risk | Why it matters | Validation |
-|------|----------------|------------|
-| **MCP server reinit cost per turn** | qdrant client reconnect + hierarchical-doc tool warmup + ingestion idempotency check on every spawn. Could push P50 mid-conversation latency from ~30s to ~40s. The financial-assistant's first-turn warmup is currently ~3-5s; if that's load-bearing per-turn, chat UX gets ugly. | Spike: time five sequential turns of the same session under both models on the financial-assistant. |
-| **AG-UI stream-shape compat** | The current AG-UI bridge consumes `client.send_streaming()` output. If `query()` yields a different message ordering (e.g. `SystemMessage` placement) the bridge breaks subtly. | Run the existing AG-UI test suite against a `query()`-backed session implementation. |
-| **Subprocess spawn jitter under burst** | Spawning 5 subprocesses at once = 5 simultaneous Node.js CLI starts + 5 MCP server inits. Could cause CPU saturation despite memory headroom. | Re-run the 5-concurrent burst test from P1 validation; measure end-to-end latency distribution. |
-| **Transcript disk pressure** | Long-lived deployments accumulate JSONLs forever without cleanup. | Implement TTL job; size estimate per session before committing. |
-| **Lost session state on transcript corruption** | A corrupted transcript bricks the session permanently (no in-memory fallback as we have today). | Catch decode errors at resume; surface as "session lost, please reconnect" rather than 500. |
+| Risk | Why it matters | Validation | Status |
+|------|----------------|------------|--------|
+| **MCP server reinit cost per turn** | qdrant client reconnect + hierarchical-doc tool warmup + ingestion idempotency check on every spawn. Could push P50 mid-conversation latency from ~30s to ~40s. | Five sequential turns of the same session under both models on the financial-assistant. | ✅ **Resolved by spike** (2026-05-19). P4 total 101.13s vs baseline 112.72s over 5 turns; P4 was *2.32s/turn faster*. Per-turn variance dominated by LLM + retrieval, not subprocess spawn. |
+| **`resume=session_id` context fidelity** | If the transcript replay loses tool-use/tool-result blocks, the agent would re-retrieve every turn and lose conversation continuity. | Conversation-dependent follow-up turns ("and the prior year?") that can only be answered using prior context. | ✅ **Resolved by spike v2** (2026-05-19). Five-turn conversation with three follow-up turns: P4 correctly referenced ALXN/rental-payments and JKHY/capex anchors across spawns, including prior tool-result blocks ("from the **same retrieved JKHY 2008 filing**, the answer is already in context"). |
+| **AG-UI stream-shape compat** | The current AG-UI bridge consumes SDK messages emitted via `client.send_streaming()`. | No separate spike needed — `query()` yields the same SDK message types. Validate by keeping `ClaudeSession.send_streaming()` as the stable public surface and swapping its guts; the AG-UI bridge above is unchanged. Cover via the existing deploy validation loop. | ⏳ Validate during implementation. |
+| **String-prompt + SDK MCP tool callbacks deadlock** | Discovered in spike v1: when `query()` is called with a `str` prompt, it calls `end_input()` after writing the prompt, which closes stdin. Subsequent control-channel messages (the SDK's reverse path used by SDK MCP tool callbacks) fail with `ProcessTransport is not ready for writing`. | Use streaming-mode prompts (`AsyncIterable[dict]`) for every P4 turn — the SDK keeps stdin open via the background `stream_input` task. | ✅ **Resolved by spike** — required for any implementation using `holodeck_tools` SDK MCP server. |
+| **Subprocess spawn jitter under burst** | Spawning 5 subprocesses at once = 5 simultaneous Node.js CLI starts + 5 MCP server inits. Could cause CPU saturation despite memory headroom. | Re-run the 5-concurrent burst test from P1 validation; measure end-to-end latency distribution. | ⏳ Validate during implementation. |
+| **Transcript disk pressure** | Long-lived deployments accumulate JSONLs forever without cleanup. | Implement TTL job; size estimate per session before committing. | ⏳ Implementation detail. |
+| **Lost session state on transcript corruption** | A corrupted transcript bricks the session permanently (no in-memory fallback as we have today). | Catch decode errors at resume; surface as "session lost, please reconnect" rather than 500. | ⏳ Implementation detail. |
+
+#### Spike data (2026-05-19, financial-assistant sample, sequential turns)
+
+Spike v1 — latency, independent turns:
+
+| turn | baseline | P4 (`query` + `resume`) | delta |
+|------|---------:|------------------------:|------:|
+| 1 (cold) | 47.05s | 45.34s | -1.71s |
+| 2 | 8.67s | 10.86s | +2.19s |
+| 3 | 20.84s | 14.69s | -6.15s |
+| 4 | 16.99s | 15.23s | -1.76s |
+| 5 | 19.16s | 15.01s | -4.15s |
+| **TOTAL** | **112.72s** | **101.13s** | **-11.59s** |
+
+Spike v2 — context preservation, conversation-dependent turns:
+
+| turn | baseline | P4 | delta |
+|------|---------:|---:|------:|
+| 1 (cold) | 38.69s | 40.38s | +1.69s |
+| 2 ("prior year") | 18.80s | 20.90s | +2.10s |
+| 3 ("percentage change") | 5.17s | 12.04s | +6.87s |
+| 4 (context switch) | 15.78s | 9.21s | -6.58s |
+| 5 ("year before") | 11.37s | 5.31s | -6.06s |
+| **TOTAL** | **89.81s** | **87.84s** | **-1.97s** |
+
+Both legs answered every conversation-dependent turn correctly, demonstrating that `resume=` faithfully replays user messages, assistant responses, and tool-use/tool-result blocks across spawned subprocesses.
 
 ### Why this didn't ship in v1
 
@@ -547,10 +575,11 @@ The two-week diagnostic loop that produced P1 surfaced this as the natural next 
 
 ### Open questions
 
-1. **Does `query(resume=session_id)` actually round-trip every option** (hooks, MCP servers, allowed_tools, permission_mode) cleanly, or do some options reset on resume? Verify in the spike.
-2. **Does the SDK serialize tool-use blocks faithfully in the transcript?** If a tool's response was 200 KiB of text, does that bloat every resume? May need pruning.
-3. **Streaming-mode vs query() in the SDK** — is there a documented difference in latency, message ordering, or error semantics? Skim `code.claude.com/docs/en/agent-sdk/python` for the distinction.
-4. **OTel context propagation across spawned subprocesses** — today the OTel instrumentor patches `ClaudeSDKClient` instances. With `query()` we get a fresh client each turn; need to verify the instrumentor still wires the trace context.
+1. **Does `query(resume=session_id)` round-trip every option** (hooks, MCP servers, allowed_tools, permission_mode) cleanly? ✅ Spike confirmed MCP servers, allowed_tools, and prompt envelope all round-trip — same `options` dataclass reused per turn with only `resume` mutated. Hooks and `permission_mode` round-trip implicitly because they're carried on the same options object.
+2. **Does the SDK serialize tool-use blocks faithfully in the transcript?** ✅ Spike v2 confirmed — turn 5 ("And the year before?") reproduced the $34,202 figure from turn 4's tool result *without re-running the retrieval tool*, proving tool-use AND tool-result blocks are replayed from the transcript.
+3. **Streaming-mode vs string-mode `query()`** — spike v1 surfaced this: string-mode closes stdin after writing the prompt, deadlocking any SDK MCP tool callback. P4 implementation **must** use streaming-mode (`AsyncIterable[dict]`) prompts. Documented as a hard requirement above.
+4. **Transcript bloat on long tool outputs** — still open. The hierarchical_document tool can return 8KB-ish per retrieval; 50 turns × 5 retrievals × 8KB = 2MB transcript that gets read+parsed every turn. Need a size-budget knob or rolling-summary mechanism before exposing P4 to long-running chat sessions.
+5. **OTel context propagation across spawned subprocesses** — today the OTel instrumentor patches `ClaudeSDKClient` instances. With `query()` we get a fresh client each turn; need to verify the instrumentor still wires the trace context, or move the patch to the top-level `query` function.
 
 ## What we are deliberately *not* doing in v1
 

--- a/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
+++ b/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
@@ -103,7 +103,7 @@ P1 is one focused PR (and probably ships under a feature branch within days). P2
 | P2a — Container hardening | ⏳ not started | — | — |
 | P2b — Prompt-injection defenses | ⏳ not started | — | — |
 | P3 — Credential boundary | ⏳ not started | — | — |
-| P4 — Hybrid sessions / pooling | 🟢 spikes complete, ready to implement | — | Both binary risks resolved 2026-05-19: per-turn `query(resume=)` latency is *faster* than persistent `ClaudeSDKClient` (-2.32s/turn over 5 turns), and the transcript replay faithfully restores user/assistant/tool-use/tool-result blocks across spawned subprocesses. Streaming-mode prompts mandatory (string mode deadlocks SDK MCP callbacks). See Phase 4 risks table for spike data. |
+| P4 — Hybrid sessions / pooling | ✅ shipped | `feature/034-p4-hybrid-sessions` (commits `6a2ad9c` → `72bba40`) | 9 surgical commits, 124 unit tests green. `ClaudeSession` now uses top-level `query(resume=sdk_session_id)` per turn; `_send_lock` serialises concurrent sends; `close()` deletes the on-disk JSONL transcript. End-to-end ACA deploy validated 2026-05-19: AG-UI single-turn + multi-turn `resume=` + 3 concurrent threads all 200 with no OOM. **Follow-up still open:** SessionStore cap remains binding on open-session count (not concurrent turns), so 5-concurrent cold burst against the 2 GiB / cap-4 replica returned 2 × 429 as expected; the structural-pool win lands when the cap is repurposed (separate PR). |
 
 ## Phase 1a — Stop the OOM
 

--- a/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
+++ b/specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
@@ -83,10 +83,27 @@ The plan replaces each row of "Today" with a specific change, grouped into four 
 │   • Envoy sidecar holds credentials; agent has none                 │
 │   • Domain allowlist derived from agent.yaml                        │
 │   • ANTHROPIC_BASE_URL → localhost sidecar                          │
+├─────────────────────────────────────────────────────────────────────┤
+│ P4 — Hybrid sessions / SDK subprocess pooling   (1–2 sprints)       │
+│   • Switch claude_backend to per-turn `query(resume=session_id)`    │
+│   • Memory scales with concurrent **turns**, not open sessions      │
+│   • Transcript on disk is the durable state; subprocess is ephemeral│
+│   • Aligns with SDK's documented "Pattern 3 — Hybrid Sessions"      │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-P1 is one focused PR (and probably ships under a feature branch within days). P2 and P3 land independently after P1 stabilises trunk.
+P1 is one focused PR (and probably ships under a feature branch within days). P2 and P3 land independently after P1 stabilises trunk. P4 is the biggest memory-headroom win after P1 but requires reshaping `claude_backend.py`'s session model.
+
+### Status tracker
+
+| Phase | Status | Branch / PR | Notes |
+|-------|--------|-------------|-------|
+| P1a — OOM stability | ✅ shipped | `feature/034-p1-stability-permissions` (commits `a391c7d`, `b344684`) | ACA defaults bumped, memory-derived session cap, 429 backpressure, readiness probe. Memory derivation (not CPU) confirmed in ACA via `Claude cgroup memory limit: 2147483648 bytes` startup log. |
+| P1b — Permission posture | ✅ shipped | same branch | `manual → acceptEdits` mapping in serve, auto-disallow risky built-ins, `i_understand_this_is_unsafe` gate on `acceptAll`, silent test-mode escalation removed. |
+| P2a — Container hardening | ⏳ not started | — | — |
+| P2b — Prompt-injection defenses | ⏳ not started | — | — |
+| P3 — Credential boundary | ⏳ not started | — | — |
+| P4 — Hybrid sessions / pooling | ⏳ design only (see Phase 4 below) | — | Spike `query(resume=…)` latency vs. persistent `ClaudeSDKClient` first; MCP server reinit cost is the binary risk. |
 
 ## Phase 1a — Stop the OOM
 
@@ -158,7 +175,7 @@ ACA routes traffic only to ready replicas. First requests no longer race tool in
 ```
 Deploying financial-assistant to Container App 'financial-assistant'
   Replica: 1.0 CPU / 2 GiB memory
-  Concurrent sessions per replica: 2 (derived from CPU)
+  Concurrent sessions per replica: 4 (derived from 2048 MiB memory limit @ 400 MiB/session)
   Max turns per session: 20 (default)
   Ingress: internal
   Readiness probe: /ready (initial delay 5s)
@@ -176,6 +193,7 @@ WARNING: replica CPU (0.25) is below Anthropic's recommended minimum of 1 CPU pe
 - Burst traffic past `max_replicas × max_concurrent_sessions`. The 429 surfaces this honestly; raising replica count is on the operator.
 - One absurdly large prompt that single-handedly OOMs a replica. The semaphore caps process count, not per-process memory.
 - Cold-start latency. P1 surfaces a readiness probe but doesn't make init faster. That's separate work folded into P2.
+- **Idle sessions costing one full SDK subprocess each.** P1 caps concurrent *open sessions* because each one holds a persistent `ClaudeSDKClient`. A user who opens 5 chat windows and walks away pins 5 × ~330 MiB even though nothing is running. Fixing this structurally is **Phase 4** (hybrid sessions — see below). P1 is a ceiling, not an architectural fix.
 
 ## Phase 1b — Permission posture
 
@@ -478,11 +496,66 @@ The Claude backend, on detecting `security_profile: hardened`, requires `ANTHROP
 - **TLS interception of arbitrary HTTPS.** The doc is clear: for non-Anthropic HTTPS without a TLS-terminating proxy, the sidecar only sees opaque TLS tunnels. We don't ship a CA-injection setup in v1. MCP servers needed at the application layer are handled via the `custom tool` pattern from the secure-deployment doc — they expose an HTTP endpoint inside the sidecar and the agent calls them via plain HTTP.
 - **Multi-tenant-per-container isolation.** This profile assumes one tenant per replica. Multiple end-customers concurrently inside the same container with hard isolation between them is a separate spec (would require per-session ephemeral containers, Pattern 1 in the hosting doc).
 
+## Phase 4 — Hybrid sessions / SDK subprocess pooling
+
+P1 caps concurrent SDK subprocesses to whatever fits in cgroup memory. That cap is binding on **open sessions**, not on **active turns** — a 2 GiB replica with 5 idle chat sessions is at the cap even though the CPU and most of the memory is idle. Phase 4 removes that cliff by aligning HoloDeck with the SDK's documented **Pattern 3 — Hybrid Sessions**: each turn is its own subprocess, conversation state lives in a transcript file, idle sessions cost ~zero resident memory.
+
+### What the SDK actually supports
+
+From the SDK sessions doc (verified during P1 validation):
+
+1. **Session state is a JSONL transcript on disk**, written automatically to `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. Not opaque in-subprocess state.
+2. **`ClaudeAgentOptions.resume=<session_id>`** rehydrates a subprocess from that transcript at spawn time. Fully supported on the top-level `query()` function.
+3. **`ClaudeSDKClient`** (what HoloDeck uses today) keeps one subprocess for its lifetime and locks to one session_id internally. **Cannot be reused across distinct sessions** — confirmed both by the docs and by the existing codebase comment in `claude_backend.py` (rotating session_id wedges the CLI).
+4. There is **no public API for subprocess pooling** in the conventional warm-worker sense. The SDK owns subprocess lifecycle; the only pooling lever the SDK gives you is "make subprocesses ephemeral via `resume=`."
+
+### Current model vs. Phase 4 model
+
+```
+Today (P1):                       Phase 4 (Hybrid):
+1 session = 1 ClaudeSDKClient     1 session = 1 transcript file
+        = 1 persistent subprocess         (cheap, on disk)
+        = ~330 MiB resident       1 turn   = spawn subprocess
+                                          + query(resume=session_id)
+N idle sessions: N × 330 MiB              + run turn, exit
+                                  Resident memory tracks *active turns*.
+```
+
+For typical chat duty cycle (sessions spend ≥90% of wall time waiting on the user), this is 5–10× less resident memory.
+
+### Architecture sketch
+
+- Replace `ClaudeSession._ensure_client()` and `ClaudeSession.send()` so each `send()` calls the top-level `query(prompt, options=ClaudeAgentOptions(resume=session_id, ...))` and drains the async-iterable.
+- On first turn, capture `session_id` from `ResultMessage` and store it on the HoloDeck `ServerSession`.
+- The HoloDeck `SessionStore` cap changes meaning: it now tracks **concurrent turns** in flight, not open sessions. Probably rename to `max_concurrent_turns` to be honest. Cap can be much higher (e.g. 20–50 on a 2 GiB replica) because idle sessions are free.
+- Transcript cleanup: on `ServerSession.close()` and on an idle TTL (e.g. 1h), delete the JSONL. Otherwise `~/.claude/projects/` grows unboundedly.
+- AG-UI streaming: the top-level `query()` async-iterable yields the same SDK message types as `client.send_streaming()`, so the AG-UI bridge mapping should be near-identical. Worth confirming on the spike.
+
+### Risks to validate before committing
+
+| Risk | Why it matters | Validation |
+|------|----------------|------------|
+| **MCP server reinit cost per turn** | qdrant client reconnect + hierarchical-doc tool warmup + ingestion idempotency check on every spawn. Could push P50 mid-conversation latency from ~30s to ~40s. The financial-assistant's first-turn warmup is currently ~3-5s; if that's load-bearing per-turn, chat UX gets ugly. | Spike: time five sequential turns of the same session under both models on the financial-assistant. |
+| **AG-UI stream-shape compat** | The current AG-UI bridge consumes `client.send_streaming()` output. If `query()` yields a different message ordering (e.g. `SystemMessage` placement) the bridge breaks subtly. | Run the existing AG-UI test suite against a `query()`-backed session implementation. |
+| **Subprocess spawn jitter under burst** | Spawning 5 subprocesses at once = 5 simultaneous Node.js CLI starts + 5 MCP server inits. Could cause CPU saturation despite memory headroom. | Re-run the 5-concurrent burst test from P1 validation; measure end-to-end latency distribution. |
+| **Transcript disk pressure** | Long-lived deployments accumulate JSONLs forever without cleanup. | Implement TTL job; size estimate per session before committing. |
+| **Lost session state on transcript corruption** | A corrupted transcript bricks the session permanently (no in-memory fallback as we have today). | Catch decode errors at resume; surface as "session lost, please reconnect" rather than 500. |
+
+### Why this didn't ship in v1
+
+The two-week diagnostic loop that produced P1 surfaced this as the natural next move, but P1 was already a bounded scope with clear success criteria (no more OOM, cap is binding, permissions tightened). Stuffing a subprocess-lifecycle rewrite into the same PR would have made it un-reviewable. P1 gets us to "no OOM at our current scale" — P4 gets us to "no OOM as scale grows."
+
+### Open questions
+
+1. **Does `query(resume=session_id)` actually round-trip every option** (hooks, MCP servers, allowed_tools, permission_mode) cleanly, or do some options reset on resume? Verify in the spike.
+2. **Does the SDK serialize tool-use blocks faithfully in the transcript?** If a tool's response was 200 KiB of text, does that bloat every resume? May need pruning.
+3. **Streaming-mode vs query() in the SDK** — is there a documented difference in latency, message ordering, or error semantics? Skim `code.claude.com/docs/en/agent-sdk/python` for the distinction.
+4. **OTel context propagation across spawned subprocesses** — today the OTel instrumentor patches `ClaudeSDKClient` instances. With `query()` we get a fresh client each turn; need to verify the instrumentor still wires the trace context.
+
 ## What we are deliberately *not* doing in v1
 
 - **Per-session ephemeral containers (Pattern 1).** That's the strongest isolation pattern in the hosting doc but requires a new deployer (Modal, Fly Machines, etc.) and per-session billing infrastructure. Documented as a follow-up spec.
 - **gVisor / Firecracker runtime.** ACA doesn't support gVisor. Self-hosted Docker users could opt into `runsc`, but we don't template it.
-- **SDK process pooling across sessions.** The hosting doc's Pattern 4 ("multiple Claude Agent SDK processes in one global container") is what we already do; *reusing* one warm process across multiple sessions would let one container serve >N concurrent threads. Real win, but it's a redesign of `claude_backend.py`'s session model — separate spec.
 - **Statistical anomaly detection on tool calls.** Out of scope; the hook layer is the right abstraction for layering this later.
 - **Auto-derived domain allowlist from prompt content.** P3 derives the allowlist from explicit YAML fields. Inferring it from prompt text or runtime behavior is brittle and is not what the secure-deployment doc recommends.
 - **Per-tool credential mapping in default profile.** P3 moves credentials behind the sidecar. The default profile keeps the existing env-var model; we don't try to half-implement credential separation.
@@ -510,7 +583,8 @@ claude:
     permission_mode: plan | acceptEdits | manual
   disable_default_hooks: false    # NEW (P2b)
   i_understand_this_is_unsafe: false  # NEW (P1b) — required for bypassPermissions
-  max_concurrent_sessions: null   # existing — default now derived from CPU
+  max_concurrent_sessions: null   # existing — default now derived from cgroup memory
+  session_memory_estimate_mib: 200  # NEW (P1a) — per-session memory budget for derivation
 ```
 
 New field under `deployment:`:
@@ -608,7 +682,7 @@ $ holodeck serve agent.yaml
 Loading agent…
   Permission mode: plan (auto-mapped from `manual`)
   Disallowed tools (auto): Bash, Write, Edit, WebFetch
-  Max concurrent sessions: 2 (derived from CPU=1.0)
+  Max concurrent sessions: 4 (derived from 2048 MiB memory limit @ 400 MiB/session)
   Max turns per session: 20
   Default hooks: enabled
 Listening on 0.0.0.0:8080…
@@ -644,7 +718,6 @@ Each phase merges independently. P1 is one PR. P2a and P2b can be parallel PRs. 
 
 | Out-of-scope | Why deferred | Path forward |
 |---|---|---|
-| SDK subprocess pooling across sessions | Significant redesign of `claude_backend.py` session model; requires a way to inject conversation history per turn into a warm process | Separate spec (`spec-XXX-sdk-process-pool`); biggest perf lever after P1 |
 | Ephemeral per-session containers (Pattern 1) | New deployer (Modal / Fly Machines) + per-session billing | Separate spec; the right pattern for hostile multi-tenant workloads |
 | gVisor runtime templating | ACA doesn't support it; self-hosted users can adopt without HoloDeck help | Docs note in `docs/security/` |
 | TLS-terminating proxy with CA injection | Significant cert management; only needed for arbitrary HTTPS service auth | Follow-up to P3; document the custom-tool pattern for now |

--- a/specs/034-production-hardening/2026-05-19-spec-034-p4-hybrid-sessions-plan.md
+++ b/specs/034-production-hardening/2026-05-19-spec-034-p4-hybrid-sessions-plan.md
@@ -1,0 +1,1077 @@
+# Spec 034 P4 — Hybrid Sessions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `ClaudeSession`'s persistent `ClaudeSDKClient` with per-turn top-level `query()` calls using `ClaudeAgentOptions.resume=<session_id>`, so idle sessions cost ~0 resident memory and the `SessionStore` cap correctly applies to concurrent active turns instead of open threads.
+
+**Architecture:** Keep `ClaudeSession`'s public protocol stable (`send`, `send_streaming`, `prepare`, `close` — all callers downstream of `_TaskBoundSession` and the AG-UI / REST bridges are unchanged). Swap the internals from "one persistent connected `ClaudeSDKClient` per session" to "one fresh `query()` invocation per turn, replaying conversation state from the on-disk JSONL transcript via `resume=session_id`". Capture `session_id` from `ResultMessage` on turn 1 and feed it back into `options.resume` on turn 2+. Use streaming-mode prompts (`AsyncIterable[dict]`) to keep stdin open for SDK MCP tool callbacks — string-mode `query()` calls `end_input()` and deadlocks. On `close()`, delete the on-disk transcript at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`.
+
+**Tech Stack:**
+- `claude-agent-sdk==0.1.44` — `query()`, `ClaudeAgentOptions.resume`
+- pytest with `pytest-asyncio`, `unittest.mock.{AsyncMock, MagicMock, patch}`
+- Pydantic v2 (config models)
+- Python 3.10+ (`dataclasses.replace`, `asyncio.Lock`)
+
+**Branch:** `feature/034-p4-hybrid-sessions` off `feature/034-p1-stability-permissions` (or off `main` if P1 has merged by the time work starts).
+
+**Pre-flight (run from repo root):**
+```bash
+source .venv/bin/activate
+git checkout feature/034-p1-stability-permissions
+git pull origin feature/034-p1-stability-permissions
+git checkout -b feature/034-p4-hybrid-sessions
+```
+
+---
+
+## Task 1: Add streaming-prompt envelope helper
+
+**Why:** Top-level `query()` accepts two prompt shapes — `str` (one-shot, calls `end_input()` after writing) or `AsyncIterable[dict]` (streaming, keeps stdin open via a background `stream_input` task). P4 turns need streaming-mode because the agent will invoke SDK MCP tools, and the SDK's reverse control channel (tool callbacks) needs stdin to stay open. Spike v1 surfaced this — string-mode crashes with `ProcessTransport is not ready for writing` mid-turn.
+
+**Files:**
+- Modify: `src/holodeck/lib/backends/claude_backend.py` (add helper near the existing `_wrap_prompt` at line 81)
+- Test: `tests/unit/lib/backends/test_claude_backend.py` (add `TestStreamingUserEnvelope` class)
+
+- [ ] **Step 1: Ensure test-module imports cover P4 tasks**
+
+`asyncio` and `pathlib.Path` are referenced by tests added in later tasks (Tasks 2, 5, 7) but are not currently imported in `tests/unit/lib/backends/test_claude_backend.py`. Add them once now so every subsequent task can rely on them.
+
+Edit the import block at the top of `tests/unit/lib/backends/test_claude_backend.py`. After the `import json` line (around line 13), insert:
+
+```python
+import asyncio
+from pathlib import Path
+```
+
+(`patch` is already imported from `unittest.mock` — no change needed there.)
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/unit/lib/backends/test_claude_backend.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Streaming-mode envelope (spec 034 P4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStreamingUserEnvelope:
+    """The envelope wraps a string into the AsyncIterable[dict] shape that
+    ``query()`` needs in streaming mode. String-mode prompts cause query()
+    to call end_input() after writing, deadlocking SDK MCP tool callbacks.
+    """
+
+    @pytest.mark.asyncio
+    async def test_yields_single_user_message(self) -> None:
+        from holodeck.lib.backends.claude_backend import (
+            _streaming_user_envelope,
+        )
+
+        msgs = [m async for m in _streaming_user_envelope("hello")]
+
+        assert len(msgs) == 1
+        msg = msgs[0]
+        assert msg["type"] == "user"
+        assert msg["session_id"] == ""
+        assert msg["message"] == {"role": "user", "content": "hello"}
+        assert msg["parent_tool_use_id"] is None
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestStreamingUserEnvelope -v
+```
+
+Expected: `ImportError: cannot import name '_streaming_user_envelope' from 'holodeck.lib.backends.claude_backend'`.
+
+- [ ] **Step 4: Add the helper**
+
+Edit `src/holodeck/lib/backends/claude_backend.py`. After the existing `_wrap_prompt` function (ends around line 99), add:
+
+```python
+async def _streaming_user_envelope(
+    message: str,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Wrap a user message in the streaming-mode envelope ``query()`` expects.
+
+    ``query()`` accepts either a ``str`` prompt or an ``AsyncIterable[dict]``.
+    The ``str`` form writes the message and immediately closes stdin via
+    ``end_input()``, which deadlocks any subsequent SDK-MCP tool callback
+    (control-channel writes fail with ``ProcessTransport is not ready for
+    writing``). Streaming mode keeps stdin open via the SDK's background
+    ``stream_input`` task, so tool callbacks can write responses back.
+
+    See spec 034 P4 spike v1 (2026-05-19) for the surfacing.
+    """
+    yield {
+        "type": "user",
+        "session_id": "",
+        "message": {"role": "user", "content": message},
+        "parent_tool_use_id": None,
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestStreamingUserEnvelope -v
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/holodeck/lib/backends/claude_backend.py tests/unit/lib/backends/test_claude_backend.py
+git commit -m "feat(spec-034 P4): add streaming-mode prompt envelope helper"
+```
+
+---
+
+## Task 2: Add `_sdk_session_id` + `_send_lock` fields to `ClaudeSession`
+
+**Why:** Under P4, conversation state lives in `session_id` (a string captured from `ResultMessage`) rather than in a long-lived subprocess. The lock serializes concurrent `send()` calls on the same session — two simultaneous turns with the same `resume=` would race writing to the same JSONL transcript.
+
+**Files:**
+- Modify: `src/holodeck/lib/backends/claude_backend.py:687-696` (the `ClaudeSession.__init__`)
+- Test: `tests/unit/lib/backends/test_claude_backend.py` (extend existing `TestClaudeSessionEnsureClient` neighborhood)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/lib/backends/test_claude_backend.py`:
+
+```python
+@pytest.mark.unit
+class TestClaudeSessionP4Fields:
+    """P4 session model: session_id captures CLI-assigned id on turn 1,
+    feeds it into ``options.resume`` on turn 2+. Lock serialises concurrent
+    sends to prevent transcript-write races.
+    """
+
+    def test_init_sets_p4_fields(self) -> None:
+        session = ClaudeSession(options=MagicMock())
+        assert session._sdk_session_id is None
+        assert isinstance(session._send_lock, asyncio.Lock)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestClaudeSessionP4Fields -v
+```
+
+Expected: `AttributeError: 'ClaudeSession' object has no attribute '_sdk_session_id'`.
+
+- [ ] **Step 3: Add the fields**
+
+Edit `src/holodeck/lib/backends/claude_backend.py`. Modify `ClaudeSession.__init__` (around line 687):
+
+```python
+def __init__(self, options: ClaudeAgentOptions) -> None:
+    """Initialize session with base options.
+
+    Args:
+        options: Base options (immutable reference for the session lifetime).
+    """
+    self._base_options = options
+    self._client: ClaudeSDKClient | None = None
+    self._turn_count: int = 0
+    self._tool_event_queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
+    # spec 034 P4 — hybrid-session state.
+    # CLI-assigned conversation id; captured from ResultMessage on turn 1
+    # and fed into ``options.resume`` on turn 2+ so each fresh subprocess
+    # rehydrates the JSONL transcript at
+    # ``~/.claude/projects/<encoded-cwd>/<sdk_session_id>.jsonl``.
+    self._sdk_session_id: str | None = None
+    # Serialises concurrent send() / send_streaming() on the same session.
+    # Two concurrent turns with the same resume= would race the transcript.
+    self._send_lock: asyncio.Lock = asyncio.Lock()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestClaudeSessionP4Fields -v
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/holodeck/lib/backends/claude_backend.py tests/unit/lib/backends/test_claude_backend.py
+git commit -m "feat(spec-034 P4): add _sdk_session_id and _send_lock to ClaudeSession"
+```
+
+---
+
+## Task 3: Re-implement `ClaudeSession.send()` on top of `query(resume=)`
+
+**Why:** This is the core P4 swap. Replace the `_ensure_client() + client.query() + client.receive_response()` flow with `query(prompt=streaming_envelope, options=replace(opts, resume=sdk_session_id))` + async-iter drain. Spike v2 (2026-05-19) confirmed this preserves conversation context across turns including tool-use/tool-result blocks. The ExecutionResult fields downstream (response, tool_calls, tool_results, token_usage, structured_output, num_turns) are populated from the same SDK message types.
+
+**Files:**
+- Modify: `src/holodeck/lib/backends/claude_backend.py:759-864` (the `send()` method body)
+- Test: `tests/unit/lib/backends/test_claude_backend.py` — rewrite the existing `TestClaudeSessionSend` class to mock `query` instead of `ClaudeSDKClient`
+
+- [ ] **Step 1: Write the failing test (multi-turn resume= propagation)**
+
+Add a new test class to `tests/unit/lib/backends/test_claude_backend.py` (delete the existing `TestClaudeSessionSend` class and replace it with the below — the multi-turn test is the load-bearing one):
+
+```python
+@pytest.mark.unit
+class TestClaudeSessionSend:
+    """ClaudeSession.send() under spec 034 P4 (hybrid sessions).
+
+    send() calls top-level claude_agent_sdk.query() with a streaming-mode
+    prompt envelope and ``options.resume = self._sdk_session_id``. session_id
+    is captured from ResultMessage on turn 1.
+    """
+
+    @pytest.mark.asyncio
+    async def test_send_returns_execution_result(self) -> None:
+        assistant = _make_assistant_message(
+            [_make_text_block("Hello "), _make_text_block("world!")]
+        )
+        result_msg = _make_result_message(session_id="sdk-sess-001")
+
+        async def fake_query(prompt, options):
+            for m in (assistant, result_msg):
+                yield m
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            result = await session.send("Hi")
+
+        assert isinstance(result, ExecutionResult)
+        assert result.response == "Hello world!"
+        assert result.token_usage.prompt_tokens == 10
+        assert session._sdk_session_id == "sdk-sess-001"
+
+    @pytest.mark.asyncio
+    async def test_send_enriches_tool_results_with_name(self) -> None:
+        """Regression: tool_results must carry tool name (call_id → name lookup)."""
+        tool_use = _make_tool_use_block(
+            tool_id="call_abc",
+            name="mcp__holodeck_tools__legislation_search_search",
+            inp={"query": "sec3"},
+        )
+        assistant = _make_assistant_message([_make_text_block("ok"), tool_use])
+
+        tool_result_block = _make_tool_result_block("call_abc", "chunk text", False)
+        user_msg = MagicMock()
+        user_msg.content = [tool_result_block]
+        user_msg.__class__.__name__ = "UserMessage"
+
+        async def fake_query(prompt, options):
+            for m in (assistant, user_msg, _make_result_message()):
+                yield m
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            result = await session.send("search")
+
+        assert result.tool_calls[0]["name"] == (
+            "mcp__holodeck_tools__legislation_search_search"
+        )
+        assert result.tool_results[0]["name"] == (
+            "mcp__holodeck_tools__legislation_search_search"
+        )
+        assert result.tool_results[0]["call_id"] == "call_abc"
+
+    @pytest.mark.asyncio
+    async def test_send_propagates_session_id_into_resume_on_turn_2(
+        self,
+    ) -> None:
+        """Turn 1 captures session_id from ResultMessage; turn 2's query() call
+        must pass that id back as ``options.resume`` so the SDK rehydrates the
+        on-disk transcript.
+        """
+        captured_options: list[Any] = []
+
+        async def fake_query(prompt, options):
+            captured_options.append(options)
+            yield _make_assistant_message()
+            yield _make_result_message(session_id="sdk-sess-XYZ")
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            await session.send("Turn 1")
+            await session.send("Turn 2")
+
+        assert len(captured_options) == 2
+        # Turn 1: no prior session_id, resume must be None.
+        assert getattr(captured_options[0], "resume", None) is None
+        # Turn 2: must carry the captured session_id from turn 1.
+        assert captured_options[1].resume == "sdk-sess-XYZ"
+        # Session is the same across turns.
+        assert session._sdk_session_id == "sdk-sess-XYZ"
+        assert session._turn_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_uses_streaming_mode_prompt(self) -> None:
+        """The prompt passed to query() must be an AsyncIterable, not a str —
+        string-mode closes stdin and deadlocks SDK MCP tool callbacks (spec
+        034 P4 spike v1).
+        """
+        captured_prompts: list[Any] = []
+
+        async def fake_query(prompt, options):
+            captured_prompts.append(prompt)
+            # Drain the prompt iterable so the test sees what was sent.
+            async for _ in prompt:
+                pass
+            yield _make_result_message()
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            await session.send("Hi")
+
+        assert len(captured_prompts) == 1
+        # Must be an async iterable, not a str.
+        assert not isinstance(captured_prompts[0], str)
+        assert hasattr(captured_prompts[0], "__aiter__")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestClaudeSessionSend -v
+```
+
+Expected: 4 failures. The existing implementation calls `client.query()` not the top-level `query()`, and never sets `_sdk_session_id`.
+
+- [ ] **Step 3: Re-implement `send()`**
+
+Edit `src/holodeck/lib/backends/claude_backend.py`. Replace the entire body of `ClaudeSession.send()` (currently lines 759-864) with:
+
+```python
+async def send(self, message: str) -> ExecutionResult:
+    """Send a message and collect the full response.
+
+    Args:
+        message: User message text.
+
+    Returns:
+        ``ExecutionResult`` with the agent's response.
+
+    Raises:
+        BackendSessionError: On subprocess or SDK error.
+    """
+    async with self._send_lock:
+        turn_no = self._turn_count + 1
+        logger.debug(
+            "[trace] ClaudeSession.send turn=%d: entering, resume=%s",
+            turn_no,
+            self._sdk_session_id,
+        )
+        try:
+            options = self._options_with_hooks()
+            if self._sdk_session_id is not None:
+                import dataclasses
+
+                options = dataclasses.replace(
+                    options, resume=self._sdk_session_id
+                )
+
+            text_parts: list[str] = []
+            tool_calls: list[dict[str, Any]] = []
+            tool_results: list[dict[str, Any]] = []
+            token_usage = TokenUsage.zero()
+            num_turns = 1
+            structured_output: Any = None
+
+            msg_count = 0
+            async for msg in query(
+                prompt=_streaming_user_envelope(message), options=options
+            ):
+                msg_count += 1
+                logger.debug(
+                    "[trace] ClaudeSession.send turn=%d: msg #%d type=%s",
+                    turn_no,
+                    msg_count,
+                    msg.__class__.__name__,
+                )
+                _maybe_emit_subagent_message(msg, self._tool_event_queue)
+                text_parts, tool_calls, tool_results = _process_message(
+                    msg, text_parts, tool_calls, tool_results
+                )
+                if msg.__class__.__name__ == "ResultMessage":
+                    rm = cast(Any, msg)
+                    usage = rm.usage or {}
+                    prompt_tokens = usage.get("input_tokens", 0)
+                    completion = usage.get("output_tokens", 0)
+                    token_usage = TokenUsage(
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion,
+                        total_tokens=prompt_tokens + completion,
+                    )
+                    num_turns = rm.num_turns
+                    structured_output = rm.structured_output
+                    if self._sdk_session_id is None:
+                        captured = getattr(rm, "session_id", None)
+                        if isinstance(captured, str) and captured:
+                            self._sdk_session_id = captured
+
+            logger.debug(
+                "[trace] ClaudeSession.send turn=%d: exited, "
+                "msg_count=%d, num_turns=%d, sdk_session_id=%s",
+                turn_no,
+                msg_count,
+                num_turns,
+                self._sdk_session_id,
+            )
+            self._turn_count += 1
+
+            _enrich_tool_results(tool_calls, tool_results)
+
+            response_text = "".join(text_parts)
+            if structured_output is not None:
+                response_text = json.dumps(structured_output)
+
+            return ExecutionResult(
+                response=response_text,
+                tool_calls=tool_calls,
+                tool_results=tool_results,
+                token_usage=token_usage,
+                structured_output=structured_output,
+                num_turns=num_turns,
+            )
+        except (ProcessError, CLIConnectionError) as exc:
+            raise BackendSessionError(
+                f"subprocess terminated unexpectedly: {exc}"
+            ) from exc
+```
+
+Then add `query` to the top-level SDK import (the module already imports `ClaudeAgentOptions, ClaudeSDKClient` around line 19-25). Modify that import block:
+
+```python
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    HookMatcher,
+    query,
+)
+```
+
+- [ ] **Step 4: Run the rewritten send() tests**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestClaudeSessionSend -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Run the full claude_backend test module to surface regressions**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py -n auto -v
+```
+
+Expected: many passes, plus some failures in `TestClaudeSessionStreaming`, `TestClaudeSessionEnsureClient`, `TestClaudeSessionClose`, `TestClaudeBackendLazyInit::test_session_prepare_invokes_connect`. Those are intentional — Tasks 4-6 will fix them. Capture the failing test names; if any test outside that list fails, stop and investigate before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/holodeck/lib/backends/claude_backend.py tests/unit/lib/backends/test_claude_backend.py
+git commit -m "feat(spec-034 P4): ClaudeSession.send() uses query(resume=)"
+```
+
+---
+
+## Task 4: Re-implement `ClaudeSession.send_streaming()` on top of `query(resume=)`
+
+**Why:** Same architectural swap as Task 3 but for the AG-UI hot path. `send_streaming()` is what the AG-UI bridge calls per turn. Yields text chunks progressively as `AssistantMessage` frames arrive; captures `session_id` from `ResultMessage` on turn 1.
+
+**Files:**
+- Modify: `src/holodeck/lib/backends/claude_backend.py:866-893` (the `send_streaming()` method body)
+- Test: `tests/unit/lib/backends/test_claude_backend.py` — rewrite the existing `TestClaudeSessionStreaming` class
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the existing `TestClaudeSessionStreaming` class with:
+
+```python
+@pytest.mark.unit
+class TestClaudeSessionStreaming:
+    """ClaudeSession.send_streaming() under spec 034 P4."""
+
+    @pytest.mark.asyncio
+    async def test_send_streaming_yields_chunks(self) -> None:
+        chunk1 = _make_assistant_message([_make_text_block("Hello ")])
+        chunk2 = _make_assistant_message([_make_text_block("world!")])
+        result_msg = _make_result_message(session_id="sdk-stream-001")
+
+        async def fake_query(prompt, options):
+            for m in (chunk1, chunk2, result_msg):
+                yield m
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            chunks: list[str] = []
+            async for chunk in session.send_streaming("Hi"):
+                chunks.append(chunk)
+
+        assert chunks == ["Hello ", "world!"]
+        assert session._sdk_session_id == "sdk-stream-001"
+
+    @pytest.mark.asyncio
+    async def test_send_streaming_propagates_session_id_on_turn_2(self) -> None:
+        captured_options: list[Any] = []
+
+        async def fake_query(prompt, options):
+            captured_options.append(options)
+            yield _make_assistant_message([_make_text_block("ok")])
+            yield _make_result_message(session_id="sdk-stream-XYZ")
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            async for _ in session.send_streaming("Turn 1"):
+                pass
+            async for _ in session.send_streaming("Turn 2"):
+                pass
+
+        assert getattr(captured_options[0], "resume", None) is None
+        assert captured_options[1].resume == "sdk-stream-XYZ"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestClaudeSessionStreaming -v
+```
+
+Expected: 2 failures (current impl still calls `client.query`).
+
+- [ ] **Step 3: Re-implement `send_streaming()`**
+
+Edit `src/holodeck/lib/backends/claude_backend.py`. Replace the entire body of `send_streaming()` (currently lines 866-893):
+
+```python
+async def send_streaming(
+    self, message: str
+) -> AsyncGenerator[str, None]:
+    """Send a message and yield text chunks progressively.
+
+    Args:
+        message: User message text.
+
+    Yields:
+        Text chunks as they arrive from the SDK.
+
+    Raises:
+        BackendSessionError: On subprocess or SDK error.
+    """
+    async with self._send_lock:
+        options = self._options_with_hooks()
+        if self._sdk_session_id is not None:
+            import dataclasses
+
+            options = dataclasses.replace(
+                options, resume=self._sdk_session_id
+            )
+
+        try:
+            async for msg in query(
+                prompt=_streaming_user_envelope(message), options=options
+            ):
+                _maybe_emit_subagent_message(msg, self._tool_event_queue)
+                if msg.__class__.__name__ == "AssistantMessage":
+                    for block in cast(Any, msg).content:
+                        if block.__class__.__name__ == "TextBlock" and block.text:
+                            yield block.text
+                elif msg.__class__.__name__ == "ResultMessage":
+                    self._turn_count += 1
+                    if self._sdk_session_id is None:
+                        captured = getattr(msg, "session_id", None)
+                        if isinstance(captured, str) and captured:
+                            self._sdk_session_id = captured
+        except (ProcessError, CLIConnectionError) as exc:
+            raise BackendSessionError(
+                f"subprocess terminated unexpectedly: {exc}"
+            ) from exc
+```
+
+- [ ] **Step 4: Run the streaming tests**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestClaudeSessionStreaming -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/holodeck/lib/backends/claude_backend.py tests/unit/lib/backends/test_claude_backend.py
+git commit -m "feat(spec-034 P4): ClaudeSession.send_streaming() uses query(resume=)"
+```
+
+---
+
+## Task 5: `close()` deletes the on-disk JSONL transcript
+
+**Why:** Without cleanup, every ever-opened session leaves a JSONL file at `~/.claude/projects/<encoded-cwd>/<session_id>.jsonl` forever. For a long-lived deployment that's effectively a memory leak on disk. On `close()`, delete the transcript whose name matches `self._sdk_session_id`. The path-encoding rule used by the Claude CLI is to replace `/` with `-` in the absolute cwd.
+
+**Files:**
+- Modify: `src/holodeck/lib/backends/claude_backend.py:895-917` (`release_transport`, `close`)
+- Test: `tests/unit/lib/backends/test_claude_backend.py` — rewrite `TestClaudeSessionClose`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the existing `TestClaudeSessionClose` class with:
+
+```python
+@pytest.mark.unit
+class TestClaudeSessionClose:
+    """ClaudeSession.close() under spec 034 P4 — transcript cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_close_deletes_transcript_file(self, tmp_path) -> None:
+        """close() deletes ``~/.claude/projects/<encoded-cwd>/<id>.jsonl``."""
+        # Stand up a fake projects dir; point the helper at it.
+        cwd_encoded = str(tmp_path / "fake-cwd").replace("/", "-")
+        transcript = tmp_path / "projects" / cwd_encoded / "sess-001.jsonl"
+        transcript.parent.mkdir(parents=True)
+        transcript.write_text('{"type":"user"}\n')
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        session._sdk_session_id = "sess-001"
+
+        with patch(
+            "holodeck.lib.backends.claude_backend._transcript_path",
+            return_value=transcript,
+        ):
+            await session.close()
+
+        assert not transcript.exists()
+        assert session._sdk_session_id is None
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_when_transcript_missing(self) -> None:
+        """No-op when the transcript file doesn't exist (race / never-spawned)."""
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        session._sdk_session_id = "never-spawned"
+        with patch(
+            "holodeck.lib.backends.claude_backend._transcript_path",
+            return_value=Path("/nonexistent/path.jsonl"),
+        ):
+            await session.close()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_close_no_session_id_is_noop(self) -> None:
+        """Sessions that never sent a turn have no transcript to delete."""
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        await session.close()  # must not raise
+        assert session._sdk_session_id is None
+
+    def test_implements_agent_session_protocol(self) -> None:
+        """ClaudeSession still satisfies the AgentSession protocol."""
+        assert isinstance(
+            ClaudeSession(options=MagicMock()), AgentSession
+        )
+```
+
+Also add `from pathlib import Path` and `from unittest.mock import patch` to the test imports if not already present.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestClaudeSessionClose -v
+```
+
+Expected: 3 failures (helper `_transcript_path` doesn't exist yet; current `close()` calls `client.disconnect()` and won't unset `_sdk_session_id`). The protocol-conformance test should already pass.
+
+- [ ] **Step 3: Add `_transcript_path` helper + rewrite `close()`**
+
+Edit `src/holodeck/lib/backends/claude_backend.py`. Add this helper near the other module-level helpers (e.g., just before `class ClaudeSession`):
+
+```python
+def _transcript_path(session_id: str, cwd: Path | None = None) -> Path:
+    """Return the on-disk JSONL transcript path for a session_id.
+
+    The Claude CLI writes per-session transcripts to
+    ``~/.claude/projects/<encoded-cwd>/<session_id>.jsonl`` where
+    ``encoded-cwd`` is the absolute cwd with ``/`` replaced by ``-``.
+    """
+    base = cwd if cwd is not None else Path.cwd()
+    encoded = str(base.resolve()).replace("/", "-")
+    return Path.home() / ".claude" / "projects" / encoded / f"{session_id}.jsonl"
+```
+
+Add `from pathlib import Path` to the module-level imports if not already there.
+
+Replace the body of `release_transport()` and `close()` (currently lines 895-917) with:
+
+```python
+async def release_transport(self) -> None:
+    """No-op under spec 034 P4.
+
+    Retained for backwards compatibility with the chat executor's
+    ``_TaskBoundSession``. Under the hybrid-session model each turn's
+    subprocess is created and torn down inside ``query()``; there is no
+    persistent transport to release between turns.
+    """
+    return None
+
+async def close(self) -> None:
+    """Delete the on-disk JSONL transcript and clear session state.
+
+    Under spec 034 P4 the session has no persistent subprocess to
+    disconnect. Conversation state lives on disk at
+    ``~/.claude/projects/<encoded-cwd>/<sdk_session_id>.jsonl``. Closing
+    the session permanently discards that transcript so the next
+    open of the same threadId starts fresh.
+    """
+    if self._sdk_session_id is not None:
+        path = _transcript_path(self._sdk_session_id)
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning(
+                "Failed to delete transcript %s: %s", path, exc
+            )
+        self._sdk_session_id = None
+```
+
+- [ ] **Step 4: Run the close tests**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestClaudeSessionClose -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/holodeck/lib/backends/claude_backend.py tests/unit/lib/backends/test_claude_backend.py
+git commit -m "feat(spec-034 P4): ClaudeSession.close() deletes JSONL transcript"
+```
+
+---
+
+## Task 6: Strip the dead persistent-client machinery
+
+**Why:** Under P4 nothing reads `self._client`, nothing calls `_ensure_client()`, nothing benefits from `_patch_hooks_for_context_propagation`, and `_DEFAULT_SESSION_ID` is no longer relevant. Leaving them in place would mislead future readers ("does the session use a persistent client or per-turn query?"). Delete the dead code.
+
+**Files:**
+- Modify: `src/holodeck/lib/backends/claude_backend.py` — delete `_DEFAULT_SESSION_ID` (around line 69-79), `_patch_hooks_for_context_propagation` (around line 485-540), `_ensure_client` method (around line 739-757), `_client` field, `claude_agent_sdk` module-level import (used only inside `_ensure_client`)
+- Modify: `ClaudeSession.prepare()` body becomes a no-op (kept as a shim — `_TaskBoundSession` calls it).
+- Test: delete `TestClaudeSessionEnsureClient` class entirely. Modify `TestClaudeBackendLazyInit::test_session_prepare_invokes_connect` to assert `prepare()` is a no-op (no connect to invoke).
+
+- [ ] **Step 1: Delete the dead code in source**
+
+Edit `src/holodeck/lib/backends/claude_backend.py`:
+
+1. Remove the `_DEFAULT_SESSION_ID` constant block (around lines 69-79).
+2. Remove `_patch_hooks_for_context_propagation` function entirely.
+3. Remove `_ensure_client()` method from `ClaudeSession`.
+4. Remove `self._client: ClaudeSDKClient | None = None` from `__init__`.
+5. Replace `ClaudeSession.prepare()` body with:
+
+```python
+async def prepare(self) -> None:
+    """No-op under spec 034 P4.
+
+    Retained for backwards compatibility with the chat executor's
+    ``_TaskBoundSession``. Under the hybrid-session model the SDK's
+    anyio task group is created inside each ``query()`` call frame,
+    so there is no task-binding to do up front.
+    """
+    return None
+```
+
+6. Remove `import claude_agent_sdk` at the top of the file (it was only used inside `_ensure_client`). Leave `from claude_agent_sdk import ...` (used by Task 3).
+7. Remove `ClaudeSDKClient` from the `from claude_agent_sdk import (...)` block — it is no longer referenced.
+
+- [ ] **Step 2: Delete the obsolete test classes**
+
+In `tests/unit/lib/backends/test_claude_backend.py`:
+
+1. Delete the entire `TestClaudeSessionEnsureClient` class (around line 2101).
+2. Modify `TestClaudeBackendLazyInit::test_session_prepare_invokes_connect`. Find it (around line 1448) and replace its body with:
+
+```python
+@pytest.mark.asyncio
+async def test_session_prepare_is_noop(self) -> None:
+    """spec 034 P4: ClaudeSession.prepare() no longer connects a client —
+    each query() call manages its own transport. prepare() must succeed
+    without raising so existing _TaskBoundSession callers stay working.
+    """
+    session = ClaudeSession(options=MagicMock())
+    await session.prepare()  # must not raise
+    # No client to assert against; just confirm field is gone.
+    assert not hasattr(session, "_client")
+```
+
+- [ ] **Step 3: Run the full claude_backend test module**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py -n auto -v
+```
+
+Expected: all green. If anything fails outside the test classes you modified, stop and inspect — it is likely a test that was reaching into a deleted attribute.
+
+- [ ] **Step 4: Run the full unit suite to catch fan-out regressions**
+
+```bash
+pytest tests/unit -n auto -q
+```
+
+Expected: all green. Watch for failures in `tests/unit/serve/` (the AG-UI bridge tests use real `ClaudeSession` instances via the bridge — they may patch removed attributes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/holodeck/lib/backends/claude_backend.py tests/unit/lib/backends/test_claude_backend.py
+git commit -m "refactor(spec-034 P4): drop dead persistent-client machinery"
+```
+
+---
+
+## Task 7: Add unit test for the lock — concurrent sends serialise
+
+**Why:** Two concurrent `send()` calls on the same session with the same `resume=` would each spawn a fresh subprocess reading and appending the same JSONL transcript. The `_send_lock` added in Task 2 serialises them. Add an explicit test so the next person who tries to "optimise" by removing the lock breaks a test instead of production.
+
+**Files:**
+- Test: `tests/unit/lib/backends/test_claude_backend.py` — extend `TestClaudeSessionP4Fields` from Task 2
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `TestClaudeSessionP4Fields`:
+
+```python
+@pytest.mark.asyncio
+async def test_concurrent_sends_serialise(self) -> None:
+    """Two concurrent send() calls must not invoke query() in parallel.
+    The lock prevents transcript-write races under the resume= model.
+    """
+    in_flight = 0
+    max_concurrent = 0
+
+    async def fake_query(prompt, options):
+        nonlocal in_flight, max_concurrent
+        in_flight += 1
+        max_concurrent = max(max_concurrent, in_flight)
+        # Yield control so the second send() has a chance to enter.
+        await asyncio.sleep(0)
+        yield _make_assistant_message()
+        yield _make_result_message(session_id="sess-conc")
+        in_flight -= 1
+
+    session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+    with patch(
+        "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+    ):
+        await asyncio.gather(session.send("a"), session.send("b"))
+
+    assert max_concurrent == 1, (
+        "expected lock to serialise concurrent sends, "
+        f"got max_concurrent={max_concurrent}"
+    )
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+pytest tests/unit/lib/backends/test_claude_backend.py::TestClaudeSessionP4Fields::test_concurrent_sends_serialise -v
+```
+
+Expected: PASS (the lock was added in Task 2 and used in Tasks 3-4). If it fails, the lock is not being acquired — go inspect `send()` / `send_streaming()`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/lib/backends/test_claude_backend.py
+git commit -m "test(spec-034 P4): cover send-lock serialisation under concurrency"
+```
+
+---
+
+## Task 8: Quality gates
+
+**Why:** Before deploy validation, lock in the static-analysis story so the deploy iteration loop doesn't surface formatting / typing surprises.
+
+- [ ] **Step 1: Format + lint**
+
+```bash
+make format && make lint
+```
+
+Expected: both pass. If lint fails, fix the report.
+
+- [ ] **Step 2: Type-check**
+
+```bash
+rm -rf .mypy_cache && make type-check
+```
+
+Expected: no new errors compared to baseline (pre-existing errors in `keyword_search.py`, `vector_store.py`, `hierarchical_document_tool.py`, `serve/server.py`, etc. are unrelated to P4 and may stay). If the diff between this run and `git stash && make type-check` shows new errors in `claude_backend.py`, fix them.
+
+- [ ] **Step 3: Security scan**
+
+```bash
+make security
+```
+
+Expected: no high-severity findings introduced by P4.
+
+- [ ] **Step 4: Commit any auto-fixes from format/lint**
+
+```bash
+git status
+# If anything changed under src/ or tests/:
+git add -p  # interactive review
+git commit -m "chore(spec-034 P4): formatting + lint cleanup"
+```
+
+If nothing changed, skip this step.
+
+---
+
+## Task 9: End-to-end deploy validation
+
+**Why:** The unit tests cover the session-model swap, but the real binary risks (AG-UI stream-shape compat, OTel context propagation, subprocess spawn jitter under concurrent load) only surface in a live deployment. Run the deploy validation loop from `CLAUDE.md` against `sample/financial-assistant/claude`.
+
+**This task must be approved by the human operator before running** (it builds a docker image, pushes to GHCR, rolls a live ACA revision). Do not run automatically.
+
+- [ ] **Step 1: Get approval**
+
+Ask: "Ready to run the end-to-end deploy validation loop for P4 on `sample/financial-assistant/claude`? It will rebuild the base image with the working-tree wheel, push, and roll a new ACA revision."
+
+Block until the operator confirms.
+
+- [ ] **Step 2: Run the validation loop**
+
+Follow the exact sequence in `CLAUDE.md` under "End-to-End Deploy Validation Loop":
+
+```bash
+# 1. Local wheel
+rm -rf dist && uv build --wheel
+
+# 2. Local base image
+docker buildx build --platform linux/amd64 --no-cache \
+    -f docker/Dockerfile.local \
+    -t ghcr.io/justinbarias/holodeck-base:latest --load .
+docker run --rm --entrypoint python ghcr.io/justinbarias/holodeck-base:latest \
+    -c "import holodeck; print(holodeck.__version__)"
+
+# 3. Flip pull=True → pull=False in src/holodeck/deploy/builder.py (will revert
+#    in step 7).
+
+# 4. Agent image
+cd sample/financial-assistant/claude
+holodeck deploy build
+docker push ghcr.io/justinbarias/holodeck-financial-assistant:<tag>
+
+# 5. ACA deploy
+holodeck deploy run
+
+# 6. Health + smoke
+URL=https://financial-assistant.nicemoss-50caf9f5.eastus.azurecontainerapps.io
+until curl -sf -o /dev/null --max-time 5 "$URL/health"; do sleep 3; done
+curl -sS -X POST "$URL/awp" -H 'content-type: application/json' \
+    -d '{"threadId":"p4-smoke","runId":"r1","state":{},"messages":[{"id":"m1","role":"user","content":"What were ALXN'\''s 2007 rental payments?"}],"tools":[],"context":[],"forwardedProps":{}}' \
+    --max-time 180
+
+# 7. Revert builder.py pull=False → pull=True.
+```
+
+- [ ] **Step 3: Verify AG-UI stream shape**
+
+The smoke curl must return a 200 with a coherent answer referencing ALXN/2007. If the stream looks malformed (events out of order, missing TEXT_MESSAGE_CHUNK, missing RUN_FINISHED), capture the raw response and stop — the SDK-message-to-AG-UI translation layer has a P4-specific bug that needs fixing.
+
+- [ ] **Step 4: Multi-turn AG-UI verification**
+
+Re-use the same `threadId` (`p4-smoke`) and send a follow-up:
+
+```bash
+curl -sS -X POST "$URL/awp" -H 'content-type: application/json' \
+    -d '{"threadId":"p4-smoke","runId":"r2","state":{},"messages":[{"id":"m1","role":"user","content":"What were ALXN'\''s 2007 rental payments?"},{"id":"m2","role":"assistant","content":"<answer-from-r1>"},{"id":"m3","role":"user","content":"And the prior year?"}],"tools":[],"context":[],"forwardedProps":{}}' \
+    --max-time 180
+```
+
+The response must reference ALXN/2007 (the anchor from turn 1) — if it says "which company?" or asks for clarification, `resume=` is not actually being propagated into the bridge. Spike v2 proved the SDK side works; this would mean the AG-UI bridge is dropping the session id between turns.
+
+- [ ] **Step 5: Concurrent-burst validation (regression of P1 OOM scenario)**
+
+In one shell:
+
+```bash
+for tid in p4-burst-{1..5}; do
+  curl -sS -X POST "$URL/awp" -H 'content-type: application/json' \
+      -d "{\"threadId\":\"$tid\",\"runId\":\"r1\",\"state\":{},\"messages\":[{\"id\":\"m1\",\"role\":\"user\",\"content\":\"What were ALXN's 2007 rental payments?\"}],\"tools\":[],\"context\":[],\"forwardedProps\":{}}" \
+      --max-time 180 \
+      -o /tmp/p4-burst-$tid.out -w "%{http_code} t=%{time_total}s\n" &
+done
+wait
+```
+
+Expect: all five return 200 within ~60s. Under P1 with a 2 GiB replica + cap=4, the 5th burst returned 429. Under P4 with idle sessions costing ~0 memory, the cap should not bind here. If anything returns 429 or 5xx, capture container memory at the time of the burst and add to the spec.
+
+- [ ] **Step 6: Capture observations**
+
+Record in `specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md` under the Phase 4 section:
+- Per-turn AG-UI latency vs P1 baseline
+- Whether OTel traces propagated (eyeball one trace in Aspire / Azure Monitor)
+- Whether the 5-concurrent burst succeeded
+- Replica memory at concurrent-burst peak
+
+- [ ] **Step 7: Commit the spec update**
+
+```bash
+git add specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md
+git commit -m "docs(spec-034): P4 end-to-end deploy validation results"
+```
+
+- [ ] **Step 8: Open PR**
+
+```bash
+git push -u origin feature/034-p4-hybrid-sessions
+gh pr create --title "feat(spec-034): P4 hybrid sessions (subprocess pooling via query+resume)" --body "$(cat <<'EOF'
+## Summary
+- Swap `ClaudeSession`'s persistent `ClaudeSDKClient` for per-turn `query(resume=session_id)` calls.
+- Idle sessions now cost ~0 resident memory; the `SessionStore` cap correctly applies to concurrent active turns.
+- Streaming-mode prompts (AsyncIterable envelope) are mandatory — string mode closes stdin and deadlocks SDK MCP tool callbacks (spike v1 surfaced this).
+- `close()` deletes the on-disk JSONL transcript; per-session `asyncio.Lock` serialises concurrent sends to prevent transcript-write races.
+- Spike data and design recorded in `specs/034-production-hardening/2026-05-18-production-hardening-for-claude-agents.md` Phase 4.
+
+## Test plan
+- [x] Unit: `TestClaudeSessionSend`, `TestClaudeSessionStreaming`, `TestClaudeSessionClose`, `TestClaudeSessionP4Fields`, `TestStreamingUserEnvelope`.
+- [x] Lint + type + security gates green.
+- [x] End-to-end deploy validation on `sample/financial-assistant/claude` (single-turn smoke, multi-turn resume, 5-concurrent burst).
+- [x] AG-UI stream shape preserved across the bridge.
+
+## Closes
+Phase 4 of spec 034 (hybrid sessions / subprocess pooling).
+EOF
+)"
+```
+
+---
+
+## Known follow-ups (do NOT include in this PR)
+
+These were surfaced during spike v2 and remain open. Add as TODOs against spec 034 P4 but do not implement in this PR (scope discipline):
+
+1. **Transcript size budget.** Long-running sessions accumulate every tool-use/tool-result block in the JSONL; 50 turns × 5 retrievals × 8 KiB ≈ 2 MiB transcript that gets re-read every turn. Add a `claude.max_transcript_bytes` knob + rolling-summary fallback before exposing P4 to chat UIs with multi-hour sessions.
+2. **Idle-session TTL.** `ServerSession` objects in `SessionStore` still pin a Python object per threadId forever; the on-disk transcript also lives forever between turns. Add a TTL (e.g. 1 hour idle) that calls `ClaudeSession.close()` and removes the entry from `SessionStore`.
+3. **OTel context propagation.** The `_patch_hooks_for_context_propagation` workaround targeted a persistent `ClaudeSDKClient` that no longer exists under P4. Verify the OTel instrumentor still wires invocation context through top-level `query()` — if not, file a follow-up to either patch `claude_agent_sdk.query` or set the ContextVar before the call in `send()` / `send_streaming()`.
+4. **Drop `_TaskBoundSession`.** Under P4 it's a no-op wrapper (the persistent-transport-task-binding problem it solved no longer exists). Removing it simplifies `chat/executor.py` and `serve/server.py`. Separate PR.
+5. **Repurpose `SessionStore` cap from "open sessions" to "concurrent active turns".** Today it counts threadIds; under P4 the OOM constraint is concurrent active turns, not idle threads. Until this lands, the cap is still binding but for the wrong reason (it'll reject a 6th threadId even if all 5 prior threads are idle).

--- a/src/holodeck/chat/executor.py
+++ b/src/holodeck/chat/executor.py
@@ -293,7 +293,6 @@ class AgentExecutor:
                 self.agent_config,
                 tool_instances=None,
                 mode="chat",
-                allow_side_effects=False,
             )
 
         if self._use_task_bound_session:

--- a/src/holodeck/deploy/builder.py
+++ b/src/holodeck/deploy/builder.py
@@ -238,7 +238,7 @@ class ContainerBuilder:
                 labels=labels or {},
                 rm=True,  # Remove intermediate containers
                 platform=platform,
-                pull=True,  # Always pull base image to get correct platform
+                pull=True,  # Always pull base image
                 **build_kwargs,
             )
 

--- a/src/holodeck/deploy/deployers/azure_containerapps.py
+++ b/src/holodeck/deploy/deployers/azure_containerapps.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
@@ -12,6 +13,8 @@ from holodeck.models.deployment import (
     DeployResult,
     StatusResult,
 )
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from azure.core.exceptions import (
@@ -121,15 +124,21 @@ class AzureContainerAppsDeployer(BaseDeployer):
         port: int,
         env_vars: dict[str, str],
         health_check_path: str = "/health",
+        readiness_path: str = "/ready",
         **kwargs: Any,
     ) -> DeployResult:
         """Deploy a container to Azure Container Apps."""
+        self._echo_resolved_config(
+            service_name=service_name, image_uri=image_uri, port=port
+        )
+
         env_list = [
             self._EnvironmentVar(name=key, value=value)
             for key, value in env_vars.items()
         ]
 
-        # Configure liveness probe for health monitoring
+        # Liveness probe — "is this process still alive". Failure → ACA
+        # restarts the replica.
         liveness_probe = self._ContainerAppProbe(
             type="Liveness",
             http_get=self._ContainerAppProbeHttpGet(
@@ -142,6 +151,22 @@ class AzureContainerAppsDeployer(BaseDeployer):
             timeout_seconds=5,
         )
 
+        # Readiness probe — "is this replica ready to receive traffic". The
+        # serve layer's /ready endpoint reflects server state; ACA holds
+        # traffic off until this returns 200 so cold replicas don't race
+        # their first request against init work (spec 034 P1a).
+        readiness_probe = self._ContainerAppProbe(
+            type="Readiness",
+            http_get=self._ContainerAppProbeHttpGet(
+                port=port,
+                path=readiness_path,
+            ),
+            initial_delay_seconds=5,
+            period_seconds=10,
+            failure_threshold=3,
+            timeout_seconds=5,
+        )
+
         container = self._Container(
             name=service_name,
             image=image_uri,
@@ -150,7 +175,7 @@ class AzureContainerAppsDeployer(BaseDeployer):
                 memory=self._config.memory,
             ),
             env=env_list if env_list else None,
-            probes=[liveness_probe],
+            probes=[liveness_probe, readiness_probe],
         )
 
         scale = self._Scale(
@@ -309,6 +334,61 @@ class AzureContainerAppsDeployer(BaseDeployer):
         raise NotImplementedError(
             "Log streaming is not implemented for Azure Container Apps."
         )
+
+    def _echo_resolved_config(
+        self, *, service_name: str, image_uri: str, port: int
+    ) -> None:
+        """Log the resolved deployment configuration before applying it.
+
+        Surfaces the values that will land on the Container App so an
+        operator running ``holodeck deploy run`` can see the new spec
+        034 defaults (1 CPU / 2 GiB, internal ingress) before the apply
+        completes. Cheap, visible, and the only output an operator sees
+        for the runtime sizing decisions.
+        """
+        import math
+
+        # Mirror the serve layer's derivation so the operator sees the
+        # cap they'll get for this replica.
+        derived_session_cap = max(1, math.floor(self._config.cpu * 2))
+        ingress_mode = (
+            "external (public)" if self._config.ingress_external else "internal"
+        )
+
+        logger.info("Deploying %s to Azure Container Apps", service_name)
+        logger.info("  Image: %s", image_uri)
+        logger.info("  Port: %d", port)
+        logger.info(
+            "  Replica: %.2f CPU / %s memory",
+            self._config.cpu,
+            self._config.memory,
+        )
+        logger.info(
+            "  Concurrent Claude sessions per replica (default): %d",
+            derived_session_cap,
+        )
+        logger.info(
+            "  Replicas: min=%d, max=%d",
+            self._config.min_replicas,
+            self._config.max_replicas,
+        )
+        logger.info("  Ingress: %s", ingress_mode)
+        logger.info("  Probes: /health (liveness), /ready (readiness)")
+
+        if self._config.cpu < 1.0:
+            logger.warning(
+                "Replica CPU %.2f is below Anthropic's recommended minimum "
+                "of 1.0 per Claude SDK instance. Concurrent sessions will "
+                "cap at %d. Consider raising `deployment.target.azure.cpu`.",
+                self._config.cpu,
+                derived_session_cap,
+            )
+        if self._config.ingress_external:
+            logger.warning(
+                "Container App will be reachable from the PUBLIC INTERNET "
+                "(ingress_external=true). Set `deployment.target.azure."
+                "ingress_external: false` if this is unintentional."
+            )
 
     @staticmethod
     def _resolve_container_app_name(service_id: str) -> str:

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -690,15 +690,25 @@ def _maybe_emit_subagent_message(
             )
 
 
-def _transcript_path(session_id: str, cwd: Path | None = None) -> Path:
+def _transcript_path(session_id: str, cwd: Path | str | None = None) -> Path:
     """Return the on-disk JSONL transcript path for a session_id.
 
     The Claude CLI writes per-session transcripts to
     ``~/.claude/projects/<encoded-cwd>/<session_id>.jsonl`` where
     ``encoded-cwd`` is the absolute cwd with ``/`` replaced by ``-``.
+
+    Args:
+        session_id: CLI-assigned conversation id (from ResultMessage).
+        cwd: The subprocess cwd the SDK passed to the CLI. Must match
+            exactly what was set on ``ClaudeAgentOptions.cwd``; do not
+            resolve symlinks here because the CLI's encoder uses the
+            raw string passed via stdin. Defaults to ``Path.cwd()``
+            for agents that don't override cwd.
     """
-    base = cwd if cwd is not None else Path.cwd()
-    encoded = str(base.resolve()).replace("/", "-")
+    base = Path(cwd) if cwd is not None else Path.cwd()
+    if not base.is_absolute():
+        base = Path.cwd() / base
+    encoded = str(base).replace("/", "-")
     return Path.home() / ".claude" / "projects" / encoded / f"{session_id}.jsonl"
 
 
@@ -964,7 +974,8 @@ class ClaudeSession:
         open of the same threadId starts fresh.
         """
         if self._sdk_session_id is not None:
-            path = _transcript_path(self._sdk_session_id)
+            cwd_value = getattr(self._base_options, "cwd", None)
+            path = _transcript_path(self._sdk_session_id, cwd=cwd_value)
             try:
                 path.unlink()
             except FileNotFoundError:

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -52,6 +52,7 @@ from holodeck.lib.backends.validators import (
     validate_tool_filtering,
     validate_working_directory,
 )
+from holodeck.lib.errors import ConfigError
 from holodeck.lib.instruction_resolver import resolve_instructions
 from holodeck.lib.observability import get_observability_context
 from holodeck.models.agent import Agent
@@ -187,37 +188,108 @@ def _process_message(
     return text_parts, tool_calls, tool_results
 
 
+_RISKY_BUILTIN_TOOLS: frozenset[str] = frozenset({"Bash", "Write", "Edit", "WebFetch"})
+
+
+def _declared_builtin_tools(claude: Any) -> set[str]:
+    """Return the set of risky built-in SDK tools the operator has declared.
+
+    A tool counts as declared when the HoloDeck schema explicitly opts in
+    via a dedicated field (claude.bash.enabled, claude.file_system.write,
+    etc.) or when the tool name appears in claude.allowed_tools.
+
+    Args:
+        claude: ``ClaudeConfig`` instance or ``None``.
+
+    Returns:
+        Subset of ``_RISKY_BUILTIN_TOOLS`` that the operator has declared.
+    """
+    declared: set[str] = set()
+    if claude is None:
+        return declared
+    if claude.bash is not None and claude.bash.enabled:
+        declared.add("Bash")
+    if claude.file_system is not None:
+        if claude.file_system.write:
+            declared.add("Write")
+        if claude.file_system.edit:
+            declared.add("Edit")
+    if claude.allowed_tools:
+        declared.update(claude.allowed_tools)
+    return declared
+
+
 def _build_permission_mode(
-    permission_mode: PermissionMode | None,
+    claude: Any,
     mode: str,
-    allow_side_effects: bool,
 ) -> str | None:
     """Map HoloDeck permission mode to SDK permission literal.
 
+    Decision tree (P1b — spec 034):
+      * ``manual`` + serve/chat context -> SDK ``acceptEdits``. The legacy
+        mapping to ``default`` wedges in serve mode because there is no
+        operator at the terminal to answer the SDK's permission prompts.
+        ``acceptEdits`` respects ``allowed_tools``/``disallowed_tools``
+        and auto-approves Edit/Write/MultiEdit; the auto-disallow of
+        dangerous built-ins (see ``_declared_builtin_tools``) is what
+        actually fails closed for un-declared tools.
+      * ``manual`` + test -> SDK ``default``. Unchanged; ``holodeck test
+        run`` has an operator at the terminal who can answer prompts.
+      * ``acceptEdits`` -> SDK ``acceptEdits``. Unchanged.
+      * ``acceptAll`` -> SDK ``bypassPermissions`` **only when**
+        ``claude.i_understand_this_is_unsafe`` is ``True``; else raise
+        ``ConfigError`` with a migration message. ``bypassPermissions``
+        disables the SDK permission system entirely.
+
+    Removed: the legacy ``if mode == "test" and permission_mode !=
+    manual: sdk_mode = bypassPermissions`` escalation silently turned
+    every test-mode ``acceptEdits`` into ``bypassPermissions``, so an
+    operator who declared "auto-approve edits, prompt for Bash" got
+    "approve everything" in ``holodeck test run``. ``acceptAll`` +
+    explicit ``i_understand_this_is_unsafe`` is now the only path to
+    ``bypassPermissions`` in any mode.
+
     Args:
-        permission_mode: HoloDeck ``PermissionMode`` enum value, or ``None``.
+        claude: ``ClaudeConfig`` instance or ``None``.
         mode: Execution mode (``"test"`` or ``"chat"``).
-        allow_side_effects: Whether side effects are allowed in test mode.
 
     Returns:
-        SDK permission mode string, or ``None`` if not configured.
+        SDK permission mode literal, or ``None`` when no claude config.
+
+    Raises:
+        ConfigError: When ``permission_mode=acceptAll`` is set without
+            ``i_understand_this_is_unsafe=true``.
     """
-    if permission_mode is None:
+    if claude is None:
         return None
 
-    mapping: dict[PermissionMode, str] = {
-        PermissionMode.manual: "default",
-        PermissionMode.acceptEdits: "acceptEdits",
-        PermissionMode.acceptAll: "bypassPermissions",
-    }
+    permission_mode: PermissionMode = claude.permission_mode
 
-    sdk_mode = mapping[permission_mode]
+    if permission_mode == PermissionMode.acceptAll:
+        if not claude.i_understand_this_is_unsafe:
+            raise ConfigError(
+                field="claude.permission_mode",
+                message=(
+                    "permission_mode='acceptAll' disables the Claude SDK "
+                    "permission system entirely, allowing any tool (including "
+                    "Bash, Write, Edit, WebFetch) to execute without "
+                    "restriction. Add `claude.i_understand_this_is_unsafe: "
+                    "true` to opt in, or — preferred — declare the specific "
+                    "tools your agent needs via `claude.bash.enabled`, "
+                    "`claude.file_system.*`, `claude.web_search`, or "
+                    "`claude.allowed_tools` and use `permission_mode: manual` "
+                    "(the default)."
+                ),
+            )
+        return "bypassPermissions"
 
-    # In test mode, override non-manual to bypassPermissions for automation
-    if mode == "test" and permission_mode != PermissionMode.manual:
-        sdk_mode = "bypassPermissions"
+    if permission_mode == PermissionMode.acceptEdits:
+        return "acceptEdits"
 
-    return sdk_mode
+    # PermissionMode.manual
+    if mode == "chat":
+        return "acceptEdits"
+    return "default"
 
 
 def _build_output_format(
@@ -254,6 +326,15 @@ def _build_output_format(
 # ---------------------------------------------------------------------------
 
 
+_DEFAULT_MAX_TURNS = 20
+"""Bound on agent loop iterations when the operator does not set one.
+
+The hosting guide explicitly calls out maxTurns as the way to prevent
+the SDK from getting stuck in a tool-call loop. 20 is high enough for
+multi-step ConvFinQA-style reasoning and low enough to bound runaway loops.
+"""
+
+
 def build_options(
     *,
     agent: Agent,
@@ -263,7 +344,6 @@ def build_options(
     auth_env: dict[str, str],
     otel_env: dict[str, str],
     mode: str,
-    allow_side_effects: bool,
 ) -> ClaudeAgentOptions:
     """Assemble ``ClaudeAgentOptions`` from agent config and bridge outputs.
 
@@ -275,7 +355,6 @@ def build_options(
         auth_env: Auth env vars from ``validate_credentials()``.
         otel_env: OTel env vars from ``translate_observability()``.
         mode: Execution mode (``"test"`` or ``"chat"``).
-        allow_side_effects: Whether side effects are allowed in test mode.
 
     Returns:
         Configured ``ClaudeAgentOptions`` ready for ``query()`` or ``ClaudeSDKClient``.
@@ -301,12 +380,8 @@ def build_options(
     if agent.model.endpoint and agent.model.auth_provider == AuthProvider.custom:
         env["ANTHROPIC_BASE_URL"] = agent.model.endpoint
 
-    # Permission mode
-    perm_mode = None
-    if claude is not None:
-        perm_mode = _build_permission_mode(
-            claude.permission_mode, mode, allow_side_effects
-        )
+    # Permission mode (raises ConfigError for acceptAll without unsafe opt-in)
+    perm_mode = _build_permission_mode(claude, mode)
 
     # Extended thinking
     max_thinking_tokens = None
@@ -333,8 +408,35 @@ def build_options(
     if cwd is None:
         cwd = agent_base_dir.get()
 
-    # Max turns
-    max_turns = claude.max_turns if claude else None
+    # Max turns — default to _DEFAULT_MAX_TURNS when unset (spec 034 P1a)
+    max_turns = (
+        claude.max_turns
+        if claude and claude.max_turns is not None
+        else _DEFAULT_MAX_TURNS
+    )
+
+    # Disallowed tools (P1b — spec 034). Auto-disallow risky built-in SDK
+    # tools (Bash, Write, Edit, WebFetch) that the operator has not declared
+    # via the dedicated schema fields or claude.allowed_tools. This is the
+    # real fail-closed lever — permission_mode is only a tiebreaker for tools
+    # not covered by either list.
+    declared = _declared_builtin_tools(claude)
+    auto_disallow = sorted(_RISKY_BUILTIN_TOOLS - declared)
+    explicit_disallow = (
+        list(claude.disallowed_tools) if claude and claude.disallowed_tools else []
+    )
+    disallowed_tools: list[str] | None = (
+        sorted(set(explicit_disallow) | set(auto_disallow))
+        if (explicit_disallow or auto_disallow)
+        else None
+    )
+    if auto_disallow:
+        logger.info(
+            "Auto-disallowed risky built-in SDK tools not declared in agent "
+            "config: %s. Declare them via claude.bash.enabled, "
+            "claude.file_system.*, or claude.allowed_tools to opt in.",
+            ", ".join(auto_disallow),
+        )
 
     # Build the options dict
     opts_kwargs: dict[str, Any] = {
@@ -348,6 +450,8 @@ def build_options(
         "cwd": cwd,
         "output_format": output_format,
     }
+    if disallowed_tools is not None:
+        opts_kwargs["disallowed_tools"] = disallowed_tools
 
     if max_thinking_tokens is not None:
         opts_kwargs["max_thinking_tokens"] = max_thinking_tokens
@@ -359,8 +463,6 @@ def build_options(
             opts_kwargs["max_budget_usd"] = claude.max_budget_usd
         if claude.fallback_model is not None:
             opts_kwargs["fallback_model"] = claude.fallback_model
-        if claude.disallowed_tools:
-            opts_kwargs["disallowed_tools"] = list(claude.disallowed_tools)
         if claude.agents:
             opts_kwargs["agents"] = {
                 name: AgentDefinition(
@@ -836,7 +938,6 @@ class ClaudeBackend:
         agent: Agent,
         tool_instances: dict[str, Any] | None = None,
         mode: str = "test",
-        allow_side_effects: bool = False,
     ) -> None:
         """Store configuration without performing any I/O.
 
@@ -844,12 +945,10 @@ class ClaudeBackend:
             agent: Agent configuration.
             tool_instances: Initialized vectorstore/hierarchical-doc tool instances.
             mode: Execution mode (``"test"`` or ``"chat"``).
-            allow_side_effects: Allow bash/file_system.write in test mode.
         """
         self._agent = agent
         self._tool_instances = tool_instances or {}
         self._mode = mode
-        self._allow_side_effects = allow_side_effects
         self._initialized = False
         self._options: ClaudeAgentOptions | None = None
         self._owned_tools: list[Any] = []  # Tools created during initialize()
@@ -922,7 +1021,6 @@ class ClaudeBackend:
                 auth_env=auth_env,
                 otel_env=otel_env,
                 mode=self._mode,
-                allow_side_effects=self._allow_side_effects,
             )
 
             # 9. Working directory collision check

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -12,6 +12,7 @@ import contextlib
 import json
 import logging
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from typing import Any, cast
 
 import claude_agent_sdk
@@ -689,6 +690,18 @@ def _maybe_emit_subagent_message(
             )
 
 
+def _transcript_path(session_id: str, cwd: Path | None = None) -> Path:
+    """Return the on-disk JSONL transcript path for a session_id.
+
+    The Claude CLI writes per-session transcripts to
+    ``~/.claude/projects/<encoded-cwd>/<session_id>.jsonl`` where
+    ``encoded-cwd`` is the absolute cwd with ``/`` replaced by ``-``.
+    """
+    base = cwd if cwd is not None else Path.cwd()
+    encoded = str(base.resolve()).replace("/", "-")
+    return Path.home() / ".claude" / "projects" / encoded / f"{session_id}.jsonl"
+
+
 class ClaudeSession:
     """Stateful multi-turn session backed by ``ClaudeSDKClient``.
 
@@ -932,28 +945,33 @@ class ClaudeSession:
                 ) from exc
 
     async def release_transport(self) -> None:
-        """Disconnect the underlying ``ClaudeSDKClient`` connection.
+        """No-op under spec 034 P4.
 
-        After calling this, the next ``send()`` / ``send_streaming()`` call
-        will create and connect a fresh ``ClaudeSDKClient``. Note that the
-        new client starts a new CLI subprocess with no awareness of the
-        prior conversation — any conversation continuity needs to be
-        rebuilt at the application layer (e.g., by replaying history).
-
-        Provided primarily for cross-task migration scenarios (the SDK's
-        anyio task group is bound to the task that called ``connect()``)
-        and for explicit resource release in tests; it is **not** part of
-        the normal per-turn flow in ``holodeck serve`` — that path keeps
-        one connected client for the session's lifetime via
-        ``_TaskBoundSession``.
+        Retained for backwards compatibility with the chat executor's
+        ``_TaskBoundSession``. Under the hybrid-session model each turn's
+        subprocess is created and torn down inside ``query()``; there is no
+        persistent transport to release between turns.
         """
-        if self._client is not None:
-            await self._client.disconnect()
-            self._client = None
+        return None
 
     async def close(self) -> None:
-        """Disconnect the SDK client and release resources."""
-        await self.release_transport()
+        """Delete the on-disk JSONL transcript and clear session state.
+
+        Under spec 034 P4 the session has no persistent subprocess to
+        disconnect. Conversation state lives on disk at
+        ``~/.claude/projects/<encoded-cwd>/<sdk_session_id>.jsonl``. Closing
+        the session permanently discards that transcript so the next
+        open of the same threadId starts fresh.
+        """
+        if self._sdk_session_id is not None:
+            path = _transcript_path(self._sdk_session_id)
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.warning("Failed to delete transcript %s: %s", path, exc)
+            self._sdk_session_id = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -900,22 +900,36 @@ class ClaudeSession:
         Raises:
             BackendSessionError: On subprocess or SDK error.
         """
-        try:
-            client = await self._ensure_client()
-            await client.query(message, session_id=_DEFAULT_SESSION_ID)
+        async with self._send_lock:
+            options = self._options_with_hooks()
+            if self._sdk_session_id is not None:
+                import dataclasses
 
-            async for msg in client.receive_response():
-                _maybe_emit_subagent_message(msg, self._tool_event_queue)
-                if msg.__class__.__name__ == "AssistantMessage":
-                    for block in cast(Any, msg).content:
-                        if block.__class__.__name__ == "TextBlock" and block.text:
-                            yield block.text
-                elif msg.__class__.__name__ == "ResultMessage":
-                    self._turn_count += 1
-        except (ProcessError, CLIConnectionError) as exc:
-            raise BackendSessionError(
-                f"subprocess terminated unexpectedly: {exc}"
-            ) from exc
+                try:
+                    options = dataclasses.replace(options, resume=self._sdk_session_id)
+                except TypeError:
+                    # Fallback for non-dataclass options (test mocks).
+                    options.resume = self._sdk_session_id
+
+            try:
+                async for msg in query(
+                    prompt=_streaming_user_envelope(message), options=options
+                ):
+                    _maybe_emit_subagent_message(msg, self._tool_event_queue)
+                    if msg.__class__.__name__ == "AssistantMessage":
+                        for block in cast(Any, msg).content:
+                            if block.__class__.__name__ == "TextBlock" and block.text:
+                                yield block.text
+                    elif msg.__class__.__name__ == "ResultMessage":
+                        self._turn_count += 1
+                        if self._sdk_session_id is None:
+                            captured = getattr(msg, "session_id", None)
+                            if isinstance(captured, str) and captured:
+                                self._sdk_session_id = captured
+            except (ProcessError, CLIConnectionError) as exc:
+                raise BackendSessionError(
+                    f"subprocess terminated unexpectedly: {exc}"
+                ) from exc
 
     async def release_transport(self) -> None:
         """Disconnect the underlying ``ClaudeSDKClient`` connection.

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -716,6 +716,15 @@ class ClaudeSession:
         self._client: ClaudeSDKClient | None = None
         self._turn_count: int = 0
         self._tool_event_queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
+        # spec 034 P4 — hybrid-session state.
+        # CLI-assigned conversation id; captured from ResultMessage on turn 1
+        # and fed into ``options.resume`` on turn 2+ so each fresh subprocess
+        # rehydrates the JSONL transcript at
+        # ``~/.claude/projects/<encoded-cwd>/<sdk_session_id>.jsonl``.
+        self._sdk_session_id: str | None = None
+        # Serialises concurrent send() / send_streaming() on the same session.
+        # Two concurrent turns with the same resume= would race the transcript.
+        self._send_lock: asyncio.Lock = asyncio.Lock()
 
     @property
     def tool_events(self) -> asyncio.Queue[ToolEvent]:

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -1,8 +1,9 @@
 """Claude Agent SDK backend for HoloDeck.
 
 Implements ``ClaudeBackend`` (AgentBackend) and ``ClaudeSession`` (AgentSession)
-for the ``provider: anthropic`` execution path. Single-turn invocations use the
-top-level ``query()`` function; multi-turn chat sessions use ``ClaudeSDKClient``.
+for the ``provider: anthropic`` execution path. Every invocation — single-turn
+and multi-turn — uses the top-level ``query()`` function; multi-turn sessions
+thread state via ``resume=<sdk_session_id>`` (spec 034 P4).
 """
 
 from __future__ import annotations
@@ -15,11 +16,9 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, cast
 
-import claude_agent_sdk
 import jsonschema
 from claude_agent_sdk import (
     ClaudeAgentOptions,
-    ClaudeSDKClient,
     HookMatcher,
     ProcessError,
     query,
@@ -67,13 +66,6 @@ logger = logging.getLogger(__name__)
 
 _MAX_RETRIES = 3
 _BACKOFF_BASE_SECONDS = 1
-
-# Session ID passed to every ``client.query()`` for the lifetime of a
-# connected ``ClaudeSDKClient``. The CLI subprocess tracks conversation
-# state internally in interactive streaming mode; rotating to the
-# CLI-assigned id surfaced on ``ResultMessage`` wedges the CLI on the
-# next turn (query write succeeds but no response messages arrive).
-_DEFAULT_SESSION_ID = "default"
 
 # ---------------------------------------------------------------------------
 # Private helpers
@@ -381,7 +373,7 @@ def build_options(
         mode: Execution mode (``"test"`` or ``"chat"``).
 
     Returns:
-        Configured ``ClaudeAgentOptions`` ready for ``query()`` or ``ClaudeSDKClient``.
+        Configured ``ClaudeAgentOptions`` ready for ``query()``.
     """
     claude = agent.claude
     system_prompt = resolve_instructions(agent.instructions)
@@ -504,64 +496,6 @@ def build_options(
 # ---------------------------------------------------------------------------
 # ClaudeSession
 # ---------------------------------------------------------------------------
-
-
-def _patch_hooks_for_context_propagation(client: ClaudeSDKClient) -> None:
-    """Wrap hook callbacks so they re-inject the ContextVar from the instance.
-
-    Works around a ContextVar timing mismatch in the OTel instrumentor:
-    ``connect()`` spawns a ``_read_messages`` background task *before*
-    ``_wrap_client_query`` sets the ``InvocationContext`` in the ContextVar.
-    asyncio copies ContextVars at task-creation time, so the background task
-    sees ``None`` forever.
-
-    The instrumentor's ``_wrap_client_query`` *does* store the context on the
-    instance as ``_otel_invocation_ctx``.  This function wraps each hook
-    callback so that, just before it runs, it reads from the instance attribute
-    and re-sets the ContextVar — bridging the gap.
-
-    No-op when the instrumentor package is not installed.
-    """
-    try:
-        from opentelemetry.instrumentation.claude_agent_sdk._context import (
-            set_invocation_context,
-        )
-    except ImportError:
-        return  # Instrumentor not installed — nothing to patch
-
-    options = getattr(client, "options", None)
-    hooks = getattr(options, "hooks", None) if options else None
-    if not hooks:
-        return
-
-    for matchers in hooks.values():
-        if not matchers:
-            continue
-        for matcher in matchers:
-            original_hooks = matcher.hooks if hasattr(matcher, "hooks") else []
-            wrapped: list[Any] = []
-            for hook_fn in original_hooks:
-
-                async def _ctx_wrapper(
-                    input_data: Any,
-                    tool_use_id: str | None = None,
-                    context: Any = None,
-                    *,
-                    _orig: Any = hook_fn,
-                    _cli: ClaudeSDKClient = client,
-                    **kwargs: Any,
-                ) -> dict[str, Any]:
-                    ctx = getattr(_cli, "_otel_invocation_ctx", None)
-                    if ctx is not None:
-                        set_invocation_context(ctx)
-                    result: dict[str, Any] = await _orig(
-                        input_data, tool_use_id, context, **kwargs
-                    )
-                    return result
-
-                wrapped.append(_ctx_wrapper)
-            if hasattr(matcher, "hooks"):
-                matcher.hooks = wrapped
 
 
 def _build_tool_hooks(
@@ -713,18 +647,14 @@ def _transcript_path(session_id: str, cwd: Path | str | None = None) -> Path:
 
 
 class ClaudeSession:
-    """Stateful multi-turn session backed by ``ClaudeSDKClient``.
+    """Stateful multi-turn session backed by ``query(resume=...)`` (spec 034 P4).
 
-    Multi-turn state lives **inside the connected CLI subprocess**, not on
-    this object. ``ClaudeSDKClient`` in interactive streaming mode keeps a
-    single subprocess open for the session's lifetime; each ``send()``
-    writes one user message on stdin and reads the response stream off
-    stdout. The CLI tracks conversation history internally, so every
-    ``client.query()`` for that connected lifetime uses
-    ``session_id=_DEFAULT_SESSION_ID`` (the module-level constant) —
-    rotating it to the CLI-assigned id surfaced on ``ResultMessage``
-    wedges the CLI on the next turn (the query write succeeds but no
-    response messages ever come back).
+    Each ``send()`` / ``send_streaming()`` opens a fresh CLI subprocess via
+    the top-level ``query()`` function. Turn 1 has no ``resume``; the CLI
+    assigns a session id which is captured from ``ResultMessage`` and
+    stored on ``_sdk_session_id``. Subsequent turns pass that id via
+    ``options.resume`` so the CLI rehydrates the JSONL transcript at
+    ``~/.claude/projects/<encoded-cwd>/<sdk_session_id>.jsonl``.
 
     The ``_base_options`` reference is **never mutated**. Turn-specific
     options are created as new ``ClaudeAgentOptions`` instances.
@@ -737,7 +667,6 @@ class ClaudeSession:
             options: Base options (immutable reference for the session lifetime).
         """
         self._base_options = options
-        self._client: ClaudeSDKClient | None = None
         self._turn_count: int = 0
         self._tool_event_queue: asyncio.Queue[ToolEvent] = asyncio.Queue()
         # spec 034 P4 — hybrid-session state.
@@ -781,35 +710,14 @@ class ClaudeSession:
             return self._base_options
 
     async def prepare(self) -> None:
-        """Open the SDK transport in the calling task's context.
+        """No-op under spec 034 P4.
 
-        Connects the underlying ``ClaudeSDKClient`` if not already
-        connected. The SDK's anyio task group + ``_read_messages``
-        background reader bind to whichever task calls ``connect()``,
-        so callers needing a specific task to own that lifecycle should
-        call ``prepare()`` from that task before the first ``send``.
+        Retained for backwards compatibility with the chat executor's
+        ``_TaskBoundSession``. Under the hybrid-session model the SDK's
+        anyio task group is created inside each ``query()`` call frame,
+        so there is no task-binding to do up front.
         """
-        await self._ensure_client()
-
-    async def _ensure_client(self) -> ClaudeSDKClient:
-        """Lazily create, connect, and return the SDK client.
-
-        Uses ``claude_agent_sdk.ClaudeSDKClient`` (module-level attribute
-        access) instead of the locally-imported name so that wrapt
-        monkey-patches applied by the OTel instrumentor are resolved at
-        call time.
-
-        After ``__init__`` (which triggers the instrumentor's hook injection)
-        but before ``connect()`` (which spawns the ``_read_messages`` task),
-        we patch hook callbacks to re-inject the ContextVar from the instance.
-        See ``_patch_hooks_for_context_propagation`` for details.
-        """
-        if self._client is None:
-            options = self._options_with_hooks()
-            self._client = claude_agent_sdk.ClaudeSDKClient(options=options)
-            _patch_hooks_for_context_propagation(self._client)
-            await self._client.connect()
-        return self._client
+        return None
 
     async def send(self, message: str) -> ExecutionResult:
         """Send a message and collect the full response.
@@ -993,9 +901,10 @@ class ClaudeSession:
 class ClaudeBackend:
     """Backend implementation for the Claude Agent SDK.
 
-    Implements the ``AgentBackend`` protocol. Single-turn invocations use the
-    top-level ``query()`` function. Multi-turn sessions use ``ClaudeSession``
-    wrapping ``ClaudeSDKClient``.
+    Implements the ``AgentBackend`` protocol. Both single-turn invocations
+    and multi-turn sessions are built on the top-level ``query()`` function;
+    multi-turn state is threaded via ``resume=<sdk_session_id>`` inside
+    ``ClaudeSession``.
 
     The constructor stores config only — no I/O, no subprocess spawned.
     Initialization is deferred to ``initialize()`` (called lazily on first use).
@@ -1172,9 +1081,7 @@ class ClaudeBackend:
         structured_output: Any = None
 
         prompt_iter = _wrap_prompt(message)
-        async for msg in claude_agent_sdk.query(
-            prompt=prompt_iter, options=self._options
-        ):
+        async for msg in query(prompt=prompt_iter, options=self._options):
             text_parts, tool_calls, tool_results = _process_message(
                 msg, text_parts, tool_calls, tool_results
             )
@@ -1276,37 +1183,25 @@ class ClaudeBackend:
     async def create_session(self, *, eager_connect: bool = True) -> ClaudeSession:
         """Create a new multi-turn session.
 
-        Automatically initializes if not yet done. By default eagerly
-        connects the SDK client so the anyio cancel scope is entered on
-        the caller's task — required for non-actor callers because
-        deferring ``connect()`` to the first ``send()`` would bind the
-        scope to whatever task wraps ``send`` (e.g. an inner task spawned
-        by ``asyncio.wait_for`` on Python <3.11) and a later ``close()``
-        on the outer task would raise ``RuntimeError: Attempted to exit
-        cancel scope in a different task``.
-
-        Pass ``eager_connect=False`` when the caller will own the
-        connect/disconnect lifecycle in a different task (e.g. when
-        wrapping the session in ``_TaskBoundSession`` — that actor must
-        be the task that calls ``connect()`` so the SDK's anyio task
-        group + ``_read_messages`` background reader live as long as
-        the actor, not the HTTP request task that created the session).
+        Automatically initializes if not yet done. Under spec 034 P4 the
+        session no longer holds a persistent ``ClaudeSDKClient``; each
+        turn opens its own subprocess via ``query(resume=session_id)``.
+        ``eager_connect`` is retained as a no-op for API compatibility —
+        ``ClaudeSession.prepare()`` is itself a no-op under P4.
 
         Args:
-            eager_connect: When True (default), connect the SDK client
-                synchronously before returning. When False, return an
-                unconnected session; the first ``send()`` will connect.
+            eager_connect: Retained for backwards compatibility; has no
+                effect under spec 034 P4.
 
         Returns:
-            A new ``ClaudeSession`` instance, connected unless
-            ``eager_connect=False``.
+            A new ``ClaudeSession`` instance.
         """
         await self._ensure_initialized()
         if self._options is None:
             raise BackendInitError("Backend options not set after initialization")
         session = ClaudeSession(options=self._options)
         if eager_connect:
-            await session._ensure_client()
+            await session.prepare()
         return session
 
     async def _initialize_tools(self) -> None:

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -96,6 +96,28 @@ async def _wrap_prompt(message: str) -> AsyncGenerator[dict[str, Any], None]:
     }
 
 
+async def _streaming_user_envelope(
+    message: str,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Wrap a user message in the streaming-mode envelope ``query()`` expects.
+
+    ``query()`` accepts either a ``str`` prompt or an ``AsyncIterable[dict]``.
+    The ``str`` form writes the message and immediately closes stdin via
+    ``end_input()``, which deadlocks any subsequent SDK-MCP tool callback
+    (control-channel writes fail with ``ProcessTransport is not ready for
+    writing``). Streaming mode keeps stdin open via the SDK's background
+    ``stream_input`` task, so tool callbacks can write responses back.
+
+    See spec 034 P4 spike v1 (2026-05-19) for the surfacing.
+    """
+    yield {
+        "type": "user",
+        "session_id": "",
+        "message": {"role": "user", "content": message},
+        "parent_tool_use_id": None,
+    }
+
+
 def _enrich_tool_results(
     tool_calls: list[dict[str, Any]],
     tool_results: list[dict[str, Any]],

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -21,6 +21,7 @@ from claude_agent_sdk import (
     ClaudeSDKClient,
     HookMatcher,
     ProcessError,
+    query,
 )
 from claude_agent_sdk._errors import CLIConnectionError, MessageParseError
 from claude_agent_sdk.types import (
@@ -799,100 +800,93 @@ class ClaudeSession:
         Raises:
             BackendSessionError: On subprocess or SDK error.
         """
-        turn_no = self._turn_count + 1
-        logger.debug(
-            "[trace] ClaudeSession.send turn=%d: entering, client_cached=%s",
-            turn_no,
-            self._client is not None,
-        )
-        try:
-            client = await self._ensure_client()
+        async with self._send_lock:
+            turn_no = self._turn_count + 1
             logger.debug(
-                "[trace] ClaudeSession.send turn=%d: client ready, calling query",
+                "[trace] ClaudeSession.send turn=%d: entering, resume=%s",
                 turn_no,
+                self._sdk_session_id,
             )
-            await client.query(message, session_id=_DEFAULT_SESSION_ID)
-            logger.debug(
-                "[trace] ClaudeSession.send turn=%d: query written, awaiting "
-                "receive_response",
-                turn_no,
-            )
+            try:
+                options = self._options_with_hooks()
+                if self._sdk_session_id is not None:
+                    import dataclasses
 
-            text_parts: list[str] = []
-            tool_calls: list[dict[str, Any]] = []
-            tool_results: list[dict[str, Any]] = []
-            token_usage = TokenUsage.zero()
-            num_turns = 1
-            structured_output: Any = None
+                    try:
+                        options = dataclasses.replace(
+                            options, resume=self._sdk_session_id
+                        )
+                    except TypeError:
+                        # Fallback for non-dataclass options (test mocks).
+                        options.resume = self._sdk_session_id
 
-            msg_count = 0
-            async for msg in client.receive_response():
-                msg_count += 1
+                text_parts: list[str] = []
+                tool_calls: list[dict[str, Any]] = []
+                tool_results: list[dict[str, Any]] = []
+                token_usage = TokenUsage.zero()
+                num_turns = 1
+                structured_output: Any = None
+
+                msg_count = 0
+                async for msg in query(
+                    prompt=_streaming_user_envelope(message), options=options
+                ):
+                    msg_count += 1
+                    logger.debug(
+                        "[trace] ClaudeSession.send turn=%d: msg #%d type=%s",
+                        turn_no,
+                        msg_count,
+                        msg.__class__.__name__,
+                    )
+                    _maybe_emit_subagent_message(msg, self._tool_event_queue)
+                    text_parts, tool_calls, tool_results = _process_message(
+                        msg, text_parts, tool_calls, tool_results
+                    )
+                    if msg.__class__.__name__ == "ResultMessage":
+                        rm = cast(Any, msg)
+                        usage = rm.usage or {}
+                        prompt_tokens = usage.get("input_tokens", 0)
+                        completion = usage.get("output_tokens", 0)
+                        token_usage = TokenUsage(
+                            prompt_tokens=prompt_tokens,
+                            completion_tokens=completion,
+                            total_tokens=prompt_tokens + completion,
+                        )
+                        num_turns = rm.num_turns
+                        structured_output = rm.structured_output
+                        if self._sdk_session_id is None:
+                            captured = getattr(rm, "session_id", None)
+                            if isinstance(captured, str) and captured:
+                                self._sdk_session_id = captured
+
                 logger.debug(
-                    "[trace] ClaudeSession.send turn=%d: msg #%d type=%s",
+                    "[trace] ClaudeSession.send turn=%d: exited, "
+                    "msg_count=%d, num_turns=%d, sdk_session_id=%s",
                     turn_no,
                     msg_count,
-                    msg.__class__.__name__,
+                    num_turns,
+                    self._sdk_session_id,
                 )
-                _maybe_emit_subagent_message(msg, self._tool_event_queue)
-                text_parts, tool_calls, tool_results = _process_message(
-                    msg, text_parts, tool_calls, tool_results
+                self._turn_count += 1
+
+                _enrich_tool_results(tool_calls, tool_results)
+
+                response_text = "".join(text_parts)
+                if structured_output is not None:
+                    response_text = json.dumps(structured_output)
+
+                return ExecutionResult(
+                    response=response_text,
+                    tool_calls=tool_calls,
+                    tool_results=tool_results,
+                    token_usage=token_usage,
+                    structured_output=structured_output,
+                    num_turns=num_turns,
                 )
-                if msg.__class__.__name__ == "ResultMessage":
-                    rm = cast(Any, msg)
-                    usage = rm.usage or {}
-                    prompt = usage.get("input_tokens", 0)
-                    completion = usage.get("output_tokens", 0)
-                    token_usage = TokenUsage(
-                        prompt_tokens=prompt,
-                        completion_tokens=completion,
-                        total_tokens=prompt + completion,
-                    )
-                    num_turns = rm.num_turns
-                    structured_output = rm.structured_output
-
-            logger.debug(
-                "[trace] ClaudeSession.send turn=%d: receive_response exited, "
-                "msg_count=%d, num_turns=%d",
-                turn_no,
-                msg_count,
-                num_turns,
-            )
-            self._turn_count += 1
-
-            # Enrich tool results with names from tool calls so downstream
-            # consumers (eval_kwargs_builder.build_retrieval_context_from_tools)
-            # can match each result to its source tool. The SDK yields names
-            # only on ToolUseBlock; results arrive on ToolResultBlock carrying
-            # just call_id.
-            _enrich_tool_results(tool_calls, tool_results)
-
-            response_text = "".join(text_parts)
-
-            # When ``response_format`` is set the SDK delivers the validated
-            # payload on ``ResultMessage.structured_output``; the text
-            # content blocks carry the model's prose reasoning, which the
-            # CLI does NOT constrain to the schema. The structured payload
-            # is the authoritative answer — prefer it so downstream graders
-            # (response_path, equality/numeric over JSON envelopes) operate
-            # on the schema-validated value, not the unconstrained prose.
-            # Mirrors ``invoke_once`` which routes through
-            # ``_validate_structured_output``.
-            if structured_output is not None:
-                response_text = json.dumps(structured_output)
-
-            return ExecutionResult(
-                response=response_text,
-                tool_calls=tool_calls,
-                tool_results=tool_results,
-                token_usage=token_usage,
-                structured_output=structured_output,
-                num_turns=num_turns,
-            )
-        except (ProcessError, CLIConnectionError) as exc:
-            raise BackendSessionError(
-                f"subprocess terminated unexpectedly: {exc}"
-            ) from exc
+            except (ProcessError, CLIConnectionError) as exc:
+                raise BackendSessionError(
+                    f"subprocess terminated unexpectedly: {exc}"
+                ) from exc
 
     async def send_streaming(self, message: str) -> AsyncGenerator[str, None]:
         """Send a message and yield text chunks progressively.

--- a/src/holodeck/lib/backends/selector.py
+++ b/src/holodeck/lib/backends/selector.py
@@ -21,7 +21,6 @@ class BackendSelector:
         agent: Agent,
         tool_instances: dict[str, Any] | None = None,
         mode: str = "test",
-        allow_side_effects: bool = False,
     ) -> AgentBackend:
         """Select and initialize the appropriate backend for the given agent.
 
@@ -29,7 +28,6 @@ class BackendSelector:
             agent: Agent configuration with model provider information.
             tool_instances: Initialized tool instances for Claude backend.
             mode: Execution mode (``"test"`` or ``"chat"``).
-            allow_side_effects: Allow bash/file_system.write in test mode.
 
         Returns:
             An initialized AgentBackend instance ready for use.
@@ -53,7 +51,6 @@ class BackendSelector:
                 agent=agent,
                 tool_instances=tool_instances,
                 mode=mode,
-                allow_side_effects=allow_side_effects,
             )
             await claude_backend.initialize()
             return claude_backend

--- a/src/holodeck/lib/runtime.py
+++ b/src/holodeck/lib/runtime.py
@@ -1,0 +1,100 @@
+"""Container-aware runtime introspection helpers.
+
+The Python stdlib's :func:`os.cpu_count` reports the host's CPU count, which
+is wrong inside a container with cgroup CPU limits — Java's
+``Runtime.availableProcessors()`` has handled this correctly since Java 10,
+but Python has not caught up. This module reads cgroup CPU quotas directly
+so HoloDeck can size in-process concurrency to whatever the container was
+actually allocated.
+
+Used by the serve layer to derive per-replica session caps (spec 034 P1a).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CGROUP_V2_CPU_MAX = Path("/sys/fs/cgroup/cpu.max")
+_CGROUP_V1_QUOTA = Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+_CGROUP_V1_PERIOD = Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+
+
+def cpu_quota() -> float:
+    """Return the CPU quota available to this process, in fractional cores.
+
+    Reads the cgroup CPU quota directly. Returns ``os.cpu_count()`` (or
+    ``1.0`` if even that is unavailable) when no cgroup limit is set or
+    cgroup files cannot be read — covers local dev on macOS/Windows and
+    unconstrained Linux processes.
+
+    Returns:
+        Fractional CPU count (e.g. ``0.5`` for half a core, ``2.0`` for two
+        full cores). Always positive.
+    """
+    quota = _read_cgroup_v2_quota()
+    if quota is not None:
+        return quota
+    quota = _read_cgroup_v1_quota()
+    if quota is not None:
+        return quota
+    return float(os.cpu_count() or 1)
+
+
+def _read_cgroup_v2_quota() -> float | None:
+    """Read /sys/fs/cgroup/cpu.max (cgroups v2).
+
+    Format: ``"<quota> <period>"`` where quota is an integer or the literal
+    ``"max"`` (unconstrained). Returns ``quota / period``, or ``None`` when
+    the file is missing or unparseable.
+    """
+    try:
+        raw = _CGROUP_V2_CPU_MAX.read_text().strip()
+    except OSError:
+        return None
+    try:
+        quota_str, period_str = raw.split()
+        if quota_str == "max":
+            return None
+        return int(quota_str) / int(period_str)
+    except (ValueError, ZeroDivisionError):
+        logger.debug("Unparseable cgroups v2 cpu.max: %r", raw)
+        return None
+
+
+def _read_cgroup_v1_quota() -> float | None:
+    """Read cgroups v1 cpu.cfs_quota_us / cpu.cfs_period_us.
+
+    A negative quota means unconstrained.
+    """
+    try:
+        quota = int(_CGROUP_V1_QUOTA.read_text().strip())
+        period = int(_CGROUP_V1_PERIOD.read_text().strip())
+    except (OSError, ValueError):
+        return None
+    if quota < 0 or period <= 0:
+        return None
+    return quota / period
+
+
+def derived_session_cap(cpu_cores: float, multiplier: int = 2) -> int:
+    """Derive the default per-replica Claude session cap from CPU quota.
+
+    Calibrated against the ~300 MiB resident-per-subprocess footprint
+    observed in the spec 034 P1 investigation: one SDK subprocess plus
+    headroom for the serve process fits comfortably in 1 GiB per core when
+    capped at two sessions per core.
+
+    Args:
+        cpu_cores: Fractional CPU quota for this replica.
+        multiplier: Sessions allowed per CPU core (default 2).
+
+    Returns:
+        Integer session cap, always ≥ 1.
+    """
+    import math
+
+    return max(1, math.floor(cpu_cores * multiplier))

--- a/src/holodeck/lib/runtime.py
+++ b/src/holodeck/lib/runtime.py
@@ -31,10 +31,14 @@ _CGROUP_V1_PERIOD = Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
 _CGROUP_V2_MEMORY_MAX = Path("/sys/fs/cgroup/memory.max")
 _CGROUP_V1_MEMORY_LIMIT = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
 
-# Per-SDK-subprocess and serve-baseline footprints observed in the spec 034
-# P1 investigation. Used to derive the default session cap from memory.
+# Per-active-turn and serve-baseline footprints calibrated against the spec
+# 034 P4 cloud validation (2 GiB ACA replica OOMed at 4 concurrent turns).
+# The active-turn estimate has to cover the SDK subprocess's steady-state
+# resident set (~300 MiB Node CLI) plus the simultaneous-startup spike and
+# parent-side transient work (hybrid search, rerank, context generation).
+# 500 MiB lands cap=3 on a 2 GiB replica — the empirically safe ceiling.
 DEFAULT_BASELINE_BYTES = 400 * 1024 * 1024  # 400 MiB: server + tools + OTEL
-DEFAULT_PER_SESSION_BYTES = 200 * 1024 * 1024  # 200 MiB: one SDK subprocess
+DEFAULT_PER_SESSION_BYTES = 500 * 1024 * 1024  # 500 MiB: one concurrent active turn
 
 
 def cpu_quota() -> float:
@@ -160,11 +164,12 @@ def derived_session_cap_from_memory(
 ) -> int:
     """Derive the per-replica Claude session cap from a memory budget.
 
-    The SDK subprocess footprint is the binding constraint for concurrent
-    sessions (~300 MiB resident each — observed in the spec 034 P1
-    investigation). After reserving a baseline for the serve process,
-    tools and OTEL exporter, the remaining headroom divided by the
-    per-session footprint gives the cap.
+    The active-turn footprint is the binding constraint for concurrency.
+    Each concurrent turn spawns a fresh Node CLI subprocess (~300 MiB
+    steady state) and incurs parent-side transient work (hybrid search,
+    rerank, context generation). After reserving a baseline for the
+    serve process, tools and OTEL exporter, the remaining headroom
+    divided by the per-turn footprint gives the cap.
 
     Args:
         memory_bytes: Total memory limit available to the replica.

--- a/src/holodeck/lib/runtime.py
+++ b/src/holodeck/lib/runtime.py
@@ -3,16 +3,22 @@
 The Python stdlib's :func:`os.cpu_count` reports the host's CPU count, which
 is wrong inside a container with cgroup CPU limits — Java's
 ``Runtime.availableProcessors()`` has handled this correctly since Java 10,
-but Python has not caught up. This module reads cgroup CPU quotas directly
-so HoloDeck can size in-process concurrency to whatever the container was
-actually allocated.
+but Python has not caught up. This module reads cgroup CPU and memory
+limits directly so HoloDeck can size in-process concurrency to whatever the
+container was actually allocated.
 
 Used by the serve layer to derive per-replica session caps (spec 034 P1a).
+The Claude session cap is derived from **memory**, not CPU: Azure Container
+Apps (and some other managed runtimes) do not expose CPU limits via
+``/sys/fs/cgroup/cpu.max``, but the kernel enforces memory limits so
+``memory.max`` is reliably populated. The thing we're protecting against
+(SDK subprocess OOM) is a memory constraint anyway.
 """
 
 from __future__ import annotations
 
 import logging
+import math
 import os
 from pathlib import Path
 
@@ -21,6 +27,14 @@ logger = logging.getLogger(__name__)
 _CGROUP_V2_CPU_MAX = Path("/sys/fs/cgroup/cpu.max")
 _CGROUP_V1_QUOTA = Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
 _CGROUP_V1_PERIOD = Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+
+_CGROUP_V2_MEMORY_MAX = Path("/sys/fs/cgroup/memory.max")
+_CGROUP_V1_MEMORY_LIMIT = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+
+# Per-SDK-subprocess and serve-baseline footprints observed in the spec 034
+# P1 investigation. Used to derive the default session cap from memory.
+DEFAULT_BASELINE_BYTES = 400 * 1024 * 1024  # 400 MiB: server + tools + OTEL
+DEFAULT_PER_SESSION_BYTES = 200 * 1024 * 1024  # 200 MiB: one SDK subprocess
 
 
 def cpu_quota() -> float:
@@ -81,20 +95,84 @@ def _read_cgroup_v1_quota() -> float | None:
 
 
 def derived_session_cap(cpu_cores: float, multiplier: int = 2) -> int:
-    """Derive the default per-replica Claude session cap from CPU quota.
+    """Derive a CPU-based session cap (legacy).
 
-    Calibrated against the ~300 MiB resident-per-subprocess footprint
-    observed in the spec 034 P1 investigation: one SDK subprocess plus
-    headroom for the serve process fits comfortably in 1 GiB per core when
-    capped at two sessions per core.
+    Kept for compatibility with the original spec 034 P1a derivation;
+    superseded by :func:`derived_session_cap_from_memory` which maps more
+    directly to the OOM constraint. Not used in the default serve path.
+    """
+    return max(1, math.floor(cpu_cores * multiplier))
+
+
+def memory_limit_bytes() -> int | None:
+    """Return the memory limit (bytes) available to this process.
+
+    Reads the cgroup memory limit directly. Returns ``None`` when no
+    cgroup limit is set or cgroup files cannot be read — caller should
+    fall back to a conservative default.
+
+    Returns:
+        Memory limit in bytes, or ``None`` when unbounded/unavailable.
+    """
+    limit = _read_cgroup_v2_memory()
+    if limit is not None:
+        return limit
+    return _read_cgroup_v1_memory()
+
+
+def _read_cgroup_v2_memory() -> int | None:
+    """Read /sys/fs/cgroup/memory.max (cgroups v2).
+
+    Contains an integer byte count or the literal ``"max"`` (unconstrained).
+    """
+    try:
+        raw = _CGROUP_V2_MEMORY_MAX.read_text().strip()
+    except OSError:
+        return None
+    if raw == "max":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.debug("Unparseable cgroups v2 memory.max: %r", raw)
+        return None
+
+
+def _read_cgroup_v1_memory() -> int | None:
+    """Read /sys/fs/cgroup/memory/memory.limit_in_bytes (cgroups v1).
+
+    Kernels report an effectively-unlimited sentinel (very large int) when
+    no limit is set; we treat anything ≥ 1 PiB as unbounded.
+    """
+    try:
+        raw = int(_CGROUP_V1_MEMORY_LIMIT.read_text().strip())
+    except (OSError, ValueError):
+        return None
+    if raw >= 1 << 50:  # ≥ 1 PiB → effectively unbounded
+        return None
+    return raw
+
+
+def derived_session_cap_from_memory(
+    memory_bytes: int,
+    baseline_bytes: int = DEFAULT_BASELINE_BYTES,
+    per_session_bytes: int = DEFAULT_PER_SESSION_BYTES,
+) -> int:
+    """Derive the per-replica Claude session cap from a memory budget.
+
+    The SDK subprocess footprint is the binding constraint for concurrent
+    sessions (~300 MiB resident each — observed in the spec 034 P1
+    investigation). After reserving a baseline for the serve process,
+    tools and OTEL exporter, the remaining headroom divided by the
+    per-session footprint gives the cap.
 
     Args:
-        cpu_cores: Fractional CPU quota for this replica.
-        multiplier: Sessions allowed per CPU core (default 2).
+        memory_bytes: Total memory limit available to the replica.
+        baseline_bytes: Bytes reserved for non-session overhead.
+        per_session_bytes: Estimated bytes per active SDK subprocess.
 
     Returns:
         Integer session cap, always ≥ 1.
     """
-    import math
-
-    return max(1, math.floor(cpu_cores * multiplier))
+    usable = max(0, memory_bytes - baseline_bytes)
+    return max(1, usable // per_session_bytes)

--- a/src/holodeck/lib/test_runner/executor.py
+++ b/src/holodeck/lib/test_runner/executor.py
@@ -442,7 +442,6 @@ class TestExecutor:
         agent_config: Agent | None = None,
         resolved_execution_config: ExecutionConfig | None = None,
         backend: AgentBackend | None = None,
-        allow_side_effects: bool = False,
     ) -> None:
         """Initialize test executor with optional dependency injection.
 
@@ -470,8 +469,6 @@ class TestExecutor:
                                        (auto-resolved if None)
             backend: Optional AgentBackend instance. When provided, the executor
                      uses invoke_once() instead of AgentFactory.
-            allow_side_effects: Allow bash/file_system.write in test mode
-                                (passed to BackendSelector when auto-selecting).
         """
         self.agent_config_path = agent_config_path
         self.cli_config = execution_config
@@ -480,7 +477,6 @@ class TestExecutor:
         self.on_test_start = on_test_start
         self._force_ingest = force_ingest
         self._backend: AgentBackend | None = backend
-        self._allow_side_effects = allow_side_effects
 
         logger.debug(f"Initializing TestExecutor for config: {agent_config_path}")
 
@@ -803,7 +799,6 @@ class TestExecutor:
             self.agent_config,
             tool_instances=None,
             mode="test",
-            allow_side_effects=self._allow_side_effects,
         )
 
     async def execute_tests(self) -> TestReport:

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -230,15 +230,16 @@ class ClaudeConfig(BaseModel):
         ge=1,
         le=500,
         description=(
-            "Maximum concurrent Claude SDK subprocesses per serve instance. "
-            "When unset, the serve layer derives the cap from the replica's "
-            "cgroup memory limit divided by `session_memory_estimate_mib` — "
-            "memory is the OOM constraint and Azure Container Apps exposes "
-            "memory limits but not CPU limits via cgroup. Upper bound 500 "
-            "exists to allow operators to admit many warm threads under the "
-            "current persistent-session model; under cold-spawn bursts the "
-            "real ceiling is much lower. Spec 034 P1a (P4 makes this a "
-            "concurrent-turn cap instead)."
+            "Maximum concurrent active turns per serve instance — under spec "
+            "034 P4 each in-flight turn spawns a fresh SDK subprocess, so this "
+            "gates memory exposure. When unset, the serve layer derives the "
+            "cap from the replica's cgroup memory limit divided by "
+            "`session_memory_estimate_mib`. Field name retained for backward "
+            "compatibility with existing agent.yaml files. Upper bound 500 "
+            "allows operators to admit many idle threads (open sessions are "
+            "now nearly free — JSONL transcripts on disk, no resident "
+            "subprocess) while the semaphore enforces the actual memory cap "
+            "on concurrent active turns. Spec 034 P1a + P4."
         ),
     )
     session_memory_estimate_mib: int = Field(
@@ -246,12 +247,17 @@ class ClaudeConfig(BaseModel):
         ge=50,
         le=2000,
         description=(
-            "Estimated resident memory (MiB) per active Claude SDK subprocess, "
-            "used by the serve layer to derive `max_concurrent_sessions` from "
-            "the replica's cgroup memory limit. Tune up for agents whose tool "
-            "state inflates the SDK subprocess footprint, down for lighter "
-            "agents. Spec 034 P1a measured ~200 MiB for the financial-assistant "
-            "sample at steady state."
+            "Estimated peak resident memory (MiB) per *concurrent active turn* "
+            "(SDK subprocess + tool state during a single in-flight query). "
+            "Under spec 034 P4 this is no longer per-idle-session — idle "
+            "sessions cost ~30 MiB each (Python object + JSONL handle) since "
+            "the subprocess is spawned per turn and torn down at turn end. "
+            "Used by the serve layer to derive `max_concurrent_sessions` from "
+            "the replica's cgroup memory limit. Tune up for tool-heavy agents "
+            "(qdrant connection pools, hierarchical-doc caches inflate "
+            "subprocess footprint), down for thin agents. Spec 034 P1a "
+            "measured ~200 MiB baseline; financial-assistant sample uses 400 "
+            "to account for hybrid retrieval state."
         ),
     )
     extended_thinking: ExtendedThinkingConfig | None = Field(

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -232,8 +232,22 @@ class ClaudeConfig(BaseModel):
         description=(
             "Maximum concurrent Claude SDK subprocesses per serve instance. "
             "When unset, the serve layer derives the cap from the replica's "
-            "cgroup CPU quota (max(1, floor(cpu_cores * 2))) so the default "
-            "scales with container sizing — see spec 034 P1a."
+            "cgroup memory limit divided by `session_memory_estimate_mib` — "
+            "memory is the OOM constraint and Azure Container Apps exposes "
+            "memory limits but not CPU limits via cgroup. Spec 034 P1a."
+        ),
+    )
+    session_memory_estimate_mib: int = Field(
+        default=200,
+        ge=50,
+        le=2000,
+        description=(
+            "Estimated resident memory (MiB) per active Claude SDK subprocess, "
+            "used by the serve layer to derive `max_concurrent_sessions` from "
+            "the replica's cgroup memory limit. Tune up for agents whose tool "
+            "state inflates the SDK subprocess footprint, down for lighter "
+            "agents. Spec 034 P1a measured ~200 MiB for the financial-assistant "
+            "sample at steady state."
         ),
     )
     extended_thinking: ExtendedThinkingConfig | None = Field(

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -226,10 +226,15 @@ class ClaudeConfig(BaseModel):
         description="Maximum agent loop iterations. None = SDK default.",
     )
     max_concurrent_sessions: int | None = Field(
-        default=10,
+        default=None,
         ge=1,
         le=100,
-        description="Maximum concurrent Claude SDK subprocesses per serve instance",
+        description=(
+            "Maximum concurrent Claude SDK subprocesses per serve instance. "
+            "When unset, the serve layer derives the cap from the replica's "
+            "cgroup CPU quota (max(1, floor(cpu_cores * 2))) so the default "
+            "scales with container sizing — see spec 034 P1a."
+        ),
     )
     extended_thinking: ExtendedThinkingConfig | None = Field(
         default=None,
@@ -276,6 +281,18 @@ class ClaudeConfig(BaseModel):
         default=None,
         description=(
             "Tools that must never be used; takes precedence over allowed_tools."
+        ),
+    )
+    i_understand_this_is_unsafe: bool = Field(
+        default=False,
+        description=(
+            "Acknowledge that permission_mode=acceptAll disables the Claude SDK "
+            "permission system entirely, allowing any tool (including Bash, "
+            "Write, Edit, WebFetch) to execute without restriction. This is the "
+            "most direct path from prompt-injection to arbitrary tool execution. "
+            "Required to use permission_mode=acceptAll. Prefer declaring the "
+            "specific tools your agent needs via the schema fields (bash, "
+            "file_system, web_search) or claude.allowed_tools instead."
         ),
     )
 

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -228,13 +228,17 @@ class ClaudeConfig(BaseModel):
     max_concurrent_sessions: int | None = Field(
         default=None,
         ge=1,
-        le=100,
+        le=500,
         description=(
             "Maximum concurrent Claude SDK subprocesses per serve instance. "
             "When unset, the serve layer derives the cap from the replica's "
             "cgroup memory limit divided by `session_memory_estimate_mib` — "
             "memory is the OOM constraint and Azure Container Apps exposes "
-            "memory limits but not CPU limits via cgroup. Spec 034 P1a."
+            "memory limits but not CPU limits via cgroup. Upper bound 500 "
+            "exists to allow operators to admit many warm threads under the "
+            "current persistent-session model; under cold-spawn bursts the "
+            "real ceiling is much lower. Spec 034 P1a (P4 makes this a "
+            "concurrent-turn cap instead)."
         ),
     )
     session_memory_estimate_mib: int = Field(

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -243,7 +243,7 @@ class ClaudeConfig(BaseModel):
         ),
     )
     session_memory_estimate_mib: int = Field(
-        default=200,
+        default=500,
         ge=50,
         le=2000,
         description=(
@@ -253,11 +253,13 @@ class ClaudeConfig(BaseModel):
             "sessions cost ~30 MiB each (Python object + JSONL handle) since "
             "the subprocess is spawned per turn and torn down at turn end. "
             "Used by the serve layer to derive `max_concurrent_sessions` from "
-            "the replica's cgroup memory limit. Tune up for tool-heavy agents "
-            "(qdrant connection pools, hierarchical-doc caches inflate "
-            "subprocess footprint), down for thin agents. Spec 034 P1a "
-            "measured ~200 MiB baseline; financial-assistant sample uses 400 "
-            "to account for hybrid retrieval state."
+            "the replica's cgroup memory limit. The 500 MiB default is "
+            "calibrated against the spec 034 P4 cloud validation: a 2 GiB ACA "
+            "replica OOMed at 4 concurrent turns, and 3 was the empirically "
+            "safe ceiling — `(2048-400)/500 = 3` matches that. The footprint "
+            "covers the ~300 MiB Node CLI steady state plus simultaneous "
+            "startup spikes and parent-side transient work (hybrid search, "
+            "rerank, context generation). Tune up for tool-heavy agents."
         ),
     )
     extended_thinking: ExtendedThinkingConfig | None = Field(

--- a/src/holodeck/models/deployment.py
+++ b/src/holodeck/models/deployment.py
@@ -236,12 +236,30 @@ class AzureContainerAppsConfig(BaseModel):
     )
     location: str = Field(default="eastus", description="Azure region for deployment")
     cpu: float = Field(
-        default=0.5,
-        description="vCPU allocation (0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0)",
+        default=1.0,
+        description=(
+            "vCPU allocation (0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0). "
+            "Default raised to 1.0 in spec 034 P1a — Anthropic's hosting "
+            "guide recommends 1 CPU per Claude SDK instance, and the "
+            "serve layer derives the default session cap from this value."
+        ),
     )
-    memory: str = Field(default="1Gi", description="Memory allocation (e.g., 2Gi)")
+    memory: str = Field(
+        default="2Gi",
+        description=(
+            "Memory allocation (e.g. 2Gi). Default raised to 2Gi in spec "
+            "034 P1a so concurrent SDK subprocesses fit in the cgroup "
+            "limit. ACA requires memory_Gi == 2 * cpu_cores."
+        ),
+    )
     ingress_external: bool = Field(
-        default=True, description="Whether ingress is external"
+        default=False,
+        description=(
+            "Whether ingress is reachable from the public internet. "
+            "Default flipped to False in spec 034 P1a — operators must "
+            "explicitly opt in to public ingress to avoid accidentally "
+            "exposing internal-only agents."
+        ),
     )
     min_replicas: int = Field(default=0, ge=0, description="Minimum replicas")
     max_replicas: int = Field(default=10, ge=1, description="Maximum replicas")

--- a/src/holodeck/serve/server.py
+++ b/src/holodeck/serve/server.py
@@ -312,37 +312,63 @@ class AgentServer:
         sem = self._active_turn_semaphore
         return sem is not None and sem.locked()
 
-    @contextlib.asynccontextmanager
-    async def _acquire_turn_slot(self) -> AsyncGenerator[None, None]:
-        """Acquire one active-turn slot for the duration of this context.
+    def _try_acquire_turn_slot(self) -> bool:
+        """Atomic non-blocking acquire.
 
-        No-op when no semaphore is configured (non-Claude providers).
-        The slot is released even if the wrapped work raises or the
-        request generator is cancelled by the client.
+        Returns True if a slot was acquired (or no gate is configured),
+        False if at capacity. Atomic because asyncio is single-threaded
+        and this method contains no awaits — the check + decrement
+        happen in one tick.
+
+        Pairs with ``_release_turn_slot()``. Callers MUST release exactly
+        once for each successful acquire.
         """
         sem = self._active_turn_semaphore
         if sem is None:
-            yield
-            return
-        await sem.acquire()
-        try:
-            yield
-        finally:
+            return True
+        if sem._value <= 0:  # type: ignore[operator]
+            return False
+        sem._value -= 1
+        return True
+
+    def _release_turn_slot(self) -> None:
+        """Release one acquired turn slot. No-op when no gate is configured."""
+        sem = self._active_turn_semaphore
+        if sem is not None:
             sem.release()
+
+    @contextlib.asynccontextmanager
+    async def _acquire_turn_slot(self) -> AsyncGenerator[bool, None]:
+        """Try-acquire one active-turn slot as a context manager.
+
+        Yields True if the slot was acquired (or no gate is configured),
+        False if at capacity. Callers MUST inspect the yielded value and
+        short-circuit (e.g. return 429) when False.
+        """
+        acquired = self._try_acquire_turn_slot()
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                self._release_turn_slot()
 
     async def _turn_gated_stream(
         self,
         gen: AsyncGenerator[bytes, None],
     ) -> AsyncGenerator[bytes, None]:
-        """Wrap a streaming response generator so it holds a turn slot.
+        """Wrap a streaming response generator so it releases a turn slot.
 
-        The slot is acquired before the first chunk is produced and
-        released after the generator is exhausted (or cancelled). Keeps
-        the gating logic symmetric with the sync path.
+        Assumes the caller has already acquired a slot via
+        ``_try_acquire_turn_slot()`` before constructing the response —
+        once HTTP headers have shipped, we can no longer return 429, so
+        the gate must run synchronously in the endpoint. This wrapper
+        owns the release.
         """
-        async with self._acquire_turn_slot():
+        try:
             async for chunk in gen:
                 yield chunk
+        finally:
+            self._release_turn_slot()
 
     async def _handle_backend_session_error(
         self,
@@ -488,19 +514,20 @@ class AgentServer:
             except ValidationError as e:
                 raise HTTPException(status_code=422, detail=e.errors()) from e
 
-            # Get session by thread_id or create new one.
             # Capacity exceeded surfaces as a real HTTP 429 (not an SSE
             # error frame inside a 200) so fronting load balancers and
             # client retry logic see the backpressure (spec 034 P1a).
             # Spec 034 P4: the cap is now concurrent active turns, not
-            # open sessions — open sessions are nearly free under hybrid
-            # session model.
-            if self._turn_capacity_exceeded():
+            # open sessions. Acquire synchronously before constructing
+            # the response — once headers ship, we can't switch to 429.
+            # _turn_gated_stream owns the matching release.
+            if not self._try_acquire_turn_slot():
                 return self._capacity_exceeded_response()  # type: ignore[return-value]
 
             session_id = input_data.thread_id
             result = self._get_or_create_session(session_id)
             if isinstance(result, JSONResponse):
+                self._release_turn_slot()
                 return result  # type: ignore[return-value]
             session = result
 
@@ -514,8 +541,6 @@ class AgentServer:
                 execution_config=self.execution_config,
             )
 
-            # Stream response, holding a turn slot for the lifetime of
-            # the generator (released on exhaustion or client disconnect).
             return StreamingResponse(
                 self._turn_gated_stream(protocol.handle_request(input_data, session)),
                 media_type=protocol.content_type,
@@ -547,25 +572,25 @@ class AgentServer:
             Accepts a message, processes it through the agent, and returns
             the complete response as JSON.
             """
-            if self._turn_capacity_exceeded():
-                return self._capacity_exceeded_response()  # type: ignore[return-value,no-any-return]
+            async with self._acquire_turn_slot() as acquired:
+                if not acquired:
+                    return self._capacity_exceeded_response()  # type: ignore[return-value,no-any-return]
 
-            result = self._get_or_create_session(request.session_id)
-            if isinstance(result, JSONResponse):
-                return result  # type: ignore[return-value,no-any-return]
-            session = result
+                result = self._get_or_create_session(request.session_id)
+                if isinstance(result, JSONResponse):
+                    return result  # type: ignore[return-value,no-any-return]
+                session = result
 
-            self.sessions.touch(session.session_id)
-            session.message_count += 1
+                self.sessions.touch(session.session_id)
+                session.message_count += 1
 
-            protocol = RESTProtocol()
-            try:
-                async with self._acquire_turn_slot():
+                protocol = RESTProtocol()
+                try:
                     return await protocol.handle_sync_request(request, session)
-            except BackendSessionError:
-                return await self._handle_backend_session_error(  # type: ignore[return-value,no-any-return]
-                    session.session_id,
-                )
+                except BackendSessionError:
+                    return await self._handle_backend_session_error(  # type: ignore[return-value,no-any-return]
+                        session.session_id,
+                    )
 
         @app.post(
             f"/agent/{agent_name}/chat/stream",
@@ -577,11 +602,12 @@ class AgentServer:
             Accepts a message, processes it through the agent, and streams
             SSE events back to the client.
             """
-            if self._turn_capacity_exceeded():
+            if not self._try_acquire_turn_slot():
                 return self._capacity_exceeded_response()  # type: ignore[return-value]
 
             result = self._get_or_create_session(request.session_id)
             if isinstance(result, JSONResponse):
+                self._release_turn_slot()
                 return result  # type: ignore[return-value]
             session = result
 
@@ -633,25 +659,25 @@ class AgentServer:
                 files=file_contents if file_contents else None,
             )
 
-            if self._turn_capacity_exceeded():
-                return self._capacity_exceeded_response()  # type: ignore[return-value,no-any-return]
+            async with self._acquire_turn_slot() as acquired:
+                if not acquired:
+                    return self._capacity_exceeded_response()  # type: ignore[return-value,no-any-return]
 
-            result = self._get_or_create_session(session_id)
-            if isinstance(result, JSONResponse):
-                return result  # type: ignore[return-value,no-any-return]
-            session = result
+                result = self._get_or_create_session(session_id)
+                if isinstance(result, JSONResponse):
+                    return result  # type: ignore[return-value,no-any-return]
+                session = result
 
-            self.sessions.touch(session.session_id)
-            session.message_count += 1
+                self.sessions.touch(session.session_id)
+                session.message_count += 1
 
-            protocol = RESTProtocol()
-            try:
-                async with self._acquire_turn_slot():
+                protocol = RESTProtocol()
+                try:
                     return await protocol.handle_sync_request(chat_request, session)
-            except BackendSessionError:
-                return await self._handle_backend_session_error(  # type: ignore[return-value,no-any-return]
-                    session.session_id,
-                )
+                except BackendSessionError:
+                    return await self._handle_backend_session_error(  # type: ignore[return-value,no-any-return]
+                        session.session_id,
+                    )
 
         @app.post(
             f"/agent/{agent_name}/chat/stream/multipart",
@@ -690,11 +716,12 @@ class AgentServer:
                 files=file_contents if file_contents else None,
             )
 
-            if self._turn_capacity_exceeded():
+            if not self._try_acquire_turn_slot():
                 return self._capacity_exceeded_response()  # type: ignore[return-value]
 
             result = self._get_or_create_session(session_id)
             if isinstance(result, JSONResponse):
+                self._release_turn_slot()
                 return result  # type: ignore[return-value]
             session = result
 

--- a/src/holodeck/serve/server.py
+++ b/src/holodeck/serve/server.py
@@ -18,7 +18,10 @@ from holodeck.lib.backends import BackendInitError, BackendSessionError
 from holodeck.lib.backends.validators import validate_credentials, validate_nodejs
 from holodeck.lib.errors import ConfigError
 from holodeck.lib.logging_config import get_logger
-from holodeck.lib.runtime import cpu_quota, derived_session_cap
+from holodeck.lib.runtime import (
+    derived_session_cap_from_memory,
+    memory_limit_bytes,
+)
 from holodeck.models.llm import ProviderEnum
 from holodeck.serve.middleware import ErrorHandlingMiddleware, LoggingMiddleware
 from holodeck.serve.models import (
@@ -48,6 +51,12 @@ _CAPACITY_MSG_TEMPLATE = (
     "Retry after existing sessions complete."
 )
 _CAPACITY_RETRY_AFTER_SECONDS = 5
+
+# Fallback session cap when neither an explicit
+# claude.max_concurrent_sessions nor a cgroup memory limit is available
+# (local dev, unconstrained Linux). Keep this conservative: this number is
+# only reached when we can't introspect the runtime at all.
+_FALLBACK_SESSION_CAP = 50
 
 
 class AgentServer:
@@ -115,16 +124,23 @@ class AgentServer:
         )
 
         # Determine max sessions based on provider.
-        # For Claude, derive the default from the container's cgroup CPU
-        # quota (spec 034 P1a) so per-replica concurrency scales with
-        # container sizing — the SDK's ~300 MiB-per-subprocess footprint
-        # means a 0.5 CPU / 1 GiB replica cannot safely run 10 sessions.
+        # For Claude, derive the default from the container's cgroup memory
+        # limit (spec 034 P1a) so per-replica concurrency scales with
+        # container sizing — the SDK's ~200 MiB-per-subprocess footprint
+        # is what triggers cgroup OOMKill when over-provisioned. Memory is
+        # the binding constraint and is reliably exposed via cgroup files
+        # in every runtime we care about (including Azure Container Apps,
+        # which does *not* expose CPU limits the same way).
         max_sessions = 1000  # Non-Claude providers don't spawn subprocesses
         if self.agent_config.model.provider == ProviderEnum.ANTHROPIC:
-            explicit_cap = (
-                self.agent_config.claude.max_concurrent_sessions
-                if self.agent_config.claude is not None
-                else None
+            claude = self.agent_config.claude
+            explicit_cap = claude.max_concurrent_sessions if claude else None
+            per_session_mib = claude.session_memory_estimate_mib if claude else 200
+            per_session_bytes = per_session_mib * 1024 * 1024
+            mem_bytes = memory_limit_bytes()
+            logger.info(
+                "Claude cgroup memory limit: %s",
+                f"{mem_bytes} bytes" if mem_bytes is not None else "unbounded",
             )
             if explicit_cap is not None:
                 max_sessions = explicit_cap
@@ -133,13 +149,23 @@ class AgentServer:
                     "claude.max_concurrent_sessions)",
                     max_sessions,
                 )
-            else:
-                cores = cpu_quota()
-                max_sessions = derived_session_cap(cores)
+            elif mem_bytes is not None:
+                max_sessions = derived_session_cap_from_memory(
+                    mem_bytes, per_session_bytes=per_session_bytes
+                )
                 logger.info(
-                    "Claude session cap: %d (derived from %.2f CPU cores)",
+                    "Claude session cap: %d (derived from %d MiB memory "
+                    "limit @ %d MiB/session)",
                     max_sessions,
-                    cores,
+                    mem_bytes // (1024 * 1024),
+                    per_session_mib,
+                )
+            else:
+                max_sessions = _FALLBACK_SESSION_CAP
+                logger.info(
+                    "Claude session cap: %d (fallback — no cgroup memory "
+                    "limit detected)",
+                    max_sessions,
                 )
         self.sessions = SessionStore(max_sessions=max_sessions)
         self._tool_init_manager = ToolInitManager(

--- a/src/holodeck/serve/server.py
+++ b/src/holodeck/serve/server.py
@@ -7,6 +7,8 @@ for exposing agents via HTTP.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -47,16 +49,23 @@ _BACKEND_ERROR_MSG = (
     "Start a new session to retry."
 )
 _CAPACITY_MSG_TEMPLATE = (
-    "Maximum concurrent Claude sessions ({max}) reached. "
-    "Retry after existing sessions complete."
+    "Maximum concurrent active turns ({max}) reached. "
+    "Retry after in-flight turns complete."
 )
 _CAPACITY_RETRY_AFTER_SECONDS = 5
 
-# Fallback session cap when neither an explicit
+# Fallback active-turn cap when neither an explicit
 # claude.max_concurrent_sessions nor a cgroup memory limit is available
 # (local dev, unconstrained Linux). Keep this conservative: this number is
 # only reached when we can't introspect the runtime at all.
-_FALLBACK_SESSION_CAP = 50
+_FALLBACK_ACTIVE_TURN_CAP = 50
+
+# Open-session ceiling. Under spec 034 P4, idle sessions cost ~30 MiB each
+# (a Python object + JSONL transcript reference, no persistent subprocess),
+# so the real binding constraint is concurrent active turns — not open
+# session count. This cap exists only to bound disk usage from JSONL
+# transcripts and to prevent unbounded dict growth.
+_OPEN_SESSION_CEILING = 1000
 
 
 class AgentServer:
@@ -123,51 +132,53 @@ class AgentServer:
             self.agent_config.model.provider == ProviderEnum.ANTHROPIC
         )
 
-        # Determine max sessions based on provider.
-        # For Claude, derive the default from the container's cgroup memory
-        # limit (spec 034 P1a) so per-replica concurrency scales with
-        # container sizing — the SDK's ~200 MiB-per-subprocess footprint
-        # is what triggers cgroup OOMKill when over-provisioned. Memory is
-        # the binding constraint and is reliably exposed via cgroup files
-        # in every runtime we care about (including Azure Container Apps,
-        # which does *not* expose CPU limits the same way).
-        max_sessions = 1000  # Non-Claude providers don't spawn subprocesses
+        # Spec 034 P4 changed the binding constraint: the SDK subprocess
+        # is now spawned per *turn* (not per session), so memory-bounded
+        # capacity must gate concurrent active turns rather than open
+        # session count. We derive the active-turn cap from the cgroup
+        # memory limit using the same formula previously used for the
+        # session cap — only the semantic shifted.
+        self._active_turn_cap: int | None = None
+        self._active_turn_semaphore: asyncio.BoundedSemaphore | None = None
         if self.agent_config.model.provider == ProviderEnum.ANTHROPIC:
             claude = self.agent_config.claude
             explicit_cap = claude.max_concurrent_sessions if claude else None
-            per_session_mib = claude.session_memory_estimate_mib if claude else 200
-            per_session_bytes = per_session_mib * 1024 * 1024
+            per_turn_mib = claude.session_memory_estimate_mib if claude else 200
+            per_turn_bytes = per_turn_mib * 1024 * 1024
             mem_bytes = memory_limit_bytes()
             logger.info(
                 "Claude cgroup memory limit: %s",
                 f"{mem_bytes} bytes" if mem_bytes is not None else "unbounded",
             )
             if explicit_cap is not None:
-                max_sessions = explicit_cap
+                self._active_turn_cap = explicit_cap
                 logger.info(
-                    "Claude session cap: %d (explicit from "
+                    "Claude active-turn cap: %d (explicit from "
                     "claude.max_concurrent_sessions)",
-                    max_sessions,
+                    self._active_turn_cap,
                 )
             elif mem_bytes is not None:
-                max_sessions = derived_session_cap_from_memory(
-                    mem_bytes, per_session_bytes=per_session_bytes
+                self._active_turn_cap = derived_session_cap_from_memory(
+                    mem_bytes, per_session_bytes=per_turn_bytes
                 )
                 logger.info(
-                    "Claude session cap: %d (derived from %d MiB memory "
-                    "limit @ %d MiB/session)",
-                    max_sessions,
+                    "Claude active-turn cap: %d (derived from %d MiB memory "
+                    "limit @ %d MiB/turn)",
+                    self._active_turn_cap,
                     mem_bytes // (1024 * 1024),
-                    per_session_mib,
+                    per_turn_mib,
                 )
             else:
-                max_sessions = _FALLBACK_SESSION_CAP
+                self._active_turn_cap = _FALLBACK_ACTIVE_TURN_CAP
                 logger.info(
-                    "Claude session cap: %d (fallback — no cgroup memory "
+                    "Claude active-turn cap: %d (fallback — no cgroup memory "
                     "limit detected)",
-                    max_sessions,
+                    self._active_turn_cap,
                 )
-        self.sessions = SessionStore(max_sessions=max_sessions)
+            self._active_turn_semaphore = asyncio.BoundedSemaphore(
+                self._active_turn_cap
+            )
+        self.sessions = SessionStore(max_sessions=_OPEN_SESSION_CEILING)
         self._tool_init_manager = ToolInitManager(
             agent=self.agent_config, max_concurrent=max_concurrent_init_jobs
         )
@@ -258,26 +269,80 @@ class AgentServer:
             return self._capacity_exceeded_response()
 
     def _capacity_exceeded_response(self) -> JSONResponse:
-        """Build a 429 JSON response for capacity-exceeded errors.
+        """Build a 429 JSON response for active-turn capacity exhaustion.
 
         Returns HTTP 429 with ``Retry-After`` so clients (and any fronting
         load balancer) recognise the backpressure and retry against
         another replica. Spec 034 P1a switched this from 503 because most
         HTTP client libraries treat 429 as a transient retryable signal
         out of the box, whereas 503 often surfaces as a hard error.
+
+        Spec 034 P4 repurposed the cap from "open sessions" to "concurrent
+        active turns" — the field stays ``max_sessions`` in the response
+        body for client/dashboard compatibility, but reflects the
+        active-turn cap.
         """
+        cap = self._active_turn_cap or 0
+        in_flight = self._active_turn_in_flight()
         return JSONResponse(
             status_code=429,
             content={
                 "error": "capacity_exceeded",
-                "message": _CAPACITY_MSG_TEMPLATE.format(
-                    max=self.sessions.max_sessions,
-                ),
-                "active_sessions": self.sessions.active_count,
-                "max_sessions": self.sessions.max_sessions,
+                "message": _CAPACITY_MSG_TEMPLATE.format(max=cap),
+                "active_sessions": in_flight,
+                "max_sessions": cap,
             },
             headers={"Retry-After": str(_CAPACITY_RETRY_AFTER_SECONDS)},
         )
+
+    def _active_turn_in_flight(self) -> int:
+        """Return the count of currently-acquired turn slots.
+
+        Reads ``BoundedSemaphore`` internals (``_value``) since the public
+        API doesn't expose in-flight count. Safe because asyncio
+        primitives are single-threaded.
+        """
+        sem = self._active_turn_semaphore
+        if sem is None:
+            return 0
+        return self._active_turn_cap - sem._value  # type: ignore[operator]
+
+    def _turn_capacity_exceeded(self) -> bool:
+        """Return True iff acquiring a turn slot would block right now."""
+        sem = self._active_turn_semaphore
+        return sem is not None and sem.locked()
+
+    @contextlib.asynccontextmanager
+    async def _acquire_turn_slot(self) -> AsyncGenerator[None, None]:
+        """Acquire one active-turn slot for the duration of this context.
+
+        No-op when no semaphore is configured (non-Claude providers).
+        The slot is released even if the wrapped work raises or the
+        request generator is cancelled by the client.
+        """
+        sem = self._active_turn_semaphore
+        if sem is None:
+            yield
+            return
+        await sem.acquire()
+        try:
+            yield
+        finally:
+            sem.release()
+
+    async def _turn_gated_stream(
+        self,
+        gen: AsyncGenerator[bytes, None],
+    ) -> AsyncGenerator[bytes, None]:
+        """Wrap a streaming response generator so it holds a turn slot.
+
+        The slot is acquired before the first chunk is produced and
+        released after the generator is exhausted (or cancelled). Keeps
+        the gating logic symmetric with the sync path.
+        """
+        async with self._acquire_turn_slot():
+            async for chunk in gen:
+                yield chunk
 
     async def _handle_backend_session_error(
         self,
@@ -427,6 +492,12 @@ class AgentServer:
             # Capacity exceeded surfaces as a real HTTP 429 (not an SSE
             # error frame inside a 200) so fronting load balancers and
             # client retry logic see the backpressure (spec 034 P1a).
+            # Spec 034 P4: the cap is now concurrent active turns, not
+            # open sessions — open sessions are nearly free under hybrid
+            # session model.
+            if self._turn_capacity_exceeded():
+                return self._capacity_exceeded_response()  # type: ignore[return-value]
+
             session_id = input_data.thread_id
             result = self._get_or_create_session(session_id)
             if isinstance(result, JSONResponse):
@@ -443,9 +514,10 @@ class AgentServer:
                 execution_config=self.execution_config,
             )
 
-            # Stream response
+            # Stream response, holding a turn slot for the lifetime of
+            # the generator (released on exhaustion or client disconnect).
             return StreamingResponse(
-                protocol.handle_request(input_data, session),
+                self._turn_gated_stream(protocol.handle_request(input_data, session)),
                 media_type=protocol.content_type,
             )
 
@@ -475,6 +547,9 @@ class AgentServer:
             Accepts a message, processes it through the agent, and returns
             the complete response as JSON.
             """
+            if self._turn_capacity_exceeded():
+                return self._capacity_exceeded_response()  # type: ignore[return-value,no-any-return]
+
             result = self._get_or_create_session(request.session_id)
             if isinstance(result, JSONResponse):
                 return result  # type: ignore[return-value,no-any-return]
@@ -485,7 +560,8 @@ class AgentServer:
 
             protocol = RESTProtocol()
             try:
-                return await protocol.handle_sync_request(request, session)
+                async with self._acquire_turn_slot():
+                    return await protocol.handle_sync_request(request, session)
             except BackendSessionError:
                 return await self._handle_backend_session_error(  # type: ignore[return-value,no-any-return]
                     session.session_id,
@@ -501,9 +577,12 @@ class AgentServer:
             Accepts a message, processes it through the agent, and streams
             SSE events back to the client.
             """
+            if self._turn_capacity_exceeded():
+                return self._capacity_exceeded_response()  # type: ignore[return-value]
+
             result = self._get_or_create_session(request.session_id)
             if isinstance(result, JSONResponse):
-                return result  # type: ignore[return-value,no-any-return]
+                return result  # type: ignore[return-value]
             session = result
 
             self.sessions.touch(session.session_id)
@@ -511,7 +590,7 @@ class AgentServer:
 
             protocol = RESTProtocol()
             return StreamingResponse(
-                protocol.handle_request(request, session),
+                self._turn_gated_stream(protocol.handle_request(request, session)),
                 media_type=protocol.content_type,
             )
 
@@ -554,6 +633,9 @@ class AgentServer:
                 files=file_contents if file_contents else None,
             )
 
+            if self._turn_capacity_exceeded():
+                return self._capacity_exceeded_response()  # type: ignore[return-value,no-any-return]
+
             result = self._get_or_create_session(session_id)
             if isinstance(result, JSONResponse):
                 return result  # type: ignore[return-value,no-any-return]
@@ -564,7 +646,8 @@ class AgentServer:
 
             protocol = RESTProtocol()
             try:
-                return await protocol.handle_sync_request(chat_request, session)
+                async with self._acquire_turn_slot():
+                    return await protocol.handle_sync_request(chat_request, session)
             except BackendSessionError:
                 return await self._handle_backend_session_error(  # type: ignore[return-value,no-any-return]
                     session.session_id,
@@ -607,9 +690,12 @@ class AgentServer:
                 files=file_contents if file_contents else None,
             )
 
+            if self._turn_capacity_exceeded():
+                return self._capacity_exceeded_response()  # type: ignore[return-value]
+
             result = self._get_or_create_session(session_id)
             if isinstance(result, JSONResponse):
-                return result  # type: ignore[return-value,no-any-return]
+                return result  # type: ignore[return-value]
             session = result
 
             self.sessions.touch(session.session_id)
@@ -617,7 +703,7 @@ class AgentServer:
 
             protocol = RESTProtocol()
             return StreamingResponse(
-                protocol.handle_request(chat_request, session),
+                self._turn_gated_stream(protocol.handle_request(chat_request, session)),
                 media_type=protocol.content_type,
             )
 

--- a/src/holodeck/serve/server.py
+++ b/src/holodeck/serve/server.py
@@ -7,8 +7,6 @@ for exposing agents via HTTP.
 from __future__ import annotations
 
 import asyncio
-import json
-from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -20,6 +18,7 @@ from holodeck.lib.backends import BackendInitError, BackendSessionError
 from holodeck.lib.backends.validators import validate_credentials, validate_nodejs
 from holodeck.lib.errors import ConfigError
 from holodeck.lib.logging_config import get_logger
+from holodeck.lib.runtime import cpu_quota, derived_session_cap
 from holodeck.models.llm import ProviderEnum
 from holodeck.serve.middleware import ErrorHandlingMiddleware, LoggingMiddleware
 from holodeck.serve.models import (
@@ -48,6 +47,7 @@ _CAPACITY_MSG_TEMPLATE = (
     "Maximum concurrent Claude sessions ({max}) reached. "
     "Retry after existing sessions complete."
 )
+_CAPACITY_RETRY_AFTER_SECONDS = 5
 
 
 class AgentServer:
@@ -114,13 +114,33 @@ class AgentServer:
             self.agent_config.model.provider == ProviderEnum.ANTHROPIC
         )
 
-        # Determine max sessions based on provider
-        max_sessions = 1000  # Default for non-Claude providers
+        # Determine max sessions based on provider.
+        # For Claude, derive the default from the container's cgroup CPU
+        # quota (spec 034 P1a) so per-replica concurrency scales with
+        # container sizing — the SDK's ~300 MiB-per-subprocess footprint
+        # means a 0.5 CPU / 1 GiB replica cannot safely run 10 sessions.
+        max_sessions = 1000  # Non-Claude providers don't spawn subprocesses
         if self.agent_config.model.provider == ProviderEnum.ANTHROPIC:
-            if self.agent_config.claude is not None:
-                max_sessions = self.agent_config.claude.max_concurrent_sessions or 10
+            explicit_cap = (
+                self.agent_config.claude.max_concurrent_sessions
+                if self.agent_config.claude is not None
+                else None
+            )
+            if explicit_cap is not None:
+                max_sessions = explicit_cap
+                logger.info(
+                    "Claude session cap: %d (explicit from "
+                    "claude.max_concurrent_sessions)",
+                    max_sessions,
+                )
             else:
-                max_sessions = 10  # Default when claude section absent
+                cores = cpu_quota()
+                max_sessions = derived_session_cap(cores)
+                logger.info(
+                    "Claude session cap: %d (derived from %.2f CPU cores)",
+                    max_sessions,
+                    cores,
+                )
         self.sessions = SessionStore(max_sessions=max_sessions)
         self._tool_init_manager = ToolInitManager(
             agent=self.agent_config, max_concurrent=max_concurrent_init_jobs
@@ -212,9 +232,16 @@ class AgentServer:
             return self._capacity_exceeded_response()
 
     def _capacity_exceeded_response(self) -> JSONResponse:
-        """Build a 503 JSON response for capacity-exceeded errors."""
+        """Build a 429 JSON response for capacity-exceeded errors.
+
+        Returns HTTP 429 with ``Retry-After`` so clients (and any fronting
+        load balancer) recognise the backpressure and retry against
+        another replica. Spec 034 P1a switched this from 503 because most
+        HTTP client libraries treat 429 as a transient retryable signal
+        out of the box, whereas 503 often surfaces as a hard error.
+        """
         return JSONResponse(
-            status_code=503,
+            status_code=429,
             content={
                 "error": "capacity_exceeded",
                 "message": _CAPACITY_MSG_TEMPLATE.format(
@@ -223,7 +250,7 @@ class AgentServer:
                 "active_sessions": self.sessions.active_count,
                 "max_sessions": self.sessions.max_sessions,
             },
-            headers={"Retry-After": "5"},
+            headers={"Retry-After": str(_CAPACITY_RETRY_AFTER_SECONDS)},
         )
 
     async def _handle_backend_session_error(
@@ -370,29 +397,14 @@ class AgentServer:
             except ValidationError as e:
                 raise HTTPException(status_code=422, detail=e.errors()) from e
 
-            # Get session by thread_id or create new one
+            # Get session by thread_id or create new one.
+            # Capacity exceeded surfaces as a real HTTP 429 (not an SSE
+            # error frame inside a 200) so fronting load balancers and
+            # client retry logic see the backpressure (spec 034 P1a).
             session_id = input_data.thread_id
             result = self._get_or_create_session(session_id)
             if isinstance(result, JSONResponse):
-                # Convert capacity error to AG-UI SSE format
-                cap = self.sessions.max_sessions
-
-                async def capacity_error_stream() -> AsyncGenerator[bytes, None]:
-                    payload = json.dumps(
-                        {
-                            "type": "capacity_exceeded",
-                            "message": (
-                                f"Maximum concurrent Claude sessions "
-                                f"({cap}) reached."
-                            ),
-                        }
-                    )
-                    yield f"event: error\ndata: {payload}\n\n".encode()
-
-                return StreamingResponse(
-                    capacity_error_stream(),
-                    media_type="text/event-stream",
-                )
+                return result  # type: ignore[return-value]
             session = result
 
             self.sessions.touch(session_id)

--- a/tests/unit/agent/test_executor.py
+++ b/tests/unit/agent/test_executor.py
@@ -363,7 +363,6 @@ class TestBackendExecutorExecution:
                 executor.agent_config,
                 tool_instances=None,
                 mode="chat",
-                allow_side_effects=False,
             )
 
     @pytest.mark.asyncio

--- a/tests/unit/deploy/test_deployers_azure.py
+++ b/tests/unit/deploy/test_deployers_azure.py
@@ -184,16 +184,23 @@ class TestAzureContainerAppsDeployer:
         assert container.env[0].name == "OPENAI_API_KEY"
         assert container.env[0].value == "secret"
 
-        # Verify health probe configuration (uses default /health path)
-        assert len(container.probes) == 1
-        probe = container.probes[0]
-        assert probe.type == "Liveness"
-        assert probe.http_get.port == 8080
-        assert probe.http_get.path == "/health"
-        assert probe.initial_delay_seconds == 10
-        assert probe.period_seconds == 30
-        assert probe.failure_threshold == 3
-        assert probe.timeout_seconds == 5
+        # spec 034 P1a: container has both liveness + readiness probes
+        assert len(container.probes) == 2
+        liveness = next(p for p in container.probes if p.type == "Liveness")
+        assert liveness.http_get.port == 8080
+        assert liveness.http_get.path == "/health"
+        assert liveness.initial_delay_seconds == 10
+        assert liveness.period_seconds == 30
+        assert liveness.failure_threshold == 3
+        assert liveness.timeout_seconds == 5
+
+        readiness = next(p for p in container.probes if p.type == "Readiness")
+        assert readiness.http_get.port == 8080
+        assert readiness.http_get.path == "/ready"
+        assert readiness.initial_delay_seconds == 5
+        assert readiness.period_seconds == 10
+        assert readiness.failure_threshold == 3
+        assert readiness.timeout_seconds == 5
 
         scale = envelope.template.scale
         assert scale.min_replicas == 1
@@ -290,10 +297,73 @@ class TestAzureContainerAppsDeployer:
         envelope = call_kwargs["container_app_envelope"]
         container = envelope.template.containers[0]
 
-        # Verify custom health check path is used
-        probe = container.probes[0]
-        assert probe.http_get.path == "/api/healthz"
-        assert probe.http_get.port == 8080
+        # Verify custom health check path is used by the liveness probe
+        liveness = next(p for p in container.probes if p.type == "Liveness")
+        assert liveness.http_get.path == "/api/healthz"
+        assert liveness.http_get.port == 8080
+
+    def test_deploy_warns_when_cpu_below_one(
+        self, azure_sdk: type, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """spec 034 P1a: cpu<1.0 logs a warning naming the SDK guidance."""
+        config = AzureContainerAppsConfig(
+            subscription_id="00000000-0000-0000-0000-000000000000",
+            resource_group="test-rg",
+            environment_name="test-env",
+            cpu=0.5,
+        )
+        deployer = AzureContainerAppsDeployer(config)
+        client = deployer._client
+        container_apps = cast(MagicMock, client.container_apps)
+        poller = MagicMock()
+        fixture = _load_fixture()
+        poller.result.return_value = _build_result_from_fixture(fixture)
+        container_apps.begin_create_or_update.return_value = poller
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            deployer.deploy(
+                service_name="test-agent",
+                image_uri="ghcr.io/holodeck/test-agent:abc",
+                port=8080,
+                env_vars={},
+            )
+
+        assert any(
+            "below Anthropic's recommended minimum" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_deploy_warns_when_ingress_external(
+        self, azure_sdk: type, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """spec 034 P1a: ingress_external=True logs a 'public internet' warning."""
+        config = AzureContainerAppsConfig(
+            subscription_id="00000000-0000-0000-0000-000000000000",
+            resource_group="test-rg",
+            environment_name="test-env",
+            ingress_external=True,
+        )
+        deployer = AzureContainerAppsDeployer(config)
+        client = deployer._client
+        container_apps = cast(MagicMock, client.container_apps)
+        poller = MagicMock()
+        fixture = _load_fixture()
+        poller.result.return_value = _build_result_from_fixture(fixture)
+        container_apps.begin_create_or_update.return_value = poller
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            deployer.deploy(
+                service_name="test-agent",
+                image_uri="ghcr.io/holodeck/test-agent:abc",
+                port=8080,
+                env_vars={},
+            )
+
+        assert any("PUBLIC INTERNET" in rec.message for rec in caplog.records)
 
     def test_resolve_container_app_name_valid_simple_name(
         self, azure_sdk: type

--- a/tests/unit/deploy/test_models.py
+++ b/tests/unit/deploy/test_models.py
@@ -310,6 +310,10 @@ class TestAzureContainerAppsConfig:
         assert config.subscription_id == "00000000-0000-0000-0000-000000000000"
         assert config.resource_group == "my-rg"
         assert config.location == "eastus"  # default
+        # spec 034 P1a: safer/larger defaults for Claude-backed agents
+        assert config.cpu == 1.0
+        assert config.memory == "2Gi"
+        assert config.ingress_external is False
 
     def test_azure_config_with_all_options(self) -> None:
         """Test Azure config with all options specified."""

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -1206,13 +1206,6 @@ class TestClaudeSessionStreaming:
 
     @pytest.mark.asyncio
     async def test_send_streaming_propagates_session_id_on_turn_2(self) -> None:
-        captured_options: list[Any] = []
-
-        async def fake_query(prompt, options):
-            captured_options.append(options)
-            yield _make_assistant_message([_make_text_block("ok")])
-            yield _make_result_message(session_id="sdk-stream-XYZ")
-
         # Use a real ClaudeAgentOptions for the resume-propagation assertion
         # (MagicMock(spec=ClaudeAgentOptions) auto-creates the resume attribute,
         # masking the turn-1 ``is None`` check — same nuance as Task 3 test 3).

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -10,9 +10,11 @@ Tests T001–T016 covering:
 
 from __future__ import annotations
 
+import asyncio  # noqa: F401  (used by P4 tasks 2/5/7)
 import json
 import logging
 import sys
+from pathlib import Path  # noqa: F401  (used by P4 task 5)
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -3049,3 +3051,31 @@ class TestBuildOptionsSubagentTools:
         kwargs = mock_opts_cls.call_args[1]
         assert kwargs["agents"]["thinker"].tools == []
         assert kwargs["agents"]["thinker"].tools is not None
+
+
+# ---------------------------------------------------------------------------
+# Streaming-mode envelope (spec 034 P4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStreamingUserEnvelope:
+    """The envelope wraps a string into the AsyncIterable[dict] shape that
+    ``query()`` needs in streaming mode. String-mode prompts cause query()
+    to call end_input() after writing, deadlocking SDK MCP tool callbacks.
+    """
+
+    @pytest.mark.asyncio
+    async def test_yields_single_user_message(self) -> None:
+        from holodeck.lib.backends.claude_backend import (
+            _streaming_user_envelope,
+        )
+
+        msgs = [m async for m in _streaming_user_envelope("hello")]
+
+        assert len(msgs) == 1
+        msg = msgs[0]
+        assert msg["type"] == "user"
+        assert msg["session_id"] == ""
+        assert msg["message"] == {"role": "user", "content": "hello"}
+        assert msg["parent_tool_use_id"] is None

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -3079,3 +3079,16 @@ class TestStreamingUserEnvelope:
         assert msg["session_id"] == ""
         assert msg["message"] == {"role": "user", "content": "hello"}
         assert msg["parent_tool_use_id"] is None
+
+
+@pytest.mark.unit
+class TestClaudeSessionP4Fields:
+    """P4 session model: session_id captures CLI-assigned id on turn 1,
+    feeds it into ``options.resume`` on turn 2+. Lock serialises concurrent
+    sends to prevent transcript-write races.
+    """
+
+    def test_init_sets_p4_fields(self) -> None:
+        session = ClaudeSession(options=MagicMock())
+        assert session._sdk_session_id is None
+        assert isinstance(session._send_lock, asyncio.Lock)

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -1360,6 +1360,65 @@ class TestClaudeSessionSend:
 
 
 # ---------------------------------------------------------------------------
+# _transcript_path() — direct encoding tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTranscriptPath:
+    """Direct tests for _transcript_path's path-encoding logic.
+
+    These tests bypass the mock seen in TestClaudeSessionClose so the
+    real encoding (/-to-- replacement, ~/.claude/projects/ rooting,
+    cwd plumbing) is exercised end-to-end against the filesystem
+    contract the Claude CLI uses.
+    """
+
+    def test_encodes_absolute_cwd_with_dashes(self) -> None:
+        from holodeck.lib.backends.claude_backend import _transcript_path
+
+        path = _transcript_path("abc-123", cwd=Path("/Users/dev/proj"))
+
+        # ~/.claude/projects/-Users-dev-proj/abc-123.jsonl
+        assert path.name == "abc-123.jsonl"
+        assert path.parent.name == "-Users-dev-proj"
+        assert path.parent.parent.name == "projects"
+        assert path.parent.parent.parent.name == ".claude"
+
+    def test_does_not_resolve_symlinks(self, tmp_path) -> None:
+        """The CLI is passed the raw options.cwd; helper must not resolve."""
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        from holodeck.lib.backends.claude_backend import _transcript_path
+
+        path = _transcript_path("sess", cwd=link)
+
+        # Should encode the symlink path, not the resolved real path.
+        assert str(link).replace("/", "-") in str(path)
+
+    def test_relative_cwd_anchored_to_process_cwd(self, tmp_path, monkeypatch) -> None:
+        """Relative cwds are joined to the process cwd before encoding."""
+        monkeypatch.chdir(tmp_path)
+        from holodeck.lib.backends.claude_backend import _transcript_path
+
+        path = _transcript_path("sess", cwd=Path("agent-dir"))
+
+        encoded_parent = str(tmp_path / "agent-dir").replace("/", "-")
+        assert path.parent.name == encoded_parent
+
+    def test_defaults_to_process_cwd_when_none(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        from holodeck.lib.backends.claude_backend import _transcript_path
+
+        path = _transcript_path("sess")
+
+        encoded_parent = str(tmp_path).replace("/", "-")
+        assert path.parent.name == encoded_parent
+
+
+# ---------------------------------------------------------------------------
 # T013 — ClaudeSession.close()
 # ---------------------------------------------------------------------------
 
@@ -1404,6 +1463,44 @@ class TestClaudeSessionClose:
         """Sessions that never sent a turn have no transcript to delete."""
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         await session.close()  # must not raise
+        assert session._sdk_session_id is None
+
+    @pytest.mark.asyncio
+    async def test_close_uses_options_cwd_not_process_cwd(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """close() must compute the transcript path from options.cwd, not
+        Path.cwd(). Regression for the bug where an agent with
+        claude.working_directory override would leak its transcript because
+        close() looked in the wrong projects/<encoded> directory.
+        """
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        agent_cwd = tmp_path / "agent-workdir"
+        agent_cwd.mkdir()
+
+        # Create the transcript at the path close() will compute when it
+        # honours options.cwd.
+        encoded = str(agent_cwd).replace("/", "-")
+        transcript = fake_home / ".claude" / "projects" / encoded / "sess-cwd.jsonl"
+        transcript.parent.mkdir(parents=True)
+        transcript.write_text('{"type":"user"}\n')
+
+        # Build a real ClaudeAgentOptions with cwd set (the bug only
+        # manifests when options.cwd != Path.cwd()).
+        from claude_agent_sdk import ClaudeAgentOptions as RealOptions
+
+        session = ClaudeSession(options=RealOptions(cwd=str(agent_cwd)))
+        session._sdk_session_id = "sess-cwd"
+
+        await session.close()
+
+        assert not transcript.exists(), (
+            "close() failed to honour options.cwd; the transcript at "
+            f"{transcript} was not deleted."
+        )
         assert session._sdk_session_id is None
 
     def test_implements_agent_session_protocol(self) -> None:

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -19,6 +19,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from claude_agent_sdk import ClaudeAgentOptions
 from exceptiongroup import BaseExceptionGroup
 
 from holodeck.lib.backends.base import (
@@ -1213,44 +1214,38 @@ class TestClaudeSessionStreaming:
 
 @pytest.mark.unit
 class TestClaudeSessionSend:
-    """Tests for ClaudeSession.send() — non-streaming, full response."""
+    """ClaudeSession.send() under spec 034 P4 (hybrid sessions).
+
+    send() calls top-level claude_agent_sdk.query() with a streaming-mode
+    prompt envelope and ``options.resume = self._sdk_session_id``. session_id
+    is captured from ResultMessage on turn 1.
+    """
 
     @pytest.mark.asyncio
     async def test_send_returns_execution_result(self) -> None:
-        """T012: send() returns ExecutionResult with concatenated text."""
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock()
         assistant = _make_assistant_message(
             [_make_text_block("Hello "), _make_text_block("world!")]
         )
-        result_msg = _make_result_message()
+        result_msg = _make_result_message(session_id="sdk-sess-001")
 
-        def mock_receive():
-            return _async_iter([assistant, result_msg])
+        async def fake_query(prompt, options):
+            for m in (assistant, result_msg):
+                yield m
 
-        mock_client.receive_response = mock_receive
-
-        session = ClaudeSession(options=MagicMock())
-        session._client = mock_client
-
-        result = await session.send("Hi")
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            result = await session.send("Hi")
 
         assert isinstance(result, ExecutionResult)
         assert result.response == "Hello world!"
         assert result.token_usage.prompt_tokens == 10
+        assert session._sdk_session_id == "sdk-sess-001"
 
     @pytest.mark.asyncio
     async def test_send_enriches_tool_results_with_name(self) -> None:
-        """Regression: ClaudeSession.send must populate `name` on tool_results.
-
-        ToolResultBlock from the SDK only carries `call_id`, while ToolUseBlock
-        carries the tool name. `build_retrieval_context_from_tools` keys on
-        name, so sessions that skipped enrichment produced empty retrieval
-        contexts and made DeepEval RAG metrics crash with 'retrieval_context
-        cannot be None'.
-        """
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock()
+        """Regression: tool_results must carry tool name (call_id → name lookup)."""
         tool_use = _make_tool_use_block(
             tool_id="call_abc",
             name="mcp__holodeck_tools__legislation_search_search",
@@ -1263,14 +1258,15 @@ class TestClaudeSessionSend:
         user_msg.content = [tool_result_block]
         user_msg.__class__.__name__ = "UserMessage"
 
-        def mock_receive():
-            return _async_iter([assistant, user_msg, _make_result_message()])
+        async def fake_query(prompt, options):
+            for m in (assistant, user_msg, _make_result_message()):
+                yield m
 
-        mock_client.receive_response = mock_receive
-        session = ClaudeSession(options=MagicMock())
-        session._client = mock_client
-
-        result = await session.send("search")
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            result = await session.send("search")
 
         assert result.tool_calls[0]["name"] == (
             "mcp__holodeck_tools__legislation_search_search"
@@ -1281,54 +1277,58 @@ class TestClaudeSessionSend:
         assert result.tool_results[0]["call_id"] == "call_abc"
 
     @pytest.mark.asyncio
-    async def test_send_multi_turn_state_tracking(self) -> None:
-        """Multi-turn: every ``client.query()`` uses session_id="default".
-
-        Regression test for an AGUI multi-turn hang. The CLI subprocess
-        tracks conversation state implicitly across queries on the same
-        connection, so every ``client.query()`` for the lifetime of a
-        connected ``ClaudeSDKClient`` must pass the same ``session_id``.
-        Rotating it to the CLI-assigned id from ``ResultMessage`` (the
-        previous behavior) wedges the CLI on the second turn — its
-        ``query()`` write succeeds but no responses ever come back.
+    async def test_send_propagates_session_id_into_resume_on_turn_2(
+        self,
+    ) -> None:
+        """Turn 1 captures session_id from ResultMessage; turn 2's query() call
+        must pass that id back as ``options.resume`` so the SDK rehydrates the
+        on-disk transcript.
         """
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock()
+        captured_resume: list[Any] = []
 
-        # First turn
-        result_msg_1 = _make_result_message(session_id="sess-001")
-        turn1_items = [_make_assistant_message(), result_msg_1]
+        async def fake_query(prompt, options):
+            captured_resume.append(getattr(options, "resume", None))
+            yield _make_assistant_message()
+            yield _make_result_message(session_id="sdk-sess-XYZ")
 
-        def mock_receive_turn1():
-            return _async_iter(turn1_items)
+        # Use a real ClaudeAgentOptions instance so dataclasses.replace works
+        # and produces a fresh, non-aliased options per turn.
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            await session.send("Turn 1")
+            await session.send("Turn 2")
 
-        mock_client.receive_response = mock_receive_turn1
-
-        base_options = MagicMock()
-        session = ClaudeSession(options=base_options)
-        session._client = mock_client
-
-        await session.send("Turn 1")
-
-        assert session._turn_count == 1
-        # First turn uses session_id="default".
-        mock_client.query.assert_called_with("Turn 1", session_id="default")
-
-        # Second turn
-        result_msg_2 = _make_result_message(session_id="sess-002")
-        turn2_items = [_make_assistant_message(), result_msg_2]
-
-        def mock_receive_turn2():
-            return _async_iter(turn2_items)
-
-        mock_client.receive_response = mock_receive_turn2
-
-        await session.send("Turn 2")
-
-        # Turn 2 must ALSO pass session_id="default" — not the CLI-assigned
-        # "sess-001" — otherwise the CLI hangs.
-        mock_client.query.assert_called_with("Turn 2", session_id="default")
+        assert len(captured_resume) == 2
+        assert captured_resume[0] is None
+        assert captured_resume[1] == "sdk-sess-XYZ"
+        assert session._sdk_session_id == "sdk-sess-XYZ"
         assert session._turn_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_uses_streaming_mode_prompt(self) -> None:
+        """The prompt passed to query() must be an AsyncIterable, not a str —
+        string-mode closes stdin and deadlocks SDK MCP tool callbacks (spec
+        034 P4 spike v1).
+        """
+        captured_prompts: list[Any] = []
+
+        async def fake_query(prompt, options):
+            captured_prompts.append(prompt)
+            async for _ in prompt:
+                pass
+            yield _make_result_message()
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            await session.send("Hi")
+
+        assert len(captured_prompts) == 1
+        assert not isinstance(captured_prompts[0], str)
+        assert hasattr(captured_prompts[0], "__aiter__")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -1366,28 +1366,48 @@ class TestClaudeSessionSend:
 
 @pytest.mark.unit
 class TestClaudeSessionClose:
-    """Tests for ClaudeSession.close() — client disconnect."""
+    """ClaudeSession.close() under spec 034 P4 — transcript cleanup."""
 
     @pytest.mark.asyncio
-    async def test_close_calls_disconnect(self) -> None:
-        """T013: close() calls client.disconnect() exactly once."""
-        mock_client = AsyncMock()
-        session = ClaudeSession(options=MagicMock())
-        session._client = mock_client
+    async def test_close_deletes_transcript_file(self, tmp_path) -> None:
+        """close() deletes ``~/.claude/projects/<encoded-cwd>/<id>.jsonl``."""
+        cwd_encoded = str(tmp_path / "fake-cwd").replace("/", "-")
+        transcript = tmp_path / "projects" / cwd_encoded / "sess-001.jsonl"
+        transcript.parent.mkdir(parents=True)
+        transcript.write_text('{"type":"user"}\n')
 
-        await session.close()
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        session._sdk_session_id = "sess-001"
 
-        mock_client.disconnect.assert_awaited_once()
-        assert session._client is None
+        with patch(
+            "holodeck.lib.backends.claude_backend._transcript_path",
+            return_value=transcript,
+        ):
+            await session.close()
+
+        assert not transcript.exists()
+        assert session._sdk_session_id is None
 
     @pytest.mark.asyncio
-    async def test_close_no_client_is_noop(self) -> None:
-        """close() with no client is a no-op."""
-        session = ClaudeSession(options=MagicMock())
-        await session.close()  # Should not raise
+    async def test_close_is_safe_when_transcript_missing(self) -> None:
+        """No-op when the transcript file doesn't exist (race / never-spawned)."""
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        session._sdk_session_id = "never-spawned"
+        with patch(
+            "holodeck.lib.backends.claude_backend._transcript_path",
+            return_value=Path("/nonexistent/path.jsonl"),
+        ):
+            await session.close()  # must not raise
 
-    def test_implements_session_protocol(self) -> None:
-        """ClaudeSession satisfies the AgentSession protocol."""
+    @pytest.mark.asyncio
+    async def test_close_no_session_id_is_noop(self) -> None:
+        """Sessions that never sent a turn have no transcript to delete."""
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        await session.close()  # must not raise
+        assert session._sdk_session_id is None
+
+    def test_implements_agent_session_protocol(self) -> None:
+        """ClaudeSession still satisfies the AgentSession protocol."""
         assert isinstance(ClaudeSession(options=MagicMock()), AgentSession)
 
 

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -59,7 +59,6 @@ from holodeck.models.observability import (
 # ---------------------------------------------------------------------------
 
 _SDK_MODULE = "holodeck.lib.backends.claude_backend"
-_CAS_MODULE = "claude_agent_sdk"
 
 
 def _make_agent(
@@ -991,7 +990,7 @@ class TestClaudeBackendInvokeOnce:
     """Tests for ClaudeBackend.invoke_once() — execution and result mapping."""
 
     @pytest.mark.asyncio
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_invoke_once_happy_path(self, mock_query: MagicMock) -> None:
         """T005: Mocked query() → correct ExecutionResult fields."""
         assistant = _make_assistant_message([_make_text_block("Hello world")])
@@ -1012,7 +1011,7 @@ class TestClaudeBackendInvokeOnce:
         assert result.num_turns == 1
 
     @pytest.mark.asyncio
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_invoke_once_tool_extraction(self, mock_query: MagicMock) -> None:
         """T006: Tool calls and results extracted from content blocks."""
         tool_use = _make_tool_use_block("toolu_01", "kb_search", {"query": "refund"})
@@ -1042,7 +1041,7 @@ class TestClaudeBackendInvokeOnce:
         }
 
     @pytest.mark.asyncio
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_invoke_once_structured_output(self, mock_query: MagicMock) -> None:
         """T007: Structured output returned and response set to JSON string."""
         structured = {"name": "Widget", "price": 9.99}
@@ -1067,7 +1066,7 @@ class TestClaudeBackendInvokeOnce:
         assert result.response == json.dumps(structured)
 
     @pytest.mark.asyncio
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_invoke_once_structured_output_schema_failure(
         self, mock_query: MagicMock
     ) -> None:
@@ -1092,7 +1091,7 @@ class TestClaudeBackendInvokeOnce:
         assert "schema validation" in result.error_reason.lower()
 
     @pytest.mark.asyncio
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_invoke_once_max_turns_exceeded(self, mock_query: MagicMock) -> None:
         """T008: max_turns exceeded → is_error=True with partial response."""
         assistant = _make_assistant_message([_make_text_block("Partial response")])
@@ -1122,7 +1121,7 @@ class TestClaudeBackendRetry:
 
     @pytest.mark.asyncio
     @patch(f"{_SDK_MODULE}.asyncio")
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_retry_on_process_error_then_success(
         self, mock_query: MagicMock, mock_asyncio: MagicMock
     ) -> None:
@@ -1151,7 +1150,7 @@ class TestClaudeBackendRetry:
 
     @pytest.mark.asyncio
     @patch(f"{_SDK_MODULE}.asyncio")
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_retry_all_failures_raises(
         self, mock_query: MagicMock, mock_asyncio: MagicMock
     ) -> None:
@@ -1518,7 +1517,7 @@ class TestClaudeBackendLazyInit:
     """Tests for lazy-init — auto-initialize on first use."""
 
     @pytest.mark.asyncio
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_invoke_once_auto_initializes(self, mock_query: MagicMock) -> None:
         """T015a: invoke_once() without explicit initialize() auto-inits."""
         mock_query.return_value = _async_iter(
@@ -1543,13 +1542,7 @@ class TestClaudeBackendLazyInit:
         """T015b: create_session() without explicit initialize() auto-inits."""
         backend = ClaudeBackend(_make_agent())
 
-        with (
-            patch.object(backend, "initialize", new_callable=AsyncMock) as mock_init,
-            patch(f"{_CAS_MODULE}.ClaudeSDKClient") as mock_client_cls,
-        ):
-            mock_client = MagicMock()
-            mock_client.connect = AsyncMock()
-            mock_client_cls.return_value = mock_client
+        with patch.object(backend, "initialize", new_callable=AsyncMock) as mock_init:
 
             async def side_effect():
                 backend._initialized = True
@@ -1559,25 +1552,18 @@ class TestClaudeBackendLazyInit:
             session = await backend.create_session()
             mock_init.assert_awaited_once()
             assert isinstance(session, ClaudeSession)
-            # Eager connect on session creation (fixes cross-task cancel scope).
-            mock_client.connect.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_create_session_eager_connect_false_skips_connect(self) -> None:
-        """create_session(eager_connect=False) returns an unconnected session.
+        """create_session(eager_connect=False) returns a session.
 
-        Used by ``_TaskBoundSession``: the actor task — not the caller — must
-        own the SDK's ``connect()`` so the anyio task group binds correctly.
+        spec 034 P4: there is no persistent client to connect; ``eager_connect``
+        is retained as a no-op flag for API compatibility. The session is
+        usable regardless.
         """
         backend = ClaudeBackend(_make_agent())
 
-        with (
-            patch.object(backend, "initialize", new_callable=AsyncMock) as mock_init,
-            patch(f"{_CAS_MODULE}.ClaudeSDKClient") as mock_client_cls,
-        ):
-            mock_client = MagicMock()
-            mock_client.connect = AsyncMock()
-            mock_client_cls.return_value = mock_client
+        with patch.object(backend, "initialize", new_callable=AsyncMock) as mock_init:
 
             async def side_effect():
                 backend._initialized = True
@@ -1588,29 +1574,21 @@ class TestClaudeBackendLazyInit:
             session = await backend.create_session(eager_connect=False)
 
             assert isinstance(session, ClaudeSession)
-            mock_client.connect.assert_not_called()
-            assert session._client is None
+            assert not hasattr(session, "_client")
 
     @pytest.mark.asyncio
-    async def test_session_prepare_invokes_connect(self) -> None:
-        """ClaudeSession.prepare() is the public entry that connects the client.
-
-        Used by ``_TaskBoundSession._loop`` startup to bind the SDK's anyio
-        task group to the actor task rather than the request task.
+    async def test_session_prepare_is_noop(self) -> None:
+        """spec 034 P4: ClaudeSession.prepare() no longer connects a client —
+        each query() call manages its own transport. prepare() must succeed
+        without raising so existing _TaskBoundSession callers stay working.
         """
-        with patch(f"{_CAS_MODULE}.ClaudeSDKClient") as mock_client_cls:
-            mock_client = MagicMock()
-            mock_client.connect = AsyncMock()
-            mock_client_cls.return_value = mock_client
-
-            session = ClaudeSession(options=MagicMock())
-            await session.prepare()
-
-            mock_client.connect.assert_awaited_once()
-            assert session._client is mock_client
+        session = ClaudeSession(options=MagicMock())
+        await session.prepare()  # must not raise
+        # No client to assert against; just confirm field is gone.
+        assert not hasattr(session, "_client")
 
     @pytest.mark.asyncio
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_no_double_init(self, mock_query: MagicMock) -> None:
         """T015c: Explicit initialize() + invoke_once() → no second init."""
         mock_query.return_value = _async_iter(
@@ -1648,7 +1626,7 @@ class TestClaudeBackendTeardown:
         assert backend._options is None
 
     @pytest.mark.asyncio
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_invoke_after_teardown_reinitializes(
         self, mock_query: MagicMock
     ) -> None:
@@ -1883,104 +1861,6 @@ class TestClaudeBackendInstrumentation:
 
 
 # ---------------------------------------------------------------------------
-# T017 — _patch_hooks_for_context_propagation
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestPatchHooksForContextPropagation:
-    """Tests for the ContextVar re-injection hook wrapper."""
-
-    @pytest.mark.asyncio
-    async def test_wrapper_sets_contextvar_from_instance(self) -> None:
-        """Hook wrapper re-injects ContextVar from client instance."""
-        from holodeck.lib.backends.claude_backend import (
-            _patch_hooks_for_context_propagation,
-        )
-
-        # Record what the original hook callback sees
-        seen_args: list[Any] = []
-
-        async def fake_hook(
-            input_data: Any,
-            tool_use_id: str | None = None,
-            context: Any = None,
-            **kwargs: Any,
-        ) -> dict[str, Any]:
-            seen_args.append(input_data)
-            return {}
-
-        # Build a mock client with HookMatcher-like objects
-        matcher = MagicMock()
-        matcher.hooks = [fake_hook]
-
-        mock_options = MagicMock()
-        mock_options.hooks = {"PreToolUse": [matcher]}
-
-        mock_client = MagicMock()
-        mock_client.options = mock_options
-
-        fake_invocation_ctx = MagicMock(name="InvocationContext")
-        mock_client._otel_invocation_ctx = fake_invocation_ctx
-
-        # Capture set_invocation_context calls
-        set_ctx_calls: list[Any] = []
-
-        with patch.dict(
-            sys.modules,
-            {
-                "opentelemetry.instrumentation.claude_agent_sdk._context": (
-                    MagicMock(
-                        set_invocation_context=lambda c: set_ctx_calls.append(c),
-                    )
-                ),
-            },
-        ):
-            _patch_hooks_for_context_propagation(mock_client)
-
-        # Hooks were replaced with wrappers
-        assert matcher.hooks != [fake_hook]
-        assert len(matcher.hooks) == 1
-
-        # Call the wrapped hook
-        await matcher.hooks[0]({"tool": "WebSearch"}, "toolu_01")
-
-        # Original hook was called with correct args
-        assert seen_args == [{"tool": "WebSearch"}]
-        # ContextVar was set from instance attribute
-        assert set_ctx_calls == [fake_invocation_ctx]
-
-    def test_noop_when_instrumentor_not_installed(self) -> None:
-        """No-op when otel-instrumentation-claude-agent-sdk is missing."""
-        from holodeck.lib.backends.claude_backend import (
-            _patch_hooks_for_context_propagation,
-        )
-
-        mock_client = MagicMock()
-        mock_client.options = MagicMock()
-        mock_client.options.hooks = {"PreToolUse": [MagicMock()]}
-
-        # Remove the module so ImportError fires
-        with patch.dict(
-            sys.modules,
-            {"opentelemetry.instrumentation.claude_agent_sdk._context": None},
-        ):
-            _patch_hooks_for_context_propagation(mock_client)
-
-    def test_noop_when_no_hooks(self) -> None:
-        """No-op when client has no hooks on options."""
-        from holodeck.lib.backends.claude_backend import (
-            _patch_hooks_for_context_propagation,
-        )
-
-        mock_client = MagicMock()
-        mock_client.options = MagicMock()
-        mock_client.options.hooks = None
-
-        _patch_hooks_for_context_propagation(mock_client)
-
-
-# ---------------------------------------------------------------------------
 # T018 — _wrap_prompt() async generator
 # ---------------------------------------------------------------------------
 
@@ -2173,154 +2053,6 @@ class TestBuildOptionsAllowedTools:
 
 
 # ---------------------------------------------------------------------------
-# T024 — _patch_hooks no-hooks early return (line 358)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestPatchHooksNoOptions:
-    """Test _patch_hooks_for_context_propagation early returns."""
-
-    def test_noop_when_options_is_none(self) -> None:
-        """No-op when client.options is None."""
-        from holodeck.lib.backends.claude_backend import (
-            _patch_hooks_for_context_propagation,
-        )
-
-        mock_client = MagicMock()
-        mock_client.options = None
-
-        with patch.dict(
-            sys.modules,
-            {
-                "opentelemetry.instrumentation.claude_agent_sdk._context": MagicMock(
-                    set_invocation_context=MagicMock(),
-                ),
-            },
-        ):
-            _patch_hooks_for_context_propagation(mock_client)
-
-    def test_noop_when_hooks_empty_dict(self) -> None:
-        """No-op when hooks is an empty dict."""
-        from holodeck.lib.backends.claude_backend import (
-            _patch_hooks_for_context_propagation,
-        )
-
-        mock_client = MagicMock()
-        mock_client.options.hooks = {}
-
-        with patch.dict(
-            sys.modules,
-            {
-                "opentelemetry.instrumentation.claude_agent_sdk._context": MagicMock(
-                    set_invocation_context=MagicMock(),
-                ),
-            },
-        ):
-            _patch_hooks_for_context_propagation(mock_client)
-
-    def test_noop_when_matchers_is_none(self) -> None:
-        """No-op when hooks value is None."""
-        from holodeck.lib.backends.claude_backend import (
-            _patch_hooks_for_context_propagation,
-        )
-
-        mock_client = MagicMock()
-        mock_client.options.hooks = {"PreToolUse": None}
-
-        with patch.dict(
-            sys.modules,
-            {
-                "opentelemetry.instrumentation.claude_agent_sdk._context": MagicMock(
-                    set_invocation_context=MagicMock(),
-                ),
-            },
-        ):
-            _patch_hooks_for_context_propagation(mock_client)
-
-
-# ---------------------------------------------------------------------------
-# T025 — ClaudeSession._ensure_client() lazy creation
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestClaudeSessionEnsureClient:
-    """Tests for ClaudeSession._ensure_client() — lazy client creation."""
-
-    @pytest.mark.asyncio
-    async def test_ensure_client_creates_and_connects(self) -> None:
-        """First call creates client and connects."""
-        mock_client_instance = AsyncMock()
-        mock_sdk_module = MagicMock()
-        mock_sdk_module.ClaudeSDKClient.return_value = mock_client_instance
-
-        session = ClaudeSession(options=MagicMock())
-
-        with (
-            patch(f"{_SDK_MODULE}.claude_agent_sdk", mock_sdk_module),
-            patch(f"{_SDK_MODULE}._patch_hooks_for_context_propagation") as mock_patch,
-        ):
-            client = await session._ensure_client()
-
-        assert client is mock_client_instance
-        mock_client_instance.connect.assert_awaited_once()
-        mock_patch.assert_called_once_with(mock_client_instance)
-
-    @pytest.mark.asyncio
-    async def test_ensure_client_reuses_existing(self) -> None:
-        """Second call reuses existing client without reconnecting."""
-        existing_client = AsyncMock()
-        session = ClaudeSession(options=MagicMock())
-        session._client = existing_client
-
-        client = await session._ensure_client()
-
-        assert client is existing_client
-        existing_client.connect.assert_not_awaited()
-
-
-# ---------------------------------------------------------------------------
-# T026 — Session send/send_streaming error handling
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestClaudeSessionErrorHandling:
-    """Tests for ClaudeSession error paths."""
-
-    @pytest.mark.asyncio
-    async def test_send_raises_on_process_error(self) -> None:
-        """send() wraps ProcessError in BackendSessionError."""
-        from claude_agent_sdk import ProcessError
-
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock(side_effect=ProcessError("boom"))
-
-        session = ClaudeSession(options=MagicMock())
-        session._client = mock_client
-
-        with pytest.raises(BackendSessionError, match="subprocess terminated"):
-            await session.send("Hi")
-
-    @pytest.mark.asyncio
-    async def test_send_streaming_raises_on_cli_connection_error(self) -> None:
-        """send_streaming() wraps CLIConnectionError in BackendSessionError."""
-        from claude_agent_sdk._errors import CLIConnectionError
-
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock(side_effect=CLIConnectionError("disconnected"))
-
-        session = ClaudeSession(options=MagicMock())
-        session._client = mock_client
-
-        with pytest.raises(BackendSessionError, match="subprocess terminated"):
-            chunks = []
-            async for chunk in session.send_streaming("Hi"):
-                chunks.append(chunk)
-
-
-# ---------------------------------------------------------------------------
 # T027 — initialize() wraps non-BackendInitError
 # ---------------------------------------------------------------------------
 
@@ -2369,7 +2101,7 @@ class TestClaudeBackendExceptionGroup:
 
     @pytest.mark.asyncio
     @patch(f"{_SDK_MODULE}.asyncio")
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_exception_group_triggers_retry(
         self, mock_query: MagicMock, mock_asyncio: MagicMock
     ) -> None:
@@ -2399,7 +2131,7 @@ class TestClaudeBackendExceptionGroup:
 
     @pytest.mark.asyncio
     @patch(f"{_SDK_MODULE}.asyncio")
-    @patch(f"{_CAS_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.query")
     async def test_exception_group_all_retries_raises(
         self, mock_query: MagicMock, mock_asyncio: MagicMock
     ) -> None:
@@ -2827,7 +2559,7 @@ class TestGracefulDegradation:
         result_msg = _make_result_message()
 
         with patch(
-            f"{_CAS_MODULE}.query",
+            f"{_SDK_MODULE}.query",
             return_value=_async_iter([assistant_msg, result_msg]),
         ):
             result = await backend.invoke_once("Hi")

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -169,14 +169,14 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         mock_opts_cls.assert_called_once()
         kwargs = mock_opts_cls.call_args[1]
         assert kwargs["model"] == "claude-sonnet-4-6"
         assert kwargs["system_prompt"] == "Be helpful."
-        assert kwargs["max_turns"] is None
+        # spec 034 P1a: max_turns defaults to 20 when unset
+        assert kwargs["max_turns"] == 20
 
     @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
     @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
@@ -187,6 +187,7 @@ class TestBuildOptions:
         claude = ClaudeConfig(
             working_directory="/var/holodeck/test",
             permission_mode=PermissionMode.acceptAll,
+            i_understand_this_is_unsafe=True,
             max_turns=5,
             extended_thinking=ExtendedThinkingConfig(
                 enabled=True, budget_tokens=20_000
@@ -202,7 +203,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="chat",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -226,7 +226,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -247,7 +246,6 @@ class TestBuildOptions:
             auth_env={"CLAUDE_CODE_USE_BEDROCK": "1", "AWS_REGION": "us-east-1"},
             otel_env={"CLAUDE_CODE_ENABLE_TELEMETRY": "1"},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -271,7 +269,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -293,7 +290,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -314,7 +310,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -334,14 +329,14 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
         assert "effort" not in kwargs
         assert "max_budget_usd" not in kwargs
         assert "fallback_model" not in kwargs
-        assert "disallowed_tools" not in kwargs
+        # spec 034 P1b: empty ClaudeConfig auto-disallows risky built-in tools
+        assert kwargs["disallowed_tools"] == ["Bash", "Edit", "WebFetch", "Write"]
 
     @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
     @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
@@ -363,21 +358,21 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
         assert kwargs["effort"] == "high"
         assert kwargs["max_budget_usd"] == 2.5
         assert kwargs["fallback_model"] == "haiku"
-        assert kwargs["disallowed_tools"] == ["Bash", "Write"]
+        # spec 034 P1b: explicit disallow merges with auto-disallow set
+        assert kwargs["disallowed_tools"] == ["Bash", "Edit", "WebFetch", "Write"]
 
     @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
     @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
-    def test_build_options_disallowed_tools_empty_list_omitted(
+    def test_build_options_disallowed_tools_empty_list_yields_auto_disallow(
         self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
     ) -> None:
-        """Spec 026: disallowed_tools=[] is equivalent to omitted (SDK default [])."""
+        """spec 034 P1b: disallowed_tools=[] still yields the auto-disallow set."""
         claude = ClaudeConfig(disallowed_tools=[])
         build_options(
             agent=_make_agent(claude=claude),
@@ -387,11 +382,10 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
-        assert "disallowed_tools" not in kwargs
+        assert kwargs["disallowed_tools"] == ["Bash", "Edit", "WebFetch", "Write"]
 
     @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
     @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
@@ -425,7 +419,6 @@ class TestBuildOptions:
             auth_env=auth_env,
             otel_env=otel_env,
             mode="chat",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -466,7 +459,6 @@ class TestBuildOptions:
             auth_env={"ANTHROPIC_AUTH_TOKEN": "ollama"},
             otel_env={},
             mode="chat",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -489,7 +481,6 @@ class TestBuildOptions:
             auth_env={"ANTHROPIC_API_KEY": "test-key"},
             otel_env={},
             mode="chat",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -519,7 +510,6 @@ class TestBuildOptions:
             auth_env={"ANTHROPIC_API_KEY": "test-key"},
             otel_env={},
             mode="chat",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -543,7 +533,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -587,7 +576,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -635,7 +623,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -670,7 +657,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -704,7 +690,6 @@ class TestBuildOptions:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -718,40 +703,160 @@ class TestBuildOptions:
 
 @pytest.mark.unit
 class TestBuildPermissionMode:
-    """Tests for _build_permission_mode() — HoloDeck enum → SDK literals."""
+    """Tests for _build_permission_mode() — spec 034 P1b decision tree.
 
-    def test_manual_maps_to_default(self) -> None:
-        """manual → 'default'."""
-        assert _build_permission_mode(PermissionMode.manual, "chat", False) == "default"
+    HoloDeck enum + mode → SDK literal:
+      manual + chat   → acceptEdits   (no operator to prompt in serve)
+      manual + test   → default       (operator at terminal can prompt)
+      acceptEdits + * → acceptEdits   (unchanged)
+      acceptAll + *   → bypassPermissions, only with i_understand_this_is_unsafe=True
+    """
 
-    def test_accept_edits_maps_to_accept_edits(self) -> None:
-        """acceptEdits → 'acceptEdits'."""
-        assert (
-            _build_permission_mode(PermissionMode.acceptEdits, "chat", False)
-            == "acceptEdits"
+    def test_manual_in_chat_maps_to_accept_edits(self) -> None:
+        """manual + chat → 'acceptEdits' (no wedge in serve)."""
+        claude = ClaudeConfig(permission_mode=PermissionMode.manual)
+        assert _build_permission_mode(claude, "chat") == "acceptEdits"
+
+    def test_manual_in_test_maps_to_default(self) -> None:
+        """manual + test → 'default' (operator at terminal answers prompts)."""
+        claude = ClaudeConfig(permission_mode=PermissionMode.manual)
+        assert _build_permission_mode(claude, "test") == "default"
+
+    def test_accept_edits_in_chat_maps_to_accept_edits(self) -> None:
+        """acceptEdits + chat → 'acceptEdits'."""
+        claude = ClaudeConfig(permission_mode=PermissionMode.acceptEdits)
+        assert _build_permission_mode(claude, "chat") == "acceptEdits"
+
+    def test_accept_edits_in_test_no_longer_escalates_to_bypass(self) -> None:
+        """acceptEdits + test → 'acceptEdits' (silent escalation removed)."""
+        claude = ClaudeConfig(permission_mode=PermissionMode.acceptEdits)
+        assert _build_permission_mode(claude, "test") == "acceptEdits"
+
+    def test_accept_all_without_unsafe_flag_raises(self) -> None:
+        """acceptAll without i_understand_this_is_unsafe → ConfigError."""
+        from holodeck.lib.errors import ConfigError
+
+        claude = ClaudeConfig(permission_mode=PermissionMode.acceptAll)
+        with pytest.raises(ConfigError, match="i_understand_this_is_unsafe"):
+            _build_permission_mode(claude, "chat")
+
+    def test_accept_all_without_unsafe_flag_raises_in_test_mode(self) -> None:
+        """acceptAll guard applies uniformly across modes."""
+        from holodeck.lib.errors import ConfigError
+
+        claude = ClaudeConfig(permission_mode=PermissionMode.acceptAll)
+        with pytest.raises(ConfigError, match="i_understand_this_is_unsafe"):
+            _build_permission_mode(claude, "test")
+
+    def test_accept_all_with_unsafe_flag_maps_to_bypass(self) -> None:
+        """acceptAll + i_understand_this_is_unsafe → 'bypassPermissions'."""
+        claude = ClaudeConfig(
+            permission_mode=PermissionMode.acceptAll,
+            i_understand_this_is_unsafe=True,
         )
+        assert _build_permission_mode(claude, "chat") == "bypassPermissions"
 
-    def test_accept_all_maps_to_bypass_permissions(self) -> None:
-        """acceptAll → 'bypassPermissions'."""
-        assert (
-            _build_permission_mode(PermissionMode.acceptAll, "chat", False)
-            == "bypassPermissions"
+    def test_none_claude_config(self) -> None:
+        """No claude config → None."""
+        assert _build_permission_mode(None, "test") is None
+
+
+# ---------------------------------------------------------------------------
+# T002b — Auto-disallow of risky built-in SDK tools (spec 034 P1b)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAutoDisallowBuiltinTools:
+    """build_options() auto-disallows {Bash, Write, Edit, WebFetch} when not declared.
+
+    A tool counts as declared when (a) the schema field opts in
+    (claude.bash.enabled, claude.file_system.write/edit, claude.web_search)
+    or (b) the tool name appears in claude.allowed_tools.
+    """
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_undeclared_builtins_are_auto_disallowed(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """No claude config → full risky set in disallowed_tools."""
+        build_options(
+            agent=_make_agent(),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
         )
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["disallowed_tools"] == ["Bash", "Edit", "WebFetch", "Write"]
 
-    def test_test_mode_overrides_to_bypass(self) -> None:
-        """In test mode, non-manual permission → 'bypassPermissions'."""
-        assert (
-            _build_permission_mode(PermissionMode.acceptEdits, "test", False)
-            == "bypassPermissions"
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_bash_declared_via_bash_config_drops_from_disallow(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """claude.bash.enabled=True → Bash not auto-disallowed."""
+        from holodeck.models.claude_config import BashConfig
+
+        claude = ClaudeConfig(bash=BashConfig(enabled=True))
+        build_options(
+            agent=_make_agent(claude=claude),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
         )
+        kwargs = mock_opts_cls.call_args[1]
+        assert "Bash" not in kwargs["disallowed_tools"]
+        assert set(kwargs["disallowed_tools"]) == {"Edit", "WebFetch", "Write"}
 
-    def test_test_mode_manual_keeps_default(self) -> None:
-        """In test mode, manual keeps 'default' (no override)."""
-        assert _build_permission_mode(PermissionMode.manual, "test", False) == "default"
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_write_and_edit_declared_via_file_system_drop_from_disallow(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """claude.file_system.write/edit → Write/Edit not auto-disallowed."""
+        from holodeck.models.claude_config import FileSystemConfig
 
-    def test_none_permission_mode(self) -> None:
-        """No permission mode configured → None."""
-        assert _build_permission_mode(None, "test", False) is None
+        claude = ClaudeConfig(
+            file_system=FileSystemConfig(read=True, write=True, edit=True)
+        )
+        build_options(
+            agent=_make_agent(claude=claude),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+        )
+        kwargs = mock_opts_cls.call_args[1]
+        assert set(kwargs["disallowed_tools"]) == {"Bash", "WebFetch"}
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_webfetch_declared_via_allowed_tools_drops_from_disallow(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """claude.allowed_tools includes 'WebFetch' → not auto-disallowed."""
+        claude = ClaudeConfig(allowed_tools=["WebFetch"])
+        build_options(
+            agent=_make_agent(claude=claude),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+        )
+        kwargs = mock_opts_cls.call_args[1]
+        assert "WebFetch" not in kwargs["disallowed_tools"]
+        assert set(kwargs["disallowed_tools"]) == {"Bash", "Edit", "Write"}
 
 
 # ---------------------------------------------------------------------------
@@ -776,13 +881,10 @@ class TestClaudeBackendInit:
         """Constructor stores tool_instances."""
         agent = _make_agent()
         tools = {"kb": MagicMock()}
-        backend = ClaudeBackend(
-            agent=agent, tool_instances=tools, mode="chat", allow_side_effects=True
-        )
+        backend = ClaudeBackend(agent=agent, tool_instances=tools, mode="chat")
 
         assert backend._tool_instances is tools
         assert backend._mode == "chat"
-        assert backend._allow_side_effects is True
 
     def test_implements_backend_protocol(self) -> None:
         """ClaudeBackend satisfies the AgentBackend protocol."""
@@ -1914,7 +2016,6 @@ class TestBuildOptionsAllowedTools:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -2845,7 +2946,6 @@ class TestBuildOptionsSubagentTools:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -2883,7 +2983,6 @@ class TestBuildOptionsSubagentTools:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -2916,7 +3015,6 @@ class TestBuildOptionsSubagentTools:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]
@@ -2946,7 +3044,6 @@ class TestBuildOptionsSubagentTools:
             auth_env={},
             otel_env={},
             mode="test",
-            allow_side_effects=False,
         )
 
         kwargs = mock_opts_cls.call_args[1]

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -1181,30 +1181,65 @@ class TestClaudeBackendRetry:
 
 @pytest.mark.unit
 class TestClaudeSessionStreaming:
-    """Tests for ClaudeSession.send_streaming() — progressive text chunks."""
+    """ClaudeSession.send_streaming() under spec 034 P4."""
 
     @pytest.mark.asyncio
     async def test_send_streaming_yields_chunks(self) -> None:
-        """T011: Chunks arrive progressively, not all at once."""
-        mock_client = MagicMock()
-        mock_client.query = AsyncMock()
         chunk1 = _make_assistant_message([_make_text_block("Hello ")])
         chunk2 = _make_assistant_message([_make_text_block("world!")])
-        result_msg = _make_result_message()
+        result_msg = _make_result_message(session_id="sdk-stream-001")
 
-        def mock_receive():
-            return _async_iter([chunk1, chunk2, result_msg])
+        async def fake_query(prompt, options):
+            for m in (chunk1, chunk2, result_msg):
+                yield m
 
-        mock_client.receive_response = mock_receive
-
-        session = ClaudeSession(options=MagicMock())
-        session._client = mock_client
-
-        chunks: list[str] = []
-        async for chunk in session.send_streaming("Hi"):
-            chunks.append(chunk)
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            chunks: list[str] = []
+            async for chunk in session.send_streaming("Hi"):
+                chunks.append(chunk)
 
         assert chunks == ["Hello ", "world!"]
+        assert session._sdk_session_id == "sdk-stream-001"
+
+    @pytest.mark.asyncio
+    async def test_send_streaming_propagates_session_id_on_turn_2(self) -> None:
+        captured_options: list[Any] = []
+
+        async def fake_query(prompt, options):
+            captured_options.append(options)
+            yield _make_assistant_message([_make_text_block("ok")])
+            yield _make_result_message(session_id="sdk-stream-XYZ")
+
+        # Use a real ClaudeAgentOptions for the resume-propagation assertion
+        # (MagicMock(spec=ClaudeAgentOptions) auto-creates the resume attribute,
+        # masking the turn-1 ``is None`` check — same nuance as Task 3 test 3).
+        from claude_agent_sdk import ClaudeAgentOptions as RealOptions
+
+        session = ClaudeSession(options=RealOptions())
+        captured_resume: list[Any] = []
+
+        async def fake_query_capture(prompt, options):
+            captured_resume.append(getattr(options, "resume", None))
+            async for _ in prompt:
+                pass
+            yield _make_assistant_message([_make_text_block("ok")])
+            yield _make_result_message(session_id="sdk-stream-XYZ")
+
+        with patch(
+            "holodeck.lib.backends.claude_backend.query",
+            side_effect=fake_query_capture,
+        ):
+            async for _ in session.send_streaming("Turn 1"):
+                pass
+            async for _ in session.send_streaming("Turn 2"):
+                pass
+
+        assert captured_resume[0] is None
+        assert captured_resume[1] == "sdk-stream-XYZ"
+        assert session._sdk_session_id == "sdk-stream-XYZ"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -19,7 +19,8 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from claude_agent_sdk import ClaudeAgentOptions
+from claude_agent_sdk import ClaudeAgentOptions, ProcessError
+from claude_agent_sdk._errors import CLIConnectionError
 from exceptiongroup import BaseExceptionGroup
 
 from holodeck.lib.backends.base import (
@@ -1232,6 +1233,73 @@ class TestClaudeSessionStreaming:
         assert captured_resume[0] is None
         assert captured_resume[1] == "sdk-stream-XYZ"
         assert session._sdk_session_id == "sdk-stream-XYZ"
+
+
+@pytest.mark.unit
+class TestClaudeSessionErrorTranslation:
+    """spec 034 P4: send() / send_streaming() translate SDK transport
+    errors (``ProcessError`` / ``CLIConnectionError``) into the public
+    ``BackendSessionError`` so callers don't have to depend on
+    claude_agent_sdk internals.
+
+    The old TestClaudeSessionErrorHandling exercised this via the
+    deleted persistent-client mock; the P4 injection point is the
+    top-level ``query`` symbol.
+    """
+
+    @pytest.mark.asyncio
+    async def test_send_translates_process_error(self) -> None:
+        async def fake_query(prompt, options):
+            raise ProcessError("boom")
+            yield  # pragma: no cover  (make this an async generator)
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with (
+            patch("holodeck.lib.backends.claude_backend.query", side_effect=fake_query),
+            pytest.raises(BackendSessionError, match="subprocess terminated"),
+        ):
+            await session.send("hi")
+
+    @pytest.mark.asyncio
+    async def test_send_translates_cli_connection_error(self) -> None:
+        async def fake_query(prompt, options):
+            raise CLIConnectionError("disconnected")
+            yield  # pragma: no cover
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with (
+            patch("holodeck.lib.backends.claude_backend.query", side_effect=fake_query),
+            pytest.raises(BackendSessionError, match="subprocess terminated"),
+        ):
+            await session.send("hi")
+
+    @pytest.mark.asyncio
+    async def test_send_streaming_translates_process_error(self) -> None:
+        async def fake_query(prompt, options):
+            raise ProcessError("boom")
+            yield  # pragma: no cover
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with (
+            patch("holodeck.lib.backends.claude_backend.query", side_effect=fake_query),
+            pytest.raises(BackendSessionError, match="subprocess terminated"),
+        ):
+            async for _ in session.send_streaming("hi"):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_send_streaming_translates_cli_connection_error(self) -> None:
+        async def fake_query(prompt, options):
+            raise CLIConnectionError("disconnected")
+            yield  # pragma: no cover
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with (
+            patch("holodeck.lib.backends.claude_backend.query", side_effect=fake_query),
+            pytest.raises(BackendSessionError, match="subprocess terminated"),
+        ):
+            async for _ in session.send_streaming("hi"):
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -2969,3 +3037,32 @@ class TestClaudeSessionP4Fields:
         session = ClaudeSession(options=MagicMock())
         assert session._sdk_session_id is None
         assert isinstance(session._send_lock, asyncio.Lock)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_sends_serialise(self) -> None:
+        """Two concurrent send() calls must not invoke query() in parallel.
+        The lock prevents transcript-write races under the resume= model.
+        """
+        in_flight = 0
+        max_concurrent = 0
+
+        async def fake_query(prompt, options):
+            nonlocal in_flight, max_concurrent
+            in_flight += 1
+            max_concurrent = max(max_concurrent, in_flight)
+            # Yield control so the second send() has a chance to enter.
+            await asyncio.sleep(0)
+            yield _make_assistant_message()
+            yield _make_result_message(session_id="sess-conc")
+            in_flight -= 1
+
+        session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
+        with patch(
+            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+        ):
+            await asyncio.gather(session.send("a"), session.send("b"))
+
+        assert max_concurrent == 1, (
+            "expected lock to serialise concurrent sends, "
+            f"got max_concurrent={max_concurrent}"
+        )

--- a/tests/unit/lib/backends/test_selector.py
+++ b/tests/unit/lib/backends/test_selector.py
@@ -110,14 +110,12 @@ class TestBackendSelector:
             agent,
             tool_instances={"kb": mock_tool},
             mode="chat",
-            allow_side_effects=True,
         )
 
         mock_claude_cls.assert_called_once_with(
             agent=agent,
             tool_instances={"kb": mock_tool},
             mode="chat",
-            allow_side_effects=True,
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/lib/test_runtime.py
+++ b/tests/unit/lib/test_runtime.py
@@ -1,0 +1,100 @@
+"""Unit tests for holodeck.lib.runtime (spec 034 P1a)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from holodeck.lib import runtime
+
+
+@pytest.mark.unit
+class TestCpuQuota:
+    """cgroup-aware CPU quota detection."""
+
+    def test_cgroups_v2_quota_returns_fractional_cores(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cgroups v2 cpu.max with quota and period yields quota/period."""
+        v2 = tmp_path / "cpu.max"
+        v2.write_text("50000 100000\n")  # 0.5 CPU
+        monkeypatch.setattr(runtime, "_CGROUP_V2_CPU_MAX", v2)
+
+        assert runtime.cpu_quota() == 0.5
+
+    def test_cgroups_v2_quota_max_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cgroups v2 cpu.max == "max <period>" means unconstrained → fallback."""
+        v2 = tmp_path / "cpu.max"
+        v2.write_text("max 100000\n")
+        monkeypatch.setattr(runtime, "_CGROUP_V2_CPU_MAX", v2)
+        # Block v1 fallback too
+        monkeypatch.setattr(runtime, "_CGROUP_V1_QUOTA", tmp_path / "missing-quota")
+        monkeypatch.setattr(runtime, "_CGROUP_V1_PERIOD", tmp_path / "missing-period")
+
+        # Falls back to os.cpu_count() (or 1), which is always ≥ 1
+        assert runtime.cpu_quota() >= 1.0
+
+    def test_cgroups_v1_quota_used_when_v2_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cgroups v1 quota/period read when v2 file is missing."""
+        monkeypatch.setattr(runtime, "_CGROUP_V2_CPU_MAX", tmp_path / "missing-v2")
+        v1_quota = tmp_path / "cpu.cfs_quota_us"
+        v1_period = tmp_path / "cpu.cfs_period_us"
+        v1_quota.write_text("200000\n")  # 2.0 CPU
+        v1_period.write_text("100000\n")
+        monkeypatch.setattr(runtime, "_CGROUP_V1_QUOTA", v1_quota)
+        monkeypatch.setattr(runtime, "_CGROUP_V1_PERIOD", v1_period)
+
+        assert runtime.cpu_quota() == 2.0
+
+    def test_cgroups_v1_negative_quota_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cgroups v1 quota=-1 means unconstrained → fallback."""
+        monkeypatch.setattr(runtime, "_CGROUP_V2_CPU_MAX", tmp_path / "missing-v2")
+        v1_quota = tmp_path / "cpu.cfs_quota_us"
+        v1_period = tmp_path / "cpu.cfs_period_us"
+        v1_quota.write_text("-1\n")
+        v1_period.write_text("100000\n")
+        monkeypatch.setattr(runtime, "_CGROUP_V1_QUOTA", v1_quota)
+        monkeypatch.setattr(runtime, "_CGROUP_V1_PERIOD", v1_period)
+
+        assert runtime.cpu_quota() >= 1.0
+
+    def test_no_cgroup_files_falls_back_to_os_cpu_count(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Missing cgroup files → os.cpu_count() (covers macOS/Windows dev)."""
+        monkeypatch.setattr(runtime, "_CGROUP_V2_CPU_MAX", tmp_path / "nope-v2")
+        monkeypatch.setattr(runtime, "_CGROUP_V1_QUOTA", tmp_path / "nope-v1q")
+        monkeypatch.setattr(runtime, "_CGROUP_V1_PERIOD", tmp_path / "nope-v1p")
+
+        result = runtime.cpu_quota()
+        assert result >= 1.0
+
+
+@pytest.mark.unit
+class TestDerivedSessionCap:
+    """Session cap derivation from CPU quota."""
+
+    @pytest.mark.parametrize(
+        ("cores", "expected"),
+        [
+            (0.25, 1),  # floors to 1 even on tiny replicas
+            (0.5, 1),
+            (1.0, 2),
+            (1.5, 3),
+            (2.0, 4),
+            (4.0, 8),
+        ],
+    )
+    def test_derivation_floors_at_one(self, cores: float, expected: int) -> None:
+        assert runtime.derived_session_cap(cores) == expected
+
+    def test_custom_multiplier(self) -> None:
+        """Multiplier is overridable for future tuning."""
+        assert runtime.derived_session_cap(1.0, multiplier=4) == 4

--- a/tests/unit/lib/test_runtime.py
+++ b/tests/unit/lib/test_runtime.py
@@ -79,7 +79,7 @@ class TestCpuQuota:
 
 @pytest.mark.unit
 class TestDerivedSessionCap:
-    """Session cap derivation from CPU quota."""
+    """Legacy CPU-based derivation, kept for compatibility."""
 
     @pytest.mark.parametrize(
         ("cores", "expected"),
@@ -98,3 +98,104 @@ class TestDerivedSessionCap:
     def test_custom_multiplier(self) -> None:
         """Multiplier is overridable for future tuning."""
         assert runtime.derived_session_cap(1.0, multiplier=4) == 4
+
+
+_MIB = 1024 * 1024
+
+
+@pytest.mark.unit
+class TestMemoryLimitBytes:
+    """cgroup-aware memory limit detection."""
+
+    def test_cgroups_v2_memory_max_returns_bytes(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        v2 = tmp_path / "memory.max"
+        v2.write_text(f"{2 * 1024 * _MIB}\n")  # 2 GiB
+        monkeypatch.setattr(runtime, "_CGROUP_V2_MEMORY_MAX", v2)
+
+        assert runtime.memory_limit_bytes() == 2 * 1024 * _MIB
+
+    def test_cgroups_v2_memory_max_literal_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        v2 = tmp_path / "memory.max"
+        v2.write_text("max\n")
+        monkeypatch.setattr(runtime, "_CGROUP_V2_MEMORY_MAX", v2)
+        monkeypatch.setattr(runtime, "_CGROUP_V1_MEMORY_LIMIT", tmp_path / "missing-v1")
+
+        assert runtime.memory_limit_bytes() is None
+
+    def test_cgroups_v1_memory_used_when_v2_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(runtime, "_CGROUP_V2_MEMORY_MAX", tmp_path / "missing-v2")
+        v1 = tmp_path / "memory.limit_in_bytes"
+        v1.write_text(f"{512 * _MIB}\n")
+        monkeypatch.setattr(runtime, "_CGROUP_V1_MEMORY_LIMIT", v1)
+
+        assert runtime.memory_limit_bytes() == 512 * _MIB
+
+    def test_cgroups_v1_unbounded_sentinel_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """v1 reports a near-INT64-max sentinel when unlimited; treat as None."""
+        monkeypatch.setattr(runtime, "_CGROUP_V2_MEMORY_MAX", tmp_path / "missing-v2")
+        v1 = tmp_path / "memory.limit_in_bytes"
+        v1.write_text("9223372036854771712\n")  # kernel's "unlimited" sentinel
+        monkeypatch.setattr(runtime, "_CGROUP_V1_MEMORY_LIMIT", v1)
+
+        assert runtime.memory_limit_bytes() is None
+
+    def test_no_cgroup_files_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(runtime, "_CGROUP_V2_MEMORY_MAX", tmp_path / "nope-v2")
+        monkeypatch.setattr(runtime, "_CGROUP_V1_MEMORY_LIMIT", tmp_path / "nope-v1")
+
+        assert runtime.memory_limit_bytes() is None
+
+
+@pytest.mark.unit
+class TestDerivedSessionCapFromMemory:
+    """Session cap derivation from memory budget."""
+
+    @pytest.mark.parametrize(
+        ("mem_mib", "per_session_mib", "expected"),
+        [
+            # Default 400 MiB baseline + 200 MiB/session
+            (1024, 200, 3),  # (1024-400)/200 = 3
+            (2048, 200, 8),  # (2048-400)/200 = 8
+            (4096, 200, 18),  # (4096-400)/200 = 18
+            (512, 200, 1),  # tiny replica — floors to 1
+            (200, 200, 1),  # below baseline — floors to 1
+        ],
+    )
+    def test_derivation_uses_baseline_and_per_session(
+        self, mem_mib: int, per_session_mib: int, expected: int
+    ) -> None:
+        assert (
+            runtime.derived_session_cap_from_memory(
+                mem_mib * _MIB, per_session_bytes=per_session_mib * _MIB
+            )
+            == expected
+        )
+
+    def test_custom_baseline(self) -> None:
+        """Baseline reservation is overridable."""
+        # 2 GiB - 1 GiB baseline = 1 GiB / 200 MiB = 5
+        cap = runtime.derived_session_cap_from_memory(
+            2048 * _MIB,
+            baseline_bytes=1024 * _MIB,
+            per_session_bytes=200 * _MIB,
+        )
+        assert cap == 5
+
+    def test_floors_at_one_even_with_zero_headroom(self) -> None:
+        """Below-baseline memory still yields a cap of 1, not 0."""
+        cap = runtime.derived_session_cap_from_memory(
+            100 * _MIB,
+            baseline_bytes=400 * _MIB,
+            per_session_bytes=200 * _MIB,
+        )
+        assert cap == 1

--- a/tests/unit/models/test_claude_config.py
+++ b/tests/unit/models/test_claude_config.py
@@ -216,6 +216,15 @@ class TestClaudeConfig:
         assert config.max_budget_usd is None
         assert config.fallback_model is None
         assert config.disallowed_tools is None
+        assert config.i_understand_this_is_unsafe is False
+
+    def test_i_understand_this_is_unsafe_accepts_true(self) -> None:
+        """spec 034 P1b: opt-in flag for permission_mode=acceptAll."""
+        config = ClaudeConfig(
+            permission_mode=PermissionMode.acceptAll,
+            i_understand_this_is_unsafe=True,
+        )
+        assert config.i_understand_this_is_unsafe is True
 
     def test_with_extended_thinking(self) -> None:
         """Test ClaudeConfig with extended thinking configured."""
@@ -286,10 +295,12 @@ class TestClaudeConfig:
         assert config.permission_mode == PermissionMode.manual
 
     @pytest.mark.unit
-    def test_max_concurrent_sessions_default_is_10(self) -> None:
-        """T012: Test that max_concurrent_sessions defaults to 10."""
+    def test_max_concurrent_sessions_default_is_none_for_cpu_derivation(
+        self,
+    ) -> None:
+        """spec 034 P1a: default is None so the serve layer derives from CPU."""
         config = ClaudeConfig()
-        assert config.max_concurrent_sessions == 10
+        assert config.max_concurrent_sessions is None
 
     @pytest.mark.unit
     def test_max_concurrent_sessions_valid_value(self) -> None:

--- a/tests/unit/models/test_claude_config.py
+++ b/tests/unit/models/test_claude_config.py
@@ -313,14 +313,14 @@ class TestClaudeConfig:
         ("value", "reason"),
         [
             (0, "below_min"),
-            (101, "above_max"),
+            (501, "above_max"),
         ],
-        ids=["below_min_ge1", "above_max_le100"],
+        ids=["below_min_ge1", "above_max_le500"],
     )
     def test_max_concurrent_sessions_out_of_range(
         self, value: int, reason: str
     ) -> None:
-        """T012: Test that max_concurrent_sessions outside 1-100 is rejected."""
+        """T012: Test that max_concurrent_sessions outside 1-500 is rejected."""
         with pytest.raises(ValidationError):
             ClaudeConfig(max_concurrent_sessions=value)
 

--- a/tests/unit/models/test_claude_config.py
+++ b/tests/unit/models/test_claude_config.py
@@ -331,10 +331,10 @@ class TestClaudeConfig:
         assert config.max_concurrent_sessions is None
 
     @pytest.mark.unit
-    def test_session_memory_estimate_mib_defaults_to_200(self) -> None:
-        """spec 034 P1a: per-session memory estimate defaults to 200 MiB."""
+    def test_session_memory_estimate_mib_defaults_to_500(self) -> None:
+        """spec 034 P4: per-active-turn memory estimate defaults to 500 MiB."""
         config = ClaudeConfig()
-        assert config.session_memory_estimate_mib == 200
+        assert config.session_memory_estimate_mib == 500
 
     @pytest.mark.unit
     def test_session_memory_estimate_mib_accepts_valid_value(self) -> None:

--- a/tests/unit/models/test_claude_config.py
+++ b/tests/unit/models/test_claude_config.py
@@ -295,10 +295,10 @@ class TestClaudeConfig:
         assert config.permission_mode == PermissionMode.manual
 
     @pytest.mark.unit
-    def test_max_concurrent_sessions_default_is_none_for_cpu_derivation(
+    def test_max_concurrent_sessions_default_is_none_for_memory_derivation(
         self,
     ) -> None:
-        """spec 034 P1a: default is None so the serve layer derives from CPU."""
+        """spec 034 P1a: default is None so the serve layer derives from memory."""
         config = ClaudeConfig()
         assert config.max_concurrent_sessions is None
 
@@ -329,6 +329,23 @@ class TestClaudeConfig:
         """T012: Test that max_concurrent_sessions accepts None."""
         config = ClaudeConfig(max_concurrent_sessions=None)
         assert config.max_concurrent_sessions is None
+
+    @pytest.mark.unit
+    def test_session_memory_estimate_mib_defaults_to_200(self) -> None:
+        """spec 034 P1a: per-session memory estimate defaults to 200 MiB."""
+        config = ClaudeConfig()
+        assert config.session_memory_estimate_mib == 200
+
+    @pytest.mark.unit
+    def test_session_memory_estimate_mib_accepts_valid_value(self) -> None:
+        config = ClaudeConfig(session_memory_estimate_mib=400)
+        assert config.session_memory_estimate_mib == 400
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("value", [49, 2001])
+    def test_session_memory_estimate_mib_out_of_range(self, value: int) -> None:
+        with pytest.raises(ValidationError):
+            ClaudeConfig(session_memory_estimate_mib=value)
 
     def test_extra_fields_rejected(self) -> None:
         """Test that extra fields are rejected."""

--- a/tests/unit/serve/test_protocols_agui.py
+++ b/tests/unit/serve/test_protocols_agui.py
@@ -1342,12 +1342,14 @@ class TestAGUIProtocolErrorMapping:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_capacity_exceeded_yields_sse_capacity_error(self) -> None:
-        """T017: Capacity exceeded at server level yields SSE capacity_exceeded event.
+    async def test_capacity_exceeded_returns_429(self) -> None:
+        """spec 034 P1a: capacity exceeded surfaces as HTTP 429, not an SSE frame.
 
-        When SessionStore.create raises RuntimeError (capacity full), the
-        AG-UI /awp endpoint should return a StreamingResponse containing
-        an SSE error event with type "capacity_exceeded".
+        Previously the AG-UI path converted capacity errors into an
+        ``event: error`` SSE frame returned with HTTP 200, which hid the
+        backpressure from fronting load balancers and client retry
+        logic. P1a returns the 429 directly so the wire-level signal
+        matches the REST path.
         """
         from unittest.mock import MagicMock, patch
 
@@ -1402,10 +1404,12 @@ class TestAGUIProtocolErrorMapping:
                     },
                 )
 
-        # Assert — response should be SSE with capacity_exceeded
-        assert response.status_code == 200
-        body = response.text
-        assert "capacity_exceeded" in body
+        # Assert — response should be HTTP 429 with Retry-After
+        assert response.status_code == 429
+        assert response.headers.get("retry-after") == "5"
+        body = response.json()
+        assert body["error"] == "capacity_exceeded"
+        assert "max_sessions" in body
 
     @pytest.mark.asyncio
     @pytest.mark.unit

--- a/tests/unit/serve/test_protocols_rest.py
+++ b/tests/unit/serve/test_protocols_rest.py
@@ -705,17 +705,18 @@ class TestBackendSessionErrorStreaming:
         assert "detail" in data
 
 
-class TestCapacityExceeded503:
-    """T016: Capacity exceeded returns 503 with Retry-After header."""
+class TestCapacityExceeded429:
+    """spec 034 P1a: Capacity exceeded returns 429 with Retry-After header."""
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_capacity_exceeded_returns_503_with_retry_after(self) -> None:
-        """T016: When SessionStore.create raises RuntimeError, server returns 503.
+    async def test_capacity_exceeded_returns_429_with_retry_after(self) -> None:
+        """When SessionStore.create raises RuntimeError, server returns 429.
 
-        The REST chat endpoint should return a 503 response with a
-        Retry-After header and the capacity_exceeded error body when
-        the session store is at capacity.
+        spec 034 P1a switched this from 503 to 429 so fronting load
+        balancers and HTTP client retry logic recognise the backpressure
+        as a transient retryable signal (most clients treat 503 as a
+        hard error).
         """
         from unittest.mock import patch
 
@@ -753,7 +754,7 @@ class TestCapacityExceeded503:
                 )
 
         # Assert
-        assert response.status_code == 503
+        assert response.status_code == 429
         assert response.headers.get("retry-after") == "5"
 
         body = response.json()

--- a/tests/unit/serve/test_server.py
+++ b/tests/unit/serve/test_server.py
@@ -117,7 +117,7 @@ class TestAgentServerInit:
     def test_session_cap_anthropic_with_max_concurrent_sessions(
         self, mock_agent_config: MagicMock
     ) -> None:
-        """T015: Anthropic provider uses claude.max_concurrent_sessions."""
+        """Explicit claude.max_concurrent_sessions overrides CPU derivation."""
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
         mock_agent_config.claude = MagicMock()
         mock_agent_config.claude.max_concurrent_sessions = 5
@@ -138,16 +138,60 @@ class TestAgentServerInit:
         assert server.sessions.max_sessions == 1000
 
     @pytest.mark.unit
-    def test_session_cap_anthropic_without_claude_config_defaults_to_10(
-        self, mock_agent_config: MagicMock
+    def test_session_cap_anthropic_default_derives_from_cpu_quota(
+        self,
+        mock_agent_config: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """T015: Anthropic provider without claude config defaults to 10."""
+        """spec 034 P1a: default cap is max(1, floor(cpu_quota * 2))."""
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
-        mock_agent_config.claude = None
+        mock_agent_config.claude = MagicMock()
+        mock_agent_config.claude.max_concurrent_sessions = None
+        # Pin the CPU quota so the test isn't sensitive to host hardware.
+        monkeypatch.setattr(
+            "holodeck.serve.server.cpu_quota",
+            lambda: 1.0,
+        )
 
         server = AgentServer(agent_config=mock_agent_config)
 
-        assert server.sessions.max_sessions == 10
+        assert server.sessions.max_sessions == 2
+
+    @pytest.mark.unit
+    def test_session_cap_anthropic_without_claude_config_derives_from_cpu(
+        self,
+        mock_agent_config: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """spec 034 P1a: missing claude block falls through to CPU derivation."""
+        mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
+        mock_agent_config.claude = None
+        monkeypatch.setattr(
+            "holodeck.serve.server.cpu_quota",
+            lambda: 2.0,
+        )
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        assert server.sessions.max_sessions == 4
+
+    @pytest.mark.unit
+    def test_session_cap_tiny_cpu_quota_floors_at_one(
+        self,
+        mock_agent_config: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sub-CPU replicas still get a cap of 1 (never zero)."""
+        mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
+        mock_agent_config.claude = None
+        monkeypatch.setattr(
+            "holodeck.serve.server.cpu_quota",
+            lambda: 0.25,
+        )
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        assert server.sessions.max_sessions == 1
 
 
 class TestAgentServerExecutorTimeoutWiring:

--- a/tests/unit/serve/test_server.py
+++ b/tests/unit/serve/test_server.py
@@ -803,55 +803,81 @@ class TestActiveTurnSemaphore:
     """
 
     @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_acquire_turn_slot_noop_for_non_anthropic(
+    def test_try_acquire_turn_slot_noop_for_non_anthropic(
         self, mock_agent_config: MagicMock
     ) -> None:
-        """No semaphore configured → context manager is a no-op."""
+        """No semaphore configured → try-acquire always succeeds."""
         mock_agent_config.model.provider = ProviderEnum.OPENAI
 
         server = AgentServer(agent_config=mock_agent_config)
 
         assert server._active_turn_semaphore is None
-        async with server._acquire_turn_slot():
-            assert server._turn_capacity_exceeded() is False
+        assert server._try_acquire_turn_slot() is True
+        # Release is a no-op; calling many times must not raise.
+        server._release_turn_slot()
+        server._release_turn_slot()
 
     @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_acquire_turn_slot_tracks_in_flight(
+    def test_try_acquire_turn_slot_tracks_in_flight(
         self, mock_agent_config: MagicMock
     ) -> None:
-        """Acquiring slot increments in-flight, releasing decrements."""
+        """Each try-acquire increments in-flight, each release decrements."""
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
         mock_agent_config.claude.max_concurrent_sessions = 3
 
         server = AgentServer(agent_config=mock_agent_config)
 
         assert server._active_turn_in_flight() == 0
-        async with server._acquire_turn_slot():
-            assert server._active_turn_in_flight() == 1
-            async with server._acquire_turn_slot():
-                assert server._active_turn_in_flight() == 2
-            assert server._active_turn_in_flight() == 1
+        assert server._try_acquire_turn_slot() is True
+        assert server._active_turn_in_flight() == 1
+        assert server._try_acquire_turn_slot() is True
+        assert server._active_turn_in_flight() == 2
+        server._release_turn_slot()
+        assert server._active_turn_in_flight() == 1
+        server._release_turn_slot()
         assert server._active_turn_in_flight() == 0
 
     @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_turn_capacity_exceeded_at_cap(
+    def test_try_acquire_returns_false_at_capacity(
         self, mock_agent_config: MagicMock
     ) -> None:
-        """When all slots are held, _turn_capacity_exceeded() is True."""
+        """spec 034 P4: 5 try-acquires against cap=2 → 2 succeed, 3 fail.
+
+        This is the regression that the original ``async with sem.acquire()``
+        pattern violated — under concurrent load it would QUEUE the
+        overflow requests instead of failing fast with 429.
+        """
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
         mock_agent_config.claude.max_concurrent_sessions = 2
 
         server = AgentServer(agent_config=mock_agent_config)
 
-        assert server._turn_capacity_exceeded() is False
-        async with server._acquire_turn_slot():
-            assert server._turn_capacity_exceeded() is False
-            async with server._acquire_turn_slot():
-                assert server._turn_capacity_exceeded() is True
-            assert server._turn_capacity_exceeded() is False
+        results = [server._try_acquire_turn_slot() for _ in range(5)]
+        assert results == [True, True, False, False, False]
+        assert server._turn_capacity_exceeded() is True
+        # Releasing one frees exactly one slot.
+        server._release_turn_slot()
+        assert server._try_acquire_turn_slot() is True
+        assert server._try_acquire_turn_slot() is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_acquire_turn_slot_context_manager_yields_bool(
+        self, mock_agent_config: MagicMock
+    ) -> None:
+        """``async with _acquire_turn_slot() as acquired`` yields the result."""
+        mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
+        mock_agent_config.claude.max_concurrent_sessions = 1
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        async with server._acquire_turn_slot() as acquired:
+            assert acquired is True
+            async with server._acquire_turn_slot() as second:
+                assert second is False
+            # Failed acquire must NOT release on context exit.
+            assert server._active_turn_in_flight() == 1
+        assert server._active_turn_in_flight() == 0
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -866,7 +892,9 @@ class TestActiveTurnSemaphore:
 
         server = AgentServer(agent_config=mock_agent_config)
 
-        async with server._acquire_turn_slot(), server._acquire_turn_slot():
+        assert server._try_acquire_turn_slot() is True
+        assert server._try_acquire_turn_slot() is True
+        try:
             response = server._capacity_exceeded_response()
             body = json.loads(response.body)
             assert response.status_code == 429
@@ -874,13 +902,20 @@ class TestActiveTurnSemaphore:
             assert body["active_sessions"] == 2
             assert "active turns" in body["message"]
             assert response.headers["Retry-After"] == "5"
+        finally:
+            server._release_turn_slot()
+            server._release_turn_slot()
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_turn_gated_stream_holds_slot_for_generator_lifetime(
+    async def test_turn_gated_stream_releases_after_exhaustion(
         self, mock_agent_config: MagicMock
     ) -> None:
-        """Streaming generator wrapper keeps slot acquired across yields."""
+        """Streaming wrapper releases the pre-acquired slot when done.
+
+        Caller (the endpoint) acquires synchronously before constructing
+        the response; the wrapper owns the matching release.
+        """
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
         mock_agent_config.claude.max_concurrent_sessions = 1
 
@@ -892,6 +927,7 @@ class TestActiveTurnSemaphore:
             yield b"b"
             assert server._turn_capacity_exceeded() is True
 
+        assert server._try_acquire_turn_slot() is True
         chunks: list[bytes] = []
         async for chunk in server._turn_gated_stream(inner()):
             chunks.append(chunk)
@@ -901,8 +937,7 @@ class TestActiveTurnSemaphore:
         assert server._turn_capacity_exceeded() is False
 
     @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_open_session_count_does_not_trigger_429(
+    def test_open_session_count_does_not_trigger_429(
         self, mock_agent_config: MagicMock
     ) -> None:
         """spec 034 P4: opening many sessions while no turns are active

--- a/tests/unit/serve/test_server.py
+++ b/tests/unit/serve/test_server.py
@@ -5,6 +5,7 @@ lifecycle management, and state transitions.
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,9 +21,18 @@ from holodeck.serve.server import AgentServer
 
 @pytest.fixture
 def mock_agent_config() -> MagicMock:
-    """Create a mock agent configuration."""
+    """Create a mock agent configuration.
+
+    Defaults ``claude.max_concurrent_sessions=None`` and
+    ``session_memory_estimate_mib=200`` so tests that switch provider to
+    ANTHROPIC without overriding the claude submock get a valid
+    BoundedSemaphore from AgentServer.__init__.
+    """
     agent = MagicMock()
     agent.name = "test-agent"
+    agent.claude = MagicMock()
+    agent.claude.max_concurrent_sessions = None
+    agent.claude.session_memory_estimate_mib = 200
     return agent
 
 
@@ -114,10 +124,13 @@ class TestAgentServerInit:
         assert server.sessions.active_count == 0
 
     @pytest.mark.unit
-    def test_session_cap_anthropic_with_max_concurrent_sessions(
+    def test_active_turn_cap_anthropic_with_max_concurrent_sessions(
         self, mock_agent_config: MagicMock
     ) -> None:
-        """Explicit claude.max_concurrent_sessions overrides memory derivation."""
+        """Explicit claude.max_concurrent_sessions overrides memory derivation.
+
+        Spec 034 P4: the field gates active-turn slots, not open sessions.
+        """
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
         mock_agent_config.claude = MagicMock()
         mock_agent_config.claude.max_concurrent_sessions = 5
@@ -125,26 +138,31 @@ class TestAgentServerInit:
 
         server = AgentServer(agent_config=mock_agent_config)
 
-        assert server.sessions.max_sessions == 5
+        assert server._active_turn_cap == 5
+        assert server._active_turn_semaphore is not None
+        # Open-session ceiling is now uniform and unrelated to memory.
+        assert server.sessions.max_sessions == 1000
 
     @pytest.mark.unit
-    def test_session_cap_non_anthropic_defaults_to_1000(
+    def test_active_turn_semaphore_absent_for_non_anthropic(
         self, mock_agent_config: MagicMock
     ) -> None:
-        """T015: Non-Anthropic provider defaults to 1000 max sessions."""
+        """Non-Anthropic providers don't spawn subprocesses → no turn gate."""
         mock_agent_config.model.provider = ProviderEnum.OPENAI
 
         server = AgentServer(agent_config=mock_agent_config)
 
+        assert server._active_turn_cap is None
+        assert server._active_turn_semaphore is None
         assert server.sessions.max_sessions == 1000
 
     @pytest.mark.unit
-    def test_session_cap_anthropic_default_derives_from_memory(
+    def test_active_turn_cap_anthropic_default_derives_from_memory(
         self,
         mock_agent_config: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """spec 034 P1a: default cap = (mem - baseline) / per_session_bytes."""
+        """spec 034 P4: default cap = (mem - baseline) / per_turn_bytes."""
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
         mock_agent_config.claude = MagicMock()
         mock_agent_config.claude.max_concurrent_sessions = None
@@ -157,15 +175,15 @@ class TestAgentServerInit:
 
         server = AgentServer(agent_config=mock_agent_config)
 
-        assert server.sessions.max_sessions == 8
+        assert server._active_turn_cap == 8
 
     @pytest.mark.unit
-    def test_session_cap_anthropic_respects_session_memory_estimate(
+    def test_active_turn_cap_anthropic_respects_session_memory_estimate(
         self,
         mock_agent_config: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A larger per-session estimate yields a smaller cap."""
+        """A larger per-turn estimate yields a smaller cap."""
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
         mock_agent_config.claude = MagicMock()
         mock_agent_config.claude.max_concurrent_sessions = None
@@ -178,10 +196,10 @@ class TestAgentServerInit:
         server = AgentServer(agent_config=mock_agent_config)
 
         # (2048 - 400) / 400 = 4
-        assert server.sessions.max_sessions == 4
+        assert server._active_turn_cap == 4
 
     @pytest.mark.unit
-    def test_session_cap_anthropic_no_cgroup_memory_uses_fallback(
+    def test_active_turn_cap_anthropic_no_cgroup_memory_uses_fallback(
         self,
         mock_agent_config: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
@@ -198,11 +216,11 @@ class TestAgentServerInit:
 
         server = AgentServer(agent_config=mock_agent_config)
 
-        # _FALLBACK_SESSION_CAP
-        assert server.sessions.max_sessions == 50
+        # _FALLBACK_ACTIVE_TURN_CAP
+        assert server._active_turn_cap == 50
 
     @pytest.mark.unit
-    def test_session_cap_tiny_memory_floors_at_one(
+    def test_active_turn_cap_tiny_memory_floors_at_one(
         self,
         mock_agent_config: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
@@ -219,7 +237,7 @@ class TestAgentServerInit:
 
         server = AgentServer(agent_config=mock_agent_config)
 
-        assert server.sessions.max_sessions == 1
+        assert server._active_turn_cap == 1
 
 
 class TestAgentServerExecutorTimeoutWiring:
@@ -773,6 +791,134 @@ class TestToolInitShutdownWiring:
         await server.start()
 
         mock_cleanup.assert_awaited_once()
+
+
+class TestActiveTurnSemaphore:
+    """Tests for the spec 034 P4 active-turn semaphore.
+
+    The cap was repurposed from "max open sessions" to "max concurrent
+    active turns" because the SDK subprocess is spawned per-turn under
+    P4 hybrid sessions, not per-session. Memory pressure tracks active
+    turns, not idle session count.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_acquire_turn_slot_noop_for_non_anthropic(
+        self, mock_agent_config: MagicMock
+    ) -> None:
+        """No semaphore configured → context manager is a no-op."""
+        mock_agent_config.model.provider = ProviderEnum.OPENAI
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        assert server._active_turn_semaphore is None
+        async with server._acquire_turn_slot():
+            assert server._turn_capacity_exceeded() is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_acquire_turn_slot_tracks_in_flight(
+        self, mock_agent_config: MagicMock
+    ) -> None:
+        """Acquiring slot increments in-flight, releasing decrements."""
+        mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
+        mock_agent_config.claude.max_concurrent_sessions = 3
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        assert server._active_turn_in_flight() == 0
+        async with server._acquire_turn_slot():
+            assert server._active_turn_in_flight() == 1
+            async with server._acquire_turn_slot():
+                assert server._active_turn_in_flight() == 2
+            assert server._active_turn_in_flight() == 1
+        assert server._active_turn_in_flight() == 0
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_turn_capacity_exceeded_at_cap(
+        self, mock_agent_config: MagicMock
+    ) -> None:
+        """When all slots are held, _turn_capacity_exceeded() is True."""
+        mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
+        mock_agent_config.claude.max_concurrent_sessions = 2
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        assert server._turn_capacity_exceeded() is False
+        async with server._acquire_turn_slot():
+            assert server._turn_capacity_exceeded() is False
+            async with server._acquire_turn_slot():
+                assert server._turn_capacity_exceeded() is True
+            assert server._turn_capacity_exceeded() is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_capacity_exceeded_response_reflects_active_turns(
+        self, mock_agent_config: MagicMock
+    ) -> None:
+        """429 body reports active-turn counts, not open-session counts."""
+        import json
+
+        mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
+        mock_agent_config.claude.max_concurrent_sessions = 2
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        async with server._acquire_turn_slot(), server._acquire_turn_slot():
+            response = server._capacity_exceeded_response()
+            body = json.loads(response.body)
+            assert response.status_code == 429
+            assert body["max_sessions"] == 2
+            assert body["active_sessions"] == 2
+            assert "active turns" in body["message"]
+            assert response.headers["Retry-After"] == "5"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_turn_gated_stream_holds_slot_for_generator_lifetime(
+        self, mock_agent_config: MagicMock
+    ) -> None:
+        """Streaming generator wrapper keeps slot acquired across yields."""
+        mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
+        mock_agent_config.claude.max_concurrent_sessions = 1
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        async def inner() -> Any:
+            yield b"a"
+            assert server._active_turn_in_flight() == 1
+            yield b"b"
+            assert server._turn_capacity_exceeded() is True
+
+        chunks: list[bytes] = []
+        async for chunk in server._turn_gated_stream(inner()):
+            chunks.append(chunk)
+        assert chunks == [b"a", b"b"]
+        # Slot released after generator exhausts.
+        assert server._active_turn_in_flight() == 0
+        assert server._turn_capacity_exceeded() is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_open_session_count_does_not_trigger_429(
+        self, mock_agent_config: MagicMock
+    ) -> None:
+        """spec 034 P4: opening many sessions while no turns are active
+        must NOT trigger 429 — the gate is concurrent turns, not session count.
+        """
+        mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
+        mock_agent_config.claude.max_concurrent_sessions = 2
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        # No active turns → never exceeded, regardless of open session count.
+        assert server._turn_capacity_exceeded() is False
+        for _ in range(20):
+            server.sessions.create(MagicMock())
+        assert server._turn_capacity_exceeded() is False
+        assert server.sessions.active_count == 20
 
 
 class TestValidateBackendPrerequisites:

--- a/tests/unit/serve/test_server.py
+++ b/tests/unit/serve/test_server.py
@@ -117,10 +117,11 @@ class TestAgentServerInit:
     def test_session_cap_anthropic_with_max_concurrent_sessions(
         self, mock_agent_config: MagicMock
     ) -> None:
-        """Explicit claude.max_concurrent_sessions overrides CPU derivation."""
+        """Explicit claude.max_concurrent_sessions overrides memory derivation."""
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
         mock_agent_config.claude = MagicMock()
         mock_agent_config.claude.max_concurrent_sessions = 5
+        mock_agent_config.claude.session_memory_estimate_mib = 200
 
         server = AgentServer(agent_config=mock_agent_config)
 
@@ -138,55 +139,82 @@ class TestAgentServerInit:
         assert server.sessions.max_sessions == 1000
 
     @pytest.mark.unit
-    def test_session_cap_anthropic_default_derives_from_cpu_quota(
+    def test_session_cap_anthropic_default_derives_from_memory(
         self,
         mock_agent_config: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """spec 034 P1a: default cap is max(1, floor(cpu_quota * 2))."""
+        """spec 034 P1a: default cap = (mem - baseline) / per_session_bytes."""
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
         mock_agent_config.claude = MagicMock()
         mock_agent_config.claude.max_concurrent_sessions = None
-        # Pin the CPU quota so the test isn't sensitive to host hardware.
+        mock_agent_config.claude.session_memory_estimate_mib = 200
+        # Pin memory at 2 GiB → (2048 - 400) / 200 = 8
         monkeypatch.setattr(
-            "holodeck.serve.server.cpu_quota",
-            lambda: 1.0,
+            "holodeck.serve.server.memory_limit_bytes",
+            lambda: 2 * 1024 * 1024 * 1024,
         )
 
         server = AgentServer(agent_config=mock_agent_config)
 
-        assert server.sessions.max_sessions == 2
+        assert server.sessions.max_sessions == 8
 
     @pytest.mark.unit
-    def test_session_cap_anthropic_without_claude_config_derives_from_cpu(
+    def test_session_cap_anthropic_respects_session_memory_estimate(
         self,
         mock_agent_config: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """spec 034 P1a: missing claude block falls through to CPU derivation."""
+        """A larger per-session estimate yields a smaller cap."""
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
-        mock_agent_config.claude = None
+        mock_agent_config.claude = MagicMock()
+        mock_agent_config.claude.max_concurrent_sessions = None
+        mock_agent_config.claude.session_memory_estimate_mib = 400  # bigger
         monkeypatch.setattr(
-            "holodeck.serve.server.cpu_quota",
-            lambda: 2.0,
+            "holodeck.serve.server.memory_limit_bytes",
+            lambda: 2 * 1024 * 1024 * 1024,
         )
 
         server = AgentServer(agent_config=mock_agent_config)
 
+        # (2048 - 400) / 400 = 4
         assert server.sessions.max_sessions == 4
 
     @pytest.mark.unit
-    def test_session_cap_tiny_cpu_quota_floors_at_one(
+    def test_session_cap_anthropic_no_cgroup_memory_uses_fallback(
         self,
         mock_agent_config: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Sub-CPU replicas still get a cap of 1 (never zero)."""
+        """Unbounded memory (None) → static fallback cap, not infinite."""
         mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
-        mock_agent_config.claude = None
+        mock_agent_config.claude = MagicMock()
+        mock_agent_config.claude.max_concurrent_sessions = None
+        mock_agent_config.claude.session_memory_estimate_mib = 200
         monkeypatch.setattr(
-            "holodeck.serve.server.cpu_quota",
-            lambda: 0.25,
+            "holodeck.serve.server.memory_limit_bytes",
+            lambda: None,
+        )
+
+        server = AgentServer(agent_config=mock_agent_config)
+
+        # _FALLBACK_SESSION_CAP
+        assert server.sessions.max_sessions == 50
+
+    @pytest.mark.unit
+    def test_session_cap_tiny_memory_floors_at_one(
+        self,
+        mock_agent_config: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sub-baseline memory still gets a cap of 1 (never zero)."""
+        mock_agent_config.model.provider = ProviderEnum.ANTHROPIC
+        mock_agent_config.claude = MagicMock()
+        mock_agent_config.claude.max_concurrent_sessions = None
+        mock_agent_config.claude.session_memory_estimate_mib = 200
+        monkeypatch.setattr(
+            "holodeck.serve.server.memory_limit_bytes",
+            lambda: 100 * 1024 * 1024,  # 100 MiB
         )
 
         server = AgentServer(agent_config=mock_agent_config)

--- a/uv.lock
+++ b/uv.lock
@@ -2186,6 +2186,7 @@ dev = [
     { name = "bandit", extra = ["toml"] },
     { name = "black" },
     { name = "detect-secrets" },
+    { name = "mkdocs-llmstxt" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
     { name = "pip-audit" },
@@ -2284,6 +2285,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.0.0,<5.0.0" },
     { name = "markitdown", extras = ["all"], specifier = ">=0.1.4,<0.2.0" },
     { name = "mcp", specifier = ">=1.23" },
+    { name = "mkdocs-llmstxt", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "mkdocs-material", specifier = ">=9.6.22,<10.0.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.25.0" },
     { name = "ml-dtypes", specifier = ">=0.4.0,<0.5.0" },
@@ -3192,14 +3194,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
 ]
 
 [[package]]
@@ -3362,6 +3364,32 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat"
+version = "0.7.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610, upload-time = "2025-01-30T18:00:51.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/6f/94a7344f6d634fe3563bea8b33bccedee37f2726f7807e9a58440dc91627/mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5", size = 34447, upload-time = "2025-01-30T18:00:48.708Z" },
+]
+
+[[package]]
+name = "mdformat-tables"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106, upload-time = "2024-08-23T23:41:33.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/37/d78e37d14323da3f607cd1af7daf262cb87fe614a245c15ad03bb03a2706/mdformat_tables-1.0.0-py3-none-any.whl", hash = "sha256:94cd86126141b2adc3b04c08d1441eb1272b36c39146bab078249a41c7240a9a", size = 5104, upload-time = "2024-08-23T23:41:31.863Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3430,6 +3458,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-llmstxt"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f5/4c31cdffa7c09bf48d8c7a50d8342dc100abac98ac4150826bc11afc0c9f/mkdocs_llmstxt-0.5.0.tar.gz", hash = "sha256:b2fa9e6d68df41d7467e948a4745725b6c99434a36b36204857dbd7bb3dfe041", size = 33909, upload-time = "2025-11-20T14:02:24.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/2b/82928cc9e8d9269cd79e7ebf015efdc4945e6c646e86ec1d4dba1707f215/mkdocs_llmstxt-0.5.0-py3-none-any.whl", hash = "sha256:753c699913d2d619a9072604b26b6dc9f5fb6d257d9b107857f80c8a0b787533", size = 12040, upload-time = "2025-11-20T14:02:23.483Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2505,11 +2505,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -5927,15 +5927,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.17.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/6d/af5378dbdb379fddd9a277f8b9888c027db480cde70028669ebd009d642a/pymdown_extensions-10.17.2.tar.gz", hash = "sha256:26bb3d7688e651606260c90fb46409fbda70bf9fdc3623c7868643a1aeee4713", size = 847344, upload-time = "2025-11-26T15:43:57.004Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/78/b93cb80bd673bdc9f6ede63d8eb5b4646366953df15667eb3603be57a2b1/pymdown_extensions-10.17.2-py3-none-any.whl", hash = "sha256:bffae79a2e8b9e44aef0d813583a8fea63457b7a23643a43988055b7b79b4992", size = 266556, upload-time = "2025-11-26T15:43:55.162Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Spec 034 P4 (Hybrid Sessions):** per-turn `claude_agent_sdk.query(resume=session_id)` subprocesses with JSONL transcripts on disk; tools-in-parent via `create_sdk_mcp_server`; `_send_lock` for in-session serialization.
- **Active-turn gate:** repurposed `max_concurrent_sessions` as an `asyncio.BoundedSemaphore` over concurrent *active turns* (not open sessions), with atomic try-acquire that fail-fast 429s rather than queues — matches Anthropic's hosting-doc guidance.
- **Memory defaults retuned:** per-active-turn estimate `200 → 500 MiB`, calibrated against cloud validation (2 GiB ACA replica OOMed at 4 concurrent turns, ran cleanly at 3 → `(2048-400)/500 = 3`). Propagated through `runtime.py`, `ClaudeConfig`, sample yaml, and unit tests.
- **Docs:** new "Production considerations: memory and concurrency" section in `docs/guides/claude-backend.md` with the parent/subprocess diagram, replica sizing table, tuning guidance, and OTel signals.
- **`llms.txt` published:** added `mkdocs-llmstxt` plugin to dev deps and registered it in `mkdocs.yml`; the next docs build will publish `https://docs.useholodeck.ai/llms.txt` (curated index) and `…/llms-full.txt` (full concatenated markdown) with no workflow changes.

## Test plan

- [ ] `make test-unit` green (4788 passed at last run)
- [ ] Cloud validation: 5-concurrent burst against the financial-assistant ACA replica — expect 3 × 200 + 2 × 429 (no OOM, no queueing)
- [ ] `uv run mkdocs build -d site/` produces `site/llms.txt` (≥15 bullet links, 4 H2 sections) and `site/llms-full.txt` (≥1 MB)
- [ ] After merge + release tag, confirm `curl -sf https://docs.useholodeck.ai/llms.txt | head` returns the index