### PR TITLE
chore(docs): publish agent JSON schema on docsite + sync ClaudeConfig drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ metrics/*
 
 # mkdocs site
 /site
+# Copies of schemas/agent.schema.json staged into the docs tree by
+# scripts/mkdocs_hooks.py at build time. The canonical source is
+# schemas/agent.schema.json at the repo root.
+/docs/schemas/
 .holodeck/cache
 
 # samples folder

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,9 @@ nav:
     - Contributing: contributing.md
     - Changelog: CHANGELOG.md
 
+hooks:
+  - scripts/mkdocs_hooks.py
+
 plugins:
   - search:
       lang: en

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     "mcp>=1.23",
     "inquirerpy>=0.3.4,<0.4.0",
     "fastapi>=0.115.0,<1.0.0",
+    # PYSEC-2026-161: pin starlette transitive (via fastapi/mcp) to the patched
+    # release. fastapi 0.128 and mcp 1.26 leave starlette unconstrained, so a
+    # direct pin is the only way to keep the lockfile on a non-vulnerable build.
+    "starlette>=1.0.1",
     "uvicorn[standard]>=0.34.0,<1.0.0",
     "ag-ui-protocol>=0.1.18,<1.0.0",
     "werkzeug>=3.1.6",

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -195,7 +195,8 @@
         },
         "model": {
           "type": ["string", "null"],
-          "description": "Model override for this subagent. Passed through to the SDK verbatim (e.g. 'sonnet', 'haiku', 'inherit', or a full model id). The SDK is the source of truth for valid values."
+          "enum": ["sonnet", "opus", "haiku", "inherit", null],
+          "description": "Model override for this subagent. Must be one of the SDK's literal aliases: 'sonnet', 'opus', 'haiku', 'inherit'. Full model IDs (e.g. 'claude-haiku-4-5') are rejected — the Claude CLI silently drops AgentDefinitions whose `model` is not in this set, so the validator catches it at config-load time."
         }
       },
       "description": "A single subagent definition for multi-agent orchestration."
@@ -222,14 +223,14 @@
           "type": ["integer", "null"],
           "minimum": 1,
           "maximum": 500,
-          "description": "Maximum concurrent Claude SDK subprocesses per serve instance. When unset, the serve layer derives the cap from the replica's cgroup memory limit divided by session_memory_estimate_mib (spec 034 P1a)."
+          "description": "Maximum concurrent active turns per serve instance. Under spec 034 P4 each in-flight turn spawns a fresh SDK subprocess, so this gates memory exposure. When unset, the serve layer derives the cap from the replica's cgroup memory limit divided by session_memory_estimate_mib. Field name retained for backward compatibility with existing agent.yaml files. Upper bound 500 allows operators to admit many idle threads (open sessions are now nearly free — JSONL transcripts on disk, no resident subprocess) while the semaphore enforces the actual memory cap on concurrent active turns."
         },
         "session_memory_estimate_mib": {
           "type": "integer",
           "minimum": 50,
           "maximum": 2000,
-          "default": 200,
-          "description": "Estimated resident memory (MiB) per active Claude SDK subprocess, used to derive max_concurrent_sessions from the replica's cgroup memory limit. Default 200 MiB (spec 034 P1a)."
+          "default": 500,
+          "description": "Estimated peak resident memory (MiB) per concurrent active turn (SDK subprocess + tool state during a single in-flight query). Under spec 034 P4 this is no longer per-idle-session — idle sessions cost ~30 MiB each (Python object + JSONL handle) since the subprocess is spawned per turn and torn down at turn end. Used by the serve layer to derive max_concurrent_sessions from the replica's cgroup memory limit. The 500 MiB default is calibrated against the spec 034 P4 cloud validation: a 2 GiB ACA replica OOMed at 4 concurrent turns, and 3 was the empirically safe ceiling — (2048-400)/500 = 3 matches that. Tune up for tool-heavy agents."
         },
         "extended_thinking": {
           "$ref": "#/$defs/ExtendedThinkingConfig",

--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -1,0 +1,34 @@
+"""MkDocs build hooks.
+
+Currently:
+- ``on_pre_build`` copies ``schemas/agent.schema.json`` into ``docs/schemas/``
+  so the JSON Schema is published as a raw static asset at
+  ``https://docs.useholodeck.ai/schemas/schema.json`` (canonical) and
+  ``/schemas/agent.schema.json`` (legacy alias). This lets any editor that
+  speaks ``yaml-language-server`` resolve the schema directly from the docs
+  site for auto-complete and validation.
+
+The copy targets are git-ignored — the upstream source of truth remains
+``schemas/agent.schema.json`` at the repo root.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+SCHEMA_SOURCE = Path("schemas/agent.schema.json")
+PUBLISHED_NAMES = ("schema.json", "agent.schema.json")
+
+
+def on_pre_build(config: Any) -> None:
+    """Copy the agent JSON Schema into the docs tree before the build."""
+    repo_root = Path(config["config_file_path"]).parent
+    src = repo_root / SCHEMA_SOURCE
+    if not src.exists():
+        return
+    target_dir = Path(config["docs_dir"]) / "schemas"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for name in PUBLISHED_NAMES:
+        shutil.copy2(src, target_dir / name)

--- a/uv.lock
+++ b/uv.lock
@@ -1642,17 +1642,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.0"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -2140,6 +2141,7 @@ dependencies = [
     { name = "rouge-score" },
     { name = "sacrebleu" },
     { name = "semantic-kernel" },
+    { name = "starlette" },
     { name = "tiktoken" },
     { name = "twine" },
     { name = "urllib3" },
@@ -2332,6 +2334,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.7" },
     { name = "sacrebleu", specifier = ">=2.5.1,<3.0.0" },
     { name = "semantic-kernel", specifier = ">=1.39.4,<2.0.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "tox", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "twine", specifier = ">=6.2.0,<7.0.0" },
@@ -7227,15 +7230,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add an mkdocs `on_pre_build` hook (`scripts/mkdocs_hooks.py`) that copies `schemas/agent.schema.json` into the docs tree as both `schemas/schema.json` (canonical) and `schemas/agent.schema.json` (legacy alias). Once deployed, IDEs anywhere can resolve the canonical schema for `agent.yaml` auto-complete via:
  ```yaml
  # yaml-language-server: $schema=https://docs.useholodeck.ai/schemas/schema.json
  ```
- Fix drift between the JSON Schema and the Pydantic `ClaudeConfig` model after spec 034 P4:
  - `session_memory_estimate_mib`: default `200 → 500`; description updated to per-active-turn semantics
  - `max_concurrent_sessions`: description refreshed to reflect the active-turn semaphore (idle sessions are nearly free under spec 034 P4)
  - `SubagentSpec.model`: constrained to enum `["sonnet", "opus", "haiku", "inherit"]` to match the Pydantic `Literal` (the Claude CLI silently drops AgentDefinitions whose `model` isn't in this set, so the validator catches it at config-load time)

The companion change in `holodeck-samples/skills/holodeck/` (giving the skill explicit IDE setup recipes for VS Code, JetBrains, Neovim, etc.) is being made in that repo and isn't part of this PR.

## Test plan

- [x] `python -c "import json, jsonschema; jsonschema.Draft7Validator.check_schema(json.load(open('schemas/agent.schema.json')))"` — schema is a valid Draft-07 document
- [x] `uv run mkdocs build -d /tmp/site-test` produces `site/schemas/schema.json` and `site/schemas/agent.schema.json`, both byte-identical to `schemas/agent.schema.json`
- [x] `pytest tests/unit/models tests/unit/config -n auto` → 965 passed
- [ ] After merge + next release, verify `curl -fsSL https://docs.useholodeck.ai/schemas/schema.json | head` returns the schema, and that a YAML LSP-equipped editor (e.g. VS Code w/ Red Hat YAML) resolves the modeline against the live URL