### PR TITLE
feat(claude): default to SDK setting-source isolation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Claude backend now defaults to settings isolation.** The spawned `claude` CLI subprocess no longer inherits plugins, skills, or hooks from `~/.claude` or `.claude/`. HoloDeck passes `setting_sources=[]` to the SDK unless the agent's YAML opts in via the new `claude.setting_sources` field. Accepted values: `user`, `project`, `local`, or `all`. **Migration:** if your agents relied on host-machine Claude config (e.g. a project `CLAUDE.md` or a custom skill), add `setting_sources: [project]` (or the layers you need) to the `claude:` block. See [Claude Backend → Settings isolation](guides/claude-backend.md#settings-isolation-plugins-skills-hooks).
+- **OTel instrumentation bumped to `otel-instrumentation-claude-agent-sdk>=0.0.6`**, which structurally fixes the frozen `from claude_agent_sdk import query` import path so `invoke_agent` / `execute_tool` spans are emitted regardless of how callers reference the SDK's top-level `query()`.
+
 ### Planned Features
 
 - **Deployment Engine**: Registry push (`holodeck deploy push`) and cloud deployment (`holodeck deploy run`)

--- a/docs/guides/agent-configuration.md
+++ b/docs/guides/agent-configuration.md
@@ -200,7 +200,9 @@ embedding_provider:
 
 ## Claude Agent SDK Settings
 
-When using `model.provider: anthropic`, the agent.yaml accepts a top-level `claude:` section for backend-specific capabilities (permission modes, extended thinking, web search, subagents, bash, file_system, working_directory, max_turns, allowed_tools).
+When using `model.provider: anthropic`, the agent.yaml accepts a top-level `claude:` section for backend-specific capabilities (permission modes, extended thinking, web search, subagents, bash, file_system, working_directory, max_turns, allowed_tools, setting_sources).
+
+HoloDeck **defaults to settings isolation**: the spawned SDK subprocess does not inherit plugins, skills, or hooks from `~/.claude` or `.claude/`. Opt in per-agent via `claude.setting_sources` — see [Claude Backend: Settings isolation](claude-backend.md#settings-isolation-plugins-skills-hooks).
 
 See [Claude Backend](claude-backend.md) for the full reference and examples. The `claude` block is ignored for non-Anthropic providers.
 

--- a/docs/guides/claude-backend.md
+++ b/docs/guides/claude-backend.md
@@ -251,6 +251,35 @@ claude:
     - web-search
 ```
 
+### Settings isolation (plugins, skills, hooks)
+
+The Claude Agent SDK spawns the `claude` CLI as a subprocess. By default the CLI loads **everything** it finds under `~/.claude/`, `.claude/`, and `.claude/settings.local.json` — plugins, skills, hooks, MCP servers, etc. That means an agent deployed from your laptop can silently inherit your personal Claude Code config, and the same agent deployed in CI/cloud gets a different setup.
+
+HoloDeck **defaults to full isolation**: when `claude.setting_sources` is unset, the backend passes `setting_sources=[]` to the SDK so the subprocess loads no settings layers. Your agent's behavior is determined solely by its `agent.yaml`.
+
+Opt back in only when you need it:
+
+```yaml
+claude:
+  setting_sources:
+    - project        # loads .claude/settings.json (and CLAUDE.md)
+```
+
+Accepted values:
+
+| Value       | Loads                                        |
+|-------------|----------------------------------------------|
+| `user`      | `~/.claude/settings.json` (global)           |
+| `project`   | `.claude/settings.json` and `CLAUDE.md`      |
+| `local`     | `.claude/settings.local.json` (gitignored)   |
+| `all`       | sugar for `[user, project, local]` — cannot be combined with other entries |
+
+Notes:
+
+- Include `project` if your agent depends on `CLAUDE.md`.
+- The default is `null` → HoloDeck sends `[]`. Setting an empty list explicitly (`setting_sources: []`) has the same effect.
+- `all` is rejected if mixed with other values; use either `[all]` or any subset of the three concrete layers.
+
 ### Embedding provider requirement
 
 Anthropic does not provide embedding models. When you combine `model.provider: anthropic` with **vectorstore** or **hierarchical_document** tools, you **must** define an `embedding_provider` at the agent level:
@@ -450,6 +479,7 @@ Anthropic's [SDK hosting documentation](https://docs.anthropic.com/en/api/agent-
 | `file_system`        | object         | -             | `{ read: bool, write: bool, edit: bool }`                                |
 | `agents`             | map<str, spec> | -             | Named subagents (see Subagents above)                                    |
 | `allowed_tools`      | list of strings | all tools    | Explicit tool allowlist                                                  |
+| `setting_sources`    | list of `user`\|`project`\|`local`\|`all` | `null` → `[]` (isolation) | Which Claude Code settings layers the spawned SDK subprocess loads. See [Settings isolation](#settings-isolation-plugins-skills-hooks) below. |
 | `session_memory_estimate_mib` | int (50–2000) | `500`  | Per-active-turn memory budget; drives the concurrency cap (see [Production considerations](#production-considerations-memory-and-concurrency)) |
 | `max_concurrent_sessions` | int (1–500) | derived    | Hard cap on concurrent active turns; auto-derived from cgroup memory when omitted |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ otel-all = [
 ]
 
 # Claude GenAI instrumentation (OTel semantic conventions)
-claude-otel = ["otel-instrumentation-claude-agent-sdk>=0.0.5,<0.1.0"]
+claude-otel = ["otel-instrumentation-claude-agent-sdk>=0.0.6,<0.1.0"]
 
 # Evaluation-runs dashboard (Dash + Plotly + pandas). Pixel-fidelity rewrite of
 # the Streamlit draft — handoff CSS tokens paste into assets/ verbatim.

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -277,6 +277,11 @@
           "items": { "type": "string" },
           "description": "Tools that must never be used; takes precedence over allowed_tools"
         },
+        "setting_sources": {
+          "type": ["array", "null"],
+          "items": { "enum": ["user", "project", "local", "all"] },
+          "description": "Which Claude Code settings layers the spawned SDK subprocess loads. null (default) → HoloDeck passes [] to the SDK (full isolation; no ~/.claude or .claude/ plugins, skills, hooks). Any subset of [\"user\", \"project\", \"local\"] opts back in. [\"all\"] is sugar for all three and cannot be combined with other values. Include \"project\" if your agents rely on CLAUDE.md files."
+        },
         "i_understand_this_is_unsafe": {
           "type": "boolean",
           "default": false,

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -467,11 +467,7 @@ def build_options(
             ", ".join(auto_disallow),
         )
 
-    # Setting sources — HoloDeck defaults to SDK isolation mode so the spawned
-    # `claude` CLI subprocess does not silently inherit ~/.claude /
-    # .claude/ plugins, skills, hooks, etc. When unset, pass [] explicitly
-    # so the CLI receives `--setting-sources=` and skips its own load-everything
-    # default. Users opt back in via `claude.setting_sources`.
+    # Default [] → CLI subprocess never inherits ~/.claude plugins/skills/hooks.
     setting_sources: list[str] = (
         list(claude.setting_sources)
         if claude is not None and claude.setting_sources is not None

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -16,12 +16,12 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, cast
 
+import claude_agent_sdk
 import jsonschema
 from claude_agent_sdk import (
     ClaudeAgentOptions,
     HookMatcher,
     ProcessError,
-    query,
 )
 from claude_agent_sdk._errors import CLIConnectionError, MessageParseError
 from claude_agent_sdk.types import (
@@ -467,6 +467,17 @@ def build_options(
             ", ".join(auto_disallow),
         )
 
+    # Setting sources — HoloDeck defaults to SDK isolation mode so the spawned
+    # `claude` CLI subprocess does not silently inherit ~/.claude /
+    # .claude/ plugins, skills, hooks, etc. When unset, pass [] explicitly
+    # so the CLI receives `--setting-sources=` and skips its own load-everything
+    # default. Users opt back in via `claude.setting_sources`.
+    setting_sources: list[str] = (
+        list(claude.setting_sources)
+        if claude is not None and claude.setting_sources is not None
+        else []
+    )
+
     # Build the options dict
     opts_kwargs: dict[str, Any] = {
         "model": agent.model.name,
@@ -478,6 +489,7 @@ def build_options(
         "env": env,
         "cwd": cwd,
         "output_format": output_format,
+        "setting_sources": setting_sources,
     }
     if disallowed_tools is not None:
         opts_kwargs["disallowed_tools"] = disallowed_tools
@@ -810,7 +822,7 @@ class ClaudeSession:
                 structured_output: Any = None
 
                 msg_count = 0
-                async for msg in query(
+                async for msg in claude_agent_sdk.query(
                     prompt=_streaming_user_envelope(message), options=options
                 ):
                     msg_count += 1
@@ -902,7 +914,7 @@ class ClaudeSession:
                     options.resume = self._sdk_session_id
 
             try:
-                async for msg in query(
+                async for msg in claude_agent_sdk.query(
                     prompt=_streaming_user_envelope(message), options=options
                 ):
                     _maybe_emit_thinking_blocks(msg, self._tool_event_queue)
@@ -1142,7 +1154,9 @@ class ClaudeBackend:
         structured_output: Any = None
 
         prompt_iter = _wrap_prompt(message)
-        async for msg in query(prompt=prompt_iter, options=self._options):
+        async for msg in claude_agent_sdk.query(
+            prompt=prompt_iter, options=self._options
+        ):
             text_parts, tool_calls, tool_results, thinking_parts = _process_message(
                 msg, text_parts, tool_calls, tool_results, thinking_parts
             )

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -309,6 +309,21 @@ class ClaudeConfig(BaseModel):
             "Tools that must never be used; takes precedence over allowed_tools."
         ),
     )
+    setting_sources: list[Literal["user", "project", "local", "all"]] | None = Field(
+        default=None,
+        description=(
+            "Which Claude Code settings layers the spawned SDK subprocess "
+            "should load. HoloDeck defaults to full isolation: when this is "
+            "``None`` (default), the backend passes ``[]`` to the SDK so the "
+            "subprocess does not inherit plugins, skills, hooks, etc. from "
+            "the host's ``~/.claude`` or the project's ``.claude/`` "
+            "directories. Set to any subset of ``['user', 'project', "
+            "'local']`` to opt back in, or to ``['all']`` as sugar for all "
+            "three. ``'all'`` cannot be combined with other values. "
+            "``'project'`` must be included if your agents rely on "
+            "``CLAUDE.md`` files."
+        ),
+    )
     i_understand_this_is_unsafe: bool = Field(
         default=False,
         description=(
@@ -344,6 +359,36 @@ class ClaudeConfig(BaseModel):
         """Normalize agents={} to agents=None (data-model.md rule 1)."""
         if self.agents == {}:
             self.agents = None
+        return self
+
+    @model_validator(mode="after")
+    def _normalize_setting_sources(self) -> "ClaudeConfig":
+        """Expand ``['all']`` and dedupe ``setting_sources``.
+
+        ``'all'`` is YAML sugar for ``['user', 'project', 'local']`` and may
+        not be combined with other values. ``None`` is preserved so the
+        backend can distinguish "unset" (apply HoloDeck's isolation default)
+        from "explicitly empty" (``[]`` is the same effect but user-stated).
+        """
+        if self.setting_sources is None:
+            return self
+        sources = list(self.setting_sources)
+        if "all" in sources:
+            if len(sources) > 1:
+                raise ValueError(
+                    "claude.setting_sources: 'all' cannot be combined with "
+                    "other values; use either ['all'] or a subset of "
+                    "['user', 'project', 'local']."
+                )
+            self.setting_sources = ["user", "project", "local"]
+            return self
+        seen: set[str] = set()
+        deduped: list[Literal["user", "project", "local", "all"]] = []
+        for src in sources:
+            if src not in seen:
+                seen.add(src)
+                deduped.append(src)
+        self.setting_sources = deduped
         return self
 
     @model_validator(mode="after")

--- a/src/holodeck/models/claude_config.py
+++ b/src/holodeck/models/claude_config.py
@@ -382,6 +382,11 @@ class ClaudeConfig(BaseModel):
                 )
             self.setting_sources = ["user", "project", "local"]
             return self
+        # NB: `deduped` keeps the wider Literal that includes "all" because
+        # Python lists are invariant under mypy — a narrower
+        # `list[Literal["user","project","local"]]` cannot be assigned to the
+        # field's `list[Literal[...,"all"]] | None`. The early-return above
+        # still guarantees "all" never reaches this loop at runtime.
         seen: set[str] = set()
         deduped: list[Literal["user", "project", "local", "all"]] = []
         for src in sources:

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -402,6 +402,69 @@ class TestBuildOptions:
 
     @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
     @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_setting_sources_default_isolation(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """Default (no claude block) → setting_sources=[] (SDK isolation mode).
+
+        Guarantees the spawned CLI subprocess does not inherit ~/.claude
+        plugins, skills, or hooks from the host machine.
+        """
+        build_options(
+            agent=_make_agent(),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["setting_sources"] == []
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_setting_sources_explicit_subset(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """Explicit ['user'] passes through to the SDK verbatim."""
+        claude = ClaudeConfig(setting_sources=["user"])
+        build_options(
+            agent=_make_agent(claude=claude),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["setting_sources"] == ["user"]
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_setting_sources_all_expanded(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """['all'] is expanded by the model validator before reaching the SDK."""
+        claude = ClaudeConfig(setting_sources=["all"])
+        build_options(
+            agent=_make_agent(claude=claude),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["setting_sources"] == ["user", "project", "local"]
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
     def test_build_options_env_merges_auth_and_otel(
         self,
         mock_resolve: MagicMock,
@@ -1001,7 +1064,7 @@ class TestClaudeBackendInvokeOnce:
     """Tests for ClaudeBackend.invoke_once() — execution and result mapping."""
 
     @pytest.mark.asyncio
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_invoke_once_happy_path(self, mock_query: MagicMock) -> None:
         """T005: Mocked query() → correct ExecutionResult fields."""
         assistant = _make_assistant_message([_make_text_block("Hello world")])
@@ -1022,7 +1085,7 @@ class TestClaudeBackendInvokeOnce:
         assert result.num_turns == 1
 
     @pytest.mark.asyncio
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_invoke_once_surfaces_thinking_text(
         self, mock_query: MagicMock
     ) -> None:
@@ -1045,7 +1108,7 @@ class TestClaudeBackendInvokeOnce:
         assert result.thinking == "internal deliberation"
 
     @pytest.mark.asyncio
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_invoke_once_tool_extraction(self, mock_query: MagicMock) -> None:
         """T006: Tool calls and results extracted from content blocks."""
         tool_use = _make_tool_use_block("toolu_01", "kb_search", {"query": "refund"})
@@ -1075,7 +1138,7 @@ class TestClaudeBackendInvokeOnce:
         }
 
     @pytest.mark.asyncio
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_invoke_once_structured_output(self, mock_query: MagicMock) -> None:
         """T007: Structured output returned and response set to JSON string."""
         structured = {"name": "Widget", "price": 9.99}
@@ -1100,7 +1163,7 @@ class TestClaudeBackendInvokeOnce:
         assert result.response == json.dumps(structured)
 
     @pytest.mark.asyncio
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_invoke_once_structured_output_schema_failure(
         self, mock_query: MagicMock
     ) -> None:
@@ -1125,7 +1188,7 @@ class TestClaudeBackendInvokeOnce:
         assert "schema validation" in result.error_reason.lower()
 
     @pytest.mark.asyncio
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_invoke_once_max_turns_exceeded(self, mock_query: MagicMock) -> None:
         """T008: max_turns exceeded → is_error=True with partial response."""
         assistant = _make_assistant_message([_make_text_block("Partial response")])
@@ -1155,7 +1218,7 @@ class TestClaudeBackendRetry:
 
     @pytest.mark.asyncio
     @patch(f"{_SDK_MODULE}.asyncio")
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_retry_on_process_error_then_success(
         self, mock_query: MagicMock, mock_asyncio: MagicMock
     ) -> None:
@@ -1184,7 +1247,7 @@ class TestClaudeBackendRetry:
 
     @pytest.mark.asyncio
     @patch(f"{_SDK_MODULE}.asyncio")
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_retry_all_failures_raises(
         self, mock_query: MagicMock, mock_asyncio: MagicMock
     ) -> None:
@@ -1228,7 +1291,8 @@ class TestClaudeSessionStreaming:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with patch(
-            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
         ):
             chunks: list[str] = []
             async for chunk in session.send_streaming("Hi"):
@@ -1251,7 +1315,8 @@ class TestClaudeSessionStreaming:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with patch(
-            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
         ):
             result = await session.send("Reason about this")
 
@@ -1284,7 +1349,7 @@ class TestClaudeSessionStreaming:
             yield _make_result_message(session_id="sdk-stream-XYZ")
 
         with patch(
-            "holodeck.lib.backends.claude_backend.query",
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
             side_effect=fake_query_capture,
         ):
             async for _ in session.send_streaming("Turn 1"):
@@ -1317,7 +1382,10 @@ class TestClaudeSessionErrorTranslation:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with (
-            patch("holodeck.lib.backends.claude_backend.query", side_effect=fake_query),
+            patch(
+                "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+                side_effect=fake_query,
+            ),
             pytest.raises(BackendSessionError, match="subprocess terminated"),
         ):
             await session.send("hi")
@@ -1330,7 +1398,10 @@ class TestClaudeSessionErrorTranslation:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with (
-            patch("holodeck.lib.backends.claude_backend.query", side_effect=fake_query),
+            patch(
+                "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+                side_effect=fake_query,
+            ),
             pytest.raises(BackendSessionError, match="subprocess terminated"),
         ):
             await session.send("hi")
@@ -1343,7 +1414,10 @@ class TestClaudeSessionErrorTranslation:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with (
-            patch("holodeck.lib.backends.claude_backend.query", side_effect=fake_query),
+            patch(
+                "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+                side_effect=fake_query,
+            ),
             pytest.raises(BackendSessionError, match="subprocess terminated"),
         ):
             async for _ in session.send_streaming("hi"):
@@ -1357,7 +1431,10 @@ class TestClaudeSessionErrorTranslation:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with (
-            patch("holodeck.lib.backends.claude_backend.query", side_effect=fake_query),
+            patch(
+                "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+                side_effect=fake_query,
+            ),
             pytest.raises(BackendSessionError, match="subprocess terminated"),
         ):
             async for _ in session.send_streaming("hi"):
@@ -1391,7 +1468,8 @@ class TestClaudeSessionSend:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with patch(
-            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
         ):
             result = await session.send("Hi")
 
@@ -1421,7 +1499,8 @@ class TestClaudeSessionSend:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with patch(
-            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
         ):
             result = await session.send("search")
 
@@ -1452,7 +1531,8 @@ class TestClaudeSessionSend:
         # and produces a fresh, non-aliased options per turn.
         session = ClaudeSession(options=ClaudeAgentOptions())
         with patch(
-            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
         ):
             await session.send("Turn 1")
             await session.send("Turn 2")
@@ -1479,7 +1559,8 @@ class TestClaudeSessionSend:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with patch(
-            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
         ):
             await session.send("Hi")
 
@@ -1647,7 +1728,7 @@ class TestClaudeBackendLazyInit:
     """Tests for lazy-init — auto-initialize on first use."""
 
     @pytest.mark.asyncio
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_invoke_once_auto_initializes(self, mock_query: MagicMock) -> None:
         """T015a: invoke_once() without explicit initialize() auto-inits."""
         mock_query.return_value = _async_iter(
@@ -1718,7 +1799,7 @@ class TestClaudeBackendLazyInit:
         assert not hasattr(session, "_client")
 
     @pytest.mark.asyncio
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_no_double_init(self, mock_query: MagicMock) -> None:
         """T015c: Explicit initialize() + invoke_once() → no second init."""
         mock_query.return_value = _async_iter(
@@ -1756,7 +1837,7 @@ class TestClaudeBackendTeardown:
         assert backend._options is None
 
     @pytest.mark.asyncio
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_invoke_after_teardown_reinitializes(
         self, mock_query: MagicMock
     ) -> None:
@@ -2296,7 +2377,7 @@ class TestClaudeBackendExceptionGroup:
 
     @pytest.mark.asyncio
     @patch(f"{_SDK_MODULE}.asyncio")
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_exception_group_triggers_retry(
         self, mock_query: MagicMock, mock_asyncio: MagicMock
     ) -> None:
@@ -2326,7 +2407,7 @@ class TestClaudeBackendExceptionGroup:
 
     @pytest.mark.asyncio
     @patch(f"{_SDK_MODULE}.asyncio")
-    @patch(f"{_SDK_MODULE}.query")
+    @patch(f"{_SDK_MODULE}.claude_agent_sdk.query")
     async def test_exception_group_all_retries_raises(
         self, mock_query: MagicMock, mock_asyncio: MagicMock
     ) -> None:
@@ -2754,7 +2835,7 @@ class TestGracefulDegradation:
         result_msg = _make_result_message()
 
         with patch(
-            f"{_SDK_MODULE}.query",
+            f"{_SDK_MODULE}.claude_agent_sdk.query",
             return_value=_async_iter([assistant_msg, result_msg]),
         ):
             result = await backend.invoke_once("Hi")
@@ -3185,7 +3266,8 @@ class TestClaudeSessionP4Fields:
 
         session = ClaudeSession(options=MagicMock(spec=ClaudeAgentOptions))
         with patch(
-            "holodeck.lib.backends.claude_backend.query", side_effect=fake_query
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
         ):
             await asyncio.gather(session.send("a"), session.send("b"))
 

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -445,6 +445,31 @@ class TestBuildOptions:
 
     @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
     @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
+    def test_build_options_setting_sources_explicit_empty_list(
+        self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
+    ) -> None:
+        """Explicit ``setting_sources=[]`` reaches the SDK as ``[]`` (not None).
+
+        Same effective behavior as the default, but exercises the
+        ``claude.setting_sources is not None`` branch in ``_build_options``
+        so a future regression flipping the condition would be caught.
+        """
+        claude = ClaudeConfig(setting_sources=[])
+        build_options(
+            agent=_make_agent(claude=claude),
+            tool_server=None,
+            tool_names=[],
+            mcp_configs={},
+            auth_env={},
+            otel_env={},
+            mode="test",
+        )
+
+        kwargs = mock_opts_cls.call_args[1]
+        assert kwargs["setting_sources"] == []
+
+    @patch(f"{_SDK_MODULE}.ClaudeAgentOptions")
+    @patch(f"{_SDK_MODULE}.resolve_instructions", return_value="Be helpful.")
     def test_build_options_setting_sources_all_expanded(
         self, mock_resolve: MagicMock, mock_opts_cls: MagicMock
     ) -> None:

--- a/tests/unit/models/test_claude_config.py
+++ b/tests/unit/models/test_claude_config.py
@@ -216,7 +216,38 @@ class TestClaudeConfig:
         assert config.max_budget_usd is None
         assert config.fallback_model is None
         assert config.disallowed_tools is None
+        assert config.setting_sources is None
         assert config.i_understand_this_is_unsafe is False
+
+    def test_setting_sources_explicit_subset_preserved(self) -> None:
+        """Subset of valid sources passes through unchanged."""
+        config = ClaudeConfig(setting_sources=["user"])
+        assert config.setting_sources == ["user"]
+
+    def test_setting_sources_explicit_empty_list_preserved(self) -> None:
+        """Empty list is preserved (explicit isolation, same effect as None)."""
+        config = ClaudeConfig(setting_sources=[])
+        assert config.setting_sources == []
+
+    def test_setting_sources_all_expands_to_three(self) -> None:
+        """['all'] is sugar for the full triplet."""
+        config = ClaudeConfig(setting_sources=["all"])
+        assert config.setting_sources == ["user", "project", "local"]
+
+    def test_setting_sources_all_mixed_rejected(self) -> None:
+        """'all' cannot be combined with other values."""
+        with pytest.raises(ValidationError, match="'all' cannot be combined"):
+            ClaudeConfig(setting_sources=["all", "user"])
+
+    def test_setting_sources_invalid_value_rejected(self) -> None:
+        """Unknown layer names are rejected by the Literal."""
+        with pytest.raises(ValidationError):
+            ClaudeConfig(setting_sources=["enterprise"])  # type: ignore[list-item]
+
+    def test_setting_sources_deduplicates(self) -> None:
+        """Duplicates collapse, order is preserved."""
+        config = ClaudeConfig(setting_sources=["user", "project", "user"])
+        assert config.setting_sources == ["user", "project"]
 
     def test_i_understand_this_is_unsafe_accepts_true(self) -> None:
         """spec 034 P1b: opt-in flag for permission_mode=acceptAll."""

--- a/uv.lock
+++ b/uv.lock
@@ -2301,7 +2301,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-prometheus", marker = "extra == 'otel-all'", specifier = ">=0.60b0,<1.0.0" },
     { name = "opentelemetry-exporter-prometheus", marker = "extra == 'otel-prometheus'", specifier = ">=0.60b0,<1.0.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0,<2.0.0" },
-    { name = "otel-instrumentation-claude-agent-sdk", marker = "extra == 'claude-otel'", specifier = ">=0.0.5,<0.1.0" },
+    { name = "otel-instrumentation-claude-agent-sdk", marker = "extra == 'claude-otel'", specifier = ">=0.0.6,<0.1.0" },
     { name = "pandas", marker = "extra == 'dashboard'", specifier = ">=2.0" },
     { name = "pinecone", extras = ["asyncio", "grpc"], marker = "extra == 'pinecone'", specifier = "~=7.0" },
     { name = "pinecone", extras = ["asyncio", "grpc"], marker = "extra == 'vectorstores'", specifier = "~=7.0" },
@@ -4631,7 +4631,7 @@ wheels = [
 
 [[package]]
 name = "otel-instrumentation-claude-agent-sdk"
-version = "0.0.5"
+version = "0.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -4639,9 +4639,9 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/9b/5d7c47a3c15c7dbbfe4c4055a5da3f715a6265f815a014b29b070a262252/otel_instrumentation_claude_agent_sdk-0.0.5.tar.gz", hash = "sha256:2364af1414468daace215bae1a0afb5c52378992c63839ae6c6c83383c4f8e46", size = 246937, upload-time = "2026-05-22T00:58:15.359Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/5e/ee721e3e1ae57326ca0a604de19d427a7bc373982aa33ff5be395845e267/otel_instrumentation_claude_agent_sdk-0.0.6.tar.gz", hash = "sha256:533351efe3a36fcd51dde504d9d3072dae4dcf0a781dc34adb8965c500ebf2ad", size = 250108, upload-time = "2026-05-22T12:06:45.231Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/ba/f3f539a5ea6b27729b1668d7854d8fc3459a61c49ed8aed7a1ca19041a27/otel_instrumentation_claude_agent_sdk-0.0.5-py3-none-any.whl", hash = "sha256:71291ff01fb619b0cc345ce8ec1af3b50860be88ca8bb18b298436af59aa1346", size = 25177, upload-time = "2026-05-22T00:58:13.757Z" },
+    { url = "https://files.pythonhosted.org/packages/73/95/a15e8dddcc667795ab81099abdc5e0c728cfc7c094f8692828095ab8ddc5/otel_instrumentation_claude_agent_sdk-0.0.6-py3-none-any.whl", hash = "sha256:db7486520df7ea1361af50afc2b193e826a87e35c181d407a836685468371326", size = 26120, upload-time = "2026-05-22T12:06:43.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- HoloDeck now passes `setting_sources=[]` to the Claude Agent SDK by default, so the spawned `claude` CLI subprocess no longer silently inherits plugins, skills, hooks, or MCP servers from `~/.claude` / `.claude/`. Same agent now behaves identically on a laptop, in CI, and in a cloud replica.
- New `claude.setting_sources` field on `ClaudeConfig` for per-agent opt-in. Accepts `user`, `project`, `local`, or `all` (sugar for the full triplet; rejected when mixed with other values). Validator normalizes and dedupes.
- Bumps `otel-instrumentation-claude-agent-sdk` to `>=0.0.6` — the upstream PR I filed (#26 → #27 in that repo) structurally fixes the frozen `from claude_agent_sdk import query` binding so `invoke_agent` / `execute_tool` spans always emit.

## Why this is a behavior change worth flagging

The Claude CLI's own default is "load all settings". HoloDeck previously never set `--setting-sources`, so agents inherited the host machine's personal Claude Code config (plugins, skills, custom hooks). Users running `holodeck serve` from a laptop saw their `~/.claude` skills show up in agent loops. The fix is to default to SDK isolation mode (`[]`) and require explicit opt-in.

**Migration:** if any of your existing agents relied on host Claude config (e.g. a project `CLAUDE.md` or a custom skill), add to the `claude:` block:

```yaml
claude:
  setting_sources: [project]   # or [user, project] / [all]
```

## Changes

- `src/holodeck/models/claude_config.py` — new field + `_normalize_setting_sources` model_validator.
- `src/holodeck/lib/backends/claude_backend.py` — always emit `setting_sources` in `_build_options` (defaults to `[]`).
- `schemas/agent.schema.json` — schema mirror.
- `docs/guides/claude-backend.md` — new "Settings isolation" section + reference-table row.
- `docs/guides/agent-configuration.md` — callout in the Claude Agent SDK Settings section.
- `docs/CHANGELOG.md` — Unreleased entry with migration note.
- `pyproject.toml` + `uv.lock` — `otel-instrumentation-claude-agent-sdk>=0.0.6,<0.1.0`.

## Test plan

- [x] `pytest tests/unit/models/test_claude_config.py tests/unit/lib/backends/test_claude_backend.py -n auto` — 228 passed, 0 failed. Six new model tests (defaults / explicit subset / explicit empty / `all` expansion / `all`-mixed rejection / unknown-value rejection / dedupe) and three new backend tests (default → `[]`, explicit `[user]`, `[all]` → expanded).
- [x] Full `pytest tests/unit/ -n auto` — 4807 passed, 4 skipped (unrelated).
- [x] `ruff check` + `black` + `mypy` clean on changed files (pre-commit hooks all green).
- [x] Local wheel built + installed into `uv tool` cache; smoke-tested defaults / `[all]` expansion / mixed-value rejection in the tool venv.
- [ ] Manual: `holodeck serve` with no `setting_sources` in agent YAML — verify `~/.claude` skills/plugins no longer appear in subagent listings.
- [ ] Manual: same agent with `setting_sources: [project]` — verify project `CLAUDE.md` / `.claude/` content loads.