### PR TITLE
[codex] Bring Claude AG-UI streaming up to parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,67 @@ This file provides detailed guidance for AI agents working with the HoloDeck cod
 
 ---
 
+## Project Pointers
+
+- **Constitution (authoritative principles):** `.specify/memory/constitution.md`
+- **Product & user documentation:** `docs/`
+- **Feature specs, plans, tasks, status:** `specs/`
+- **Agent YAML schema:** `schemas/agent.schema.json`
+- **Vision & roadmap:** `VISION.md`
+- **Claude Code instructions:** `CLAUDE.md`
+- **Comprehensive agent docs:** `AGENTS.md`
+
+---
+
+## Behavioral Guidelines
+
+Bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+Do not assume or hide confusion.
+
+- State assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them instead of picking silently.
+- If a simpler approach exists, say so.
+- Push back when warranted.
+- If something is unclear, stop, name what is confusing, and ask.
+
+### 2. Simplicity First
+
+Write the minimum code that solves the problem.
+
+- Do not add features beyond what was asked.
+- Do not introduce abstractions for single-use code.
+- Do not add flexibility or configurability that was not requested.
+- Do not add error handling for impossible scenarios.
+- If a change grows large, reread it and simplify before moving on.
+
+Ask: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+Touch only what is necessary. Clean up only your own mess.
+
+- Do not improve adjacent code, comments, or formatting unless needed.
+- Do not refactor unrelated code.
+- Match existing style, even if you would choose a different style.
+- If you notice unrelated dead code, mention it instead of deleting it.
+- Remove imports, variables, functions, and tests that your own changes made unused.
+
+Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+Define success criteria and verify them.
+
+- "Add validation" means write tests for invalid inputs, then make them pass.
+- "Fix the bug" means write or identify a test that reproduces it, then make it pass.
+- "Refactor X" means preserve behavior and run the relevant tests before reporting done.
+- For multi-step tasks, state a brief plan with per-step verification.
+
+---
+
 ## Project Overview
 
 **HoloDeck** is an open-source experimentation platform for building, testing, and deploying AI agents through pure YAML configuration. The project enables teams to go from hypothesis to production API in minutes without writing code.
@@ -565,6 +626,20 @@ MyPy settings (from pyproject.toml):
 - `warn_return_any = true`: Warn when returning Any
 - `warn_unreachable = true`: Warn about unreachable code
 
+### Type Discipline
+
+Treat type annotations as part of the design, not as cleanup after the fact.
+
+- Do not use `Any` for known domain objects, AG-UI requests/events, HoloDeck models, backend sessions, or streaming surfaces. Use the concrete Pydantic model, protocol, union, `TypedDict`, or type alias that describes the value.
+- Do not write signatures such as `input_data: Any`, `request: Any`, or `AsyncGenerator[Any, None]` when the protocol is known. Examples: AG-UI handlers should use `RunAgentInput` and `BaseEvent`; backend execution should use `ExecutionResult`; tool event streams should use `ToolEvent`.
+- Keep untyped third-party SDK data at the boundary. Convert it immediately into HoloDeck-owned typed models or use a narrow `cast(...)` with the smallest possible scope.
+- Prefer `Protocol` or `TypedDict` over `getattr(...)` when code needs a capability or structured payload. For example, define a small capability protocol for `send_agui(...)` instead of probing `getattr(session, "send_agui", None)`.
+- Do not use `getattr(...)` to access fields on known Pydantic models, dataclasses, or discriminated unions. Access fields directly (`message.role`, `tool.name`) so MyPy can catch schema drift.
+- If compatibility with dynamic test doubles or SDK objects truly requires `getattr(...)`, isolate it in one helper, type the helper's return value, and explain the boundary in a short comment.
+- Avoid broad `dict[str, Any]` plumbing. If the shape is known, define a `TypedDict` or Pydantic model. If the shape is arbitrary JSON, use a JSON type alias rather than bare `Any`.
+- Do not silence typing with `# type: ignore` unless there is no practical alternative. Include the specific error code and a short reason.
+- Before committing, run MyPy against the touched files at minimum. If full `uv run mypy src/` fails because of unrelated missing third-party stubs, report that explicitly and include the focused MyPy command that passed.
+
 ### Docstring Standards (PEP 257)
 
 ```python
@@ -700,6 +775,17 @@ def test_uppercase_conversion(input_text, expected):
 1. **Arrange:** Set up test data and preconditions
 2. **Act:** Execute the code under test
 3. **Assert:** Verify the expected outcome
+
+---
+
+## Code Navigation: LSP vs Grep
+
+Use the right tool for the question.
+
+- **LSP / semantic tools:** references, definitions, type hierarchy, protocol implementations, call graphs, and symbol-aware refactors.
+- **Grep / ripgrep:** YAML, Markdown, `.env`, config keys, strings, TODOs, regex/partial patterns, and files that are not parseable Python.
+
+For repository-wide text search, prefer `rg` and `rg --files`.
 
 ---
 
@@ -1951,6 +2037,50 @@ make test               # Run all tests
 ```bash
 git add .
 git commit -m "feat: <description>"
+```
+
+---
+
+## End-to-End Deploy Validation Loop
+
+Run this loop only when the user explicitly asks for deploy validation. Do not run it automatically after every change. It builds a Docker image, pushes to GHCR, and rolls a live Azure Container Apps revision. Unit and integration tests are the default contract.
+
+The default sample is `sample/financial-assistant/claude` unless the user names a different agent.
+
+### Sequence
+
+```bash
+# 1. Build local wheel from the working tree
+rm -rf dist && uv build --wheel
+
+# 2. Build the local base image with the wheel baked in
+docker buildx build --platform linux/amd64 --no-cache \
+    -f docker/Dockerfile.local \
+    -t ghcr.io/justinbarias/holodeck-base:latest --load .
+
+# Verify the base carries the local wheel, not the published release
+docker run --rm --entrypoint python ghcr.io/justinbarias/holodeck-base:latest \
+    -c "import holodeck; print(holodeck.__version__)"
+
+# 3. Temporarily disable pull=True in src/holodeck/deploy/builder.py
+#    Revert this edit before committing.
+
+# 4. Build and push the agent image
+cd sample/financial-assistant/claude
+holodeck deploy build
+docker push ghcr.io/justinbarias/holodeck-financial-assistant:<tag>
+
+# 5. Deploy to Azure Container Apps
+holodeck deploy run
+
+# 6. Wait until /health is up, then exercise /awp
+URL=https://financial-assistant.nicemoss-50caf9f5.eastus.azurecontainerapps.io
+until curl -sf -o /dev/null --max-time 5 "$URL/health"; do sleep 3; done
+curl -sS -X POST "$URL/awp" -H 'content-type: application/json' \
+    -d '{"threadId":"v","runId":"r","state":{},"messages":[{"id":"m1","role":"user","content":"<your query>"}],"tools":[],"context":[],"forwardedProps":{}}' \
+    --max-time 180
+
+# 7. Revert the builder.py edit before committing
 ```
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,10 @@ security: ## Run security checks
 	# No-fix advisories where the vulnerable code path is unreachable for HoloDeck:
 	#   CVE-2026-0846  (nltk)    — nltk.util.filestring() path traversal; HoloDeck has no direct
 	#                              nltk usage (transitive via azure-ai-evaluation)
+	#   CVE-2026-45829 (chromadb) — pre-auth code injection in ChromaDB server API when a
+	#                              malicious model repo is accepted with trust_remote_code=true.
+	#                              No fixed chromadb release exists yet; documented in
+	#                              docs/guides/vector-stores.md.
 	#
 	# Cross-ecosystem mis-attribution: the following advisories describe bugs in the Ollama
 	# *Go server* (/api/pull endpoint, GGUF parser). The PyPI `ollama` package is an HTTP
@@ -187,6 +191,7 @@ security: ## Run security checks
 		--ignore-vuln CVE-2024-34997 \
 		--ignore-vuln CVE-2025-45768 \
 		--ignore-vuln CVE-2026-0846 \
+		--ignore-vuln CVE-2026-45829 \
 		--ignore-vuln CVE-2025-44779 \
 		--ignore-vuln CVE-2024-8063 \
 		--ignore-vuln CVE-2025-51471 \

--- a/docs/guides/vector-stores.md
+++ b/docs/guides/vector-stores.md
@@ -189,6 +189,15 @@ podman run -d \
 
 > **Version Pinning**: For stability, pin to a specific version (e.g., `chromadb/chroma:0.6.3`) instead of `latest` to avoid unexpected changes during upgrades.
 
+> **Security Advisory**: `chromadb` is currently affected by
+> [CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c](https://github.com/advisories/GHSA-f4j7-r4q5-qw2c),
+> a pre-authentication code injection issue in ChromaDB server versions 1.0.0
+> and later when the server accepts a malicious model repository with
+> `trust_remote_code=true`. As of this documentation update, upstream has not
+> published a fixed `chromadb` release. Until a fix is available, run ChromaDB
+> only on trusted networks, do not expose it directly to the public internet,
+> and treat model repository inputs as trusted administrative data.
+
 ---
 
 ## Setting Up PostgreSQL with pgvector

--- a/src/holodeck/chat/executor.py
+++ b/src/holodeck/chat/executor.py
@@ -6,7 +6,7 @@ import asyncio
 import time
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 from holodeck.lib.backends.base import (
     AgentBackend,
@@ -22,9 +22,32 @@ from holodeck.models.agent import Agent
 from holodeck.models.token_usage import TokenUsage
 from holodeck.models.tool_execution import ToolExecution, ToolStatus
 
+if TYPE_CHECKING:
+    from ag_ui.core import BaseEvent, RunAgentInput
+
 logger = get_logger(__name__)
 
 _SENTINEL = object()
+
+
+@runtime_checkable
+class _AGUISession(Protocol):
+    """Session capability for Claude-native AG-UI event streaming."""
+
+    def send_agui(
+        self,
+        input_data: RunAgentInput,
+        message_override: str | None = None,
+    ) -> AsyncGenerator[BaseEvent, None]:
+        """Stream AG-UI events for one run."""
+        ...
+
+
+def _require_agui_session(session: AgentSession | None) -> _AGUISession:
+    """Return *session* as AG-UI-capable or raise a clear runtime error."""
+    if session is None or not isinstance(session, _AGUISession):
+        raise AttributeError("Backend session does not support AG-UI streaming")
+    return cast(_AGUISession, session)
 
 
 @dataclass
@@ -209,6 +232,16 @@ class _TaskBoundSession:
             if isinstance(item, Exception):
                 raise item
             yield item
+
+    async def send_agui(
+        self,
+        input_data: RunAgentInput,
+        message_override: str | None = None,
+    ) -> AsyncGenerator[BaseEvent, None]:
+        """Stream AG-UI events from the wrapped session when supported."""
+        session = _require_agui_session(self._session)
+        async for event in session.send_agui(input_data, message_override):
+            yield event
 
     @property
     def tool_events(self) -> asyncio.Queue[ToolEvent] | None:
@@ -453,6 +486,22 @@ class AgentExecutor:
             raise
         except BackendInitError as e:
             raise RuntimeError(f"Agent streaming failed: {e}") from e
+
+    async def execute_turn_agui(
+        self,
+        input_data: RunAgentInput,
+        message_override: str | None = None,
+    ) -> AsyncGenerator[BaseEvent, None]:
+        """Execute an AG-UI turn through a backend session that supports it."""
+        try:
+            await self._ensure_backend_and_session()
+            session = _require_agui_session(self._session)
+            async for event in session.send_agui(input_data, message_override):
+                yield event
+        except BackendSessionError:
+            raise
+        except BackendInitError as e:
+            raise RuntimeError(f"Agent AG-UI execution failed: {e}") from e
 
     def get_history(self) -> list[dict[str, Any]]:
         """Get current conversation history.

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dataclasses
 import json
 import logging
 from collections.abc import AsyncGenerator
@@ -17,7 +18,51 @@ from pathlib import Path
 from typing import Any, cast
 
 import claude_agent_sdk
-import jsonschema
+import jsonschema  # type: ignore[import-untyped]
+from ag_ui.core import (
+    AssistantMessage as AguiAssistantMessage,
+)
+from ag_ui.core import (
+    BaseEvent,
+    CustomEvent,
+    EventType,
+    MessagesSnapshotEvent,
+    ReasoningEncryptedValueEvent,
+    ReasoningEndEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
+    ReasoningMessageStartEvent,
+    ReasoningStartEvent,
+    RunAgentInput,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StateSnapshotEvent,
+    TextMessageContentEvent,
+    TextMessageEndEvent,
+    TextMessageStartEvent,
+    ToolCallArgsEvent,
+    ToolCallEndEvent,
+    ToolCallResultEvent,
+    ToolCallStartEvent,
+)
+from ag_ui.core import (
+    FunctionCall as AguiFunctionCall,
+)
+from ag_ui.core import (
+    Message as AguiMessage,
+)
+from ag_ui.core import (
+    Tool as AguiTool,
+)
+from ag_ui.core import (
+    ToolCall as AguiToolCall,
+)
+from ag_ui.core import (
+    ToolMessage as AguiToolMessage,
+)
+from ag_ui.core import (
+    UserMessage as AguiUserMessage,
+)
 from claude_agent_sdk import (
     ClaudeAgentOptions,
     HookMatcher,
@@ -28,7 +73,11 @@ from claude_agent_sdk.types import (
     AgentDefinition,
     HookContext,
     HookEvent,
+    HookInput,
     McpSdkServerConfig,
+    PostToolUseFailureHookInput,
+    PostToolUseHookInput,
+    PreToolUseHookInput,
     SyncHookJSONOutput,
 )
 from exceptiongroup import BaseExceptionGroup
@@ -67,6 +116,27 @@ logger = logging.getLogger(__name__)
 
 _MAX_RETRIES = 3
 _BACKOFF_BASE_SECONDS = 1
+_AGUI_MCP_SERVER_NAME = "ag_ui"
+_AGUI_STATE_TOOL_NAME = "ag_ui_update_state"
+_AGUI_STATE_TOOL_FULL_NAME = "mcp__ag_ui__ag_ui_update_state"
+_AGUI_FORWARDED_PROPS: frozenset[str] = frozenset(
+    {
+        "resume",
+        "fork_session",
+        "model",
+        "fallback_model",
+        "max_turns",
+        "max_budget_usd",
+        "max_thinking_tokens",
+        "include_partial_messages",
+        "strict_mcp_config",
+        "betas",
+        "enable_file_checkpointing",
+        "effort",
+        "thinking",
+        "output_format",
+    }
+)
 
 # ---------------------------------------------------------------------------
 # Private helpers
@@ -132,6 +202,258 @@ def _enrich_tool_results(
         if "name" not in tr and tr.get("call_id") in id_to_name:
             tr["name"] = id_to_name[tr["call_id"]]
     return tool_results
+
+
+def _fix_surrogates(value: str) -> str:
+    """Reassemble UTF-16 surrogate pairs before Pydantic serialization."""
+    try:
+        return value.encode("utf-16", "surrogatepass").decode("utf-16")
+    except (UnicodeDecodeError, UnicodeEncodeError):
+        return value.encode("utf-8", "replace").decode("utf-8")
+
+
+def _fix_surrogates_deep(value: Any) -> Any:
+    """Recursively fix surrogate pairs in nested structures."""
+    if isinstance(value, str):
+        return _fix_surrogates(value)
+    if isinstance(value, dict):
+        return {
+            _fix_surrogates(k) if isinstance(k, str) else k: _fix_surrogates_deep(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_fix_surrogates_deep(v) for v in value]
+    return value
+
+
+def _strip_mcp_prefix(tool_name: str) -> str:
+    """Return frontend-facing tool name for SDK MCP tool identifiers."""
+    if tool_name.startswith("mcp__"):
+        parts = tool_name.split("__")
+        if len(parts) >= 3:
+            return "__".join(parts[2:])
+    return tool_name
+
+
+def _is_agui_state_tool(tool_name: str | None) -> bool:
+    """Return True when *tool_name* is the internal AG-UI state tool."""
+    return tool_name in {_AGUI_STATE_TOOL_NAME, _AGUI_STATE_TOOL_FULL_NAME}
+
+
+def _agui_tool_names(tools: list[AguiTool] | None) -> list[str]:
+    """Extract frontend tool names from AG-UI tool definitions."""
+    return [tool_def.name for tool_def in tools or [] if tool_def.name]
+
+
+def _agui_message_content(message: AguiMessage) -> str:
+    """Extract plain text content from an AG-UI message object."""
+    if isinstance(message, AguiAssistantMessage):
+        return str(message.content or "")
+    if isinstance(message, AguiToolMessage):
+        return str(message.content)
+    if isinstance(message, AguiUserMessage):
+        user_content = message.content
+        if isinstance(user_content, str):
+            return user_content
+        return " ".join(block.text for block in user_content if block.type == "text")
+    other_content = message.content
+    if isinstance(other_content, str):
+        return other_content
+    return ""
+
+
+def _agui_message_role(message: AguiMessage) -> str:
+    """Extract the AG-UI role from a message object."""
+    return str(message.role)
+
+
+def _agui_tool_call_id(message: AguiMessage) -> str:
+    """Extract the AG-UI tool call id from a tool message."""
+    if isinstance(message, AguiToolMessage):
+        return str(message.tool_call_id)
+    return ""
+
+
+def _agui_message_transcript_line(message: AguiMessage) -> str:
+    """Render one AG-UI message into a compact prompt transcript line."""
+    role = _agui_message_role(message)
+    content = _agui_message_content(message)
+    if isinstance(message, AguiAssistantMessage):
+        rendered_calls: list[str] = []
+        for call in message.tool_calls or []:
+            rendered_calls.append(
+                "tool_call "
+                f"id={call.id} "
+                f"name={call.function.name} "
+                f"arguments={call.function.arguments}"
+            )
+        if rendered_calls:
+            call_text = "; ".join(rendered_calls)
+            return f"assistant: {content}\nassistant_tool_calls: {call_text}"
+    if isinstance(message, AguiToolMessage):
+        return f"tool_result id={_agui_tool_call_id(message)}: {content}"
+    return f"{role}: {content}"
+
+
+def _agui_frontend_tool_resume_prompt(input_data: RunAgentInput) -> str:
+    """Build a continuation prompt when AG-UI resumes after a frontend tool."""
+    messages = input_data.messages or []
+    transcript = "\n".join(
+        _agui_message_transcript_line(message) for message in messages[-20:]
+    )
+    return (
+        "Continue the AG-UI conversation from this transcript.\n\n"
+        "The latest frontend tool result has already been executed by the UI. "
+        "Use that result to continue the conversation. Do not call the same "
+        "frontend tool again unless the result is missing, invalid, or the user "
+        "explicitly asks to run it again.\n\n"
+        f"{transcript}"
+    )
+
+
+def _agui_prompt_from_input(
+    input_data: RunAgentInput,
+    message_override: str | None = None,
+) -> str:
+    """Return the latest AG-UI message payload to send to Claude."""
+    if message_override is not None:
+        return message_override
+    messages = input_data.messages or []
+    if not messages:
+        return ""
+    if _agui_message_role(messages[-1]) == "tool":
+        return _agui_frontend_tool_resume_prompt(input_data)
+    return _agui_message_content(messages[-1])
+
+
+def _agui_state_context_addendum(input_data: RunAgentInput) -> str:
+    """Build a system-prompt addendum for AG-UI context and shared state."""
+    parts: list[str] = []
+    if input_data.context:
+        parts.append("## Context from the application")
+        for context in input_data.context:
+            parts.append(f"- {context.description}: {context.value}")
+        parts.append("")
+    if input_data.state is not None:
+        parts.append("## Current Shared State")
+        parts.append("This state is shared with the frontend UI and can be updated.")
+        try:
+            state_json = json.dumps(input_data.state, indent=2)
+        except (TypeError, ValueError):
+            state_json = str(input_data.state)
+        parts.append(f"```json\n{state_json}\n```")
+        parts.append("")
+        parts.append(
+            "To update this state, use the `ag_ui_update_state` tool with your "
+            "changes."
+        )
+        parts.append("")
+    return "\n".join(parts)
+
+
+def _make_agui_frontend_tool(tool_def: AguiTool) -> Any:
+    """Convert an AG-UI Tool definition to a Claude SDK MCP proxy tool."""
+    from claude_agent_sdk import tool
+
+    @tool(tool_def.name, tool_def.description, tool_def.parameters or {})
+    async def frontend_tool_stub(args: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "content": [{"type": "text", "text": "Tool call forwarded to AG-UI client"}]
+        }
+
+    return frontend_tool_stub
+
+
+def _make_agui_state_tool() -> Any:
+    """Create the internal AG-UI state update tool."""
+    from claude_agent_sdk import tool
+
+    @tool(
+        _AGUI_STATE_TOOL_NAME,
+        "Update the shared application state visible to the AG-UI frontend.",
+        {"state_updates": dict},
+    )
+    async def update_state_tool(args: dict[str, Any]) -> dict[str, Any]:
+        return {"content": [{"type": "text", "text": "State updated"}]}
+
+    return update_state_tool
+
+
+def _clone_options(options: ClaudeAgentOptions, **updates: Any) -> ClaudeAgentOptions:
+    """Clone ``ClaudeAgentOptions`` without mutating the session base options."""
+    try:
+        return dataclasses.replace(options, **updates)
+    except TypeError:
+        for key, value in updates.items():
+            setattr(options, key, value)
+        return options
+
+
+def _agui_tool_result_content(content: Any) -> str:
+    """Normalize Claude SDK tool-result content for AG-UI."""
+    if content is None:
+        return ""
+    try:
+        if isinstance(content, list) and content:
+            first = content[0]
+            if isinstance(first, dict) and first.get("type") == "text":
+                text = str(first.get("text", ""))
+                try:
+                    return json.dumps(json.loads(text))
+                except (json.JSONDecodeError, ValueError):
+                    return _fix_surrogates(text)
+            return _fix_surrogates(json.dumps(content))
+        return _fix_surrogates(json.dumps(content))
+    except (TypeError, ValueError):
+        return _fix_surrogates(str(content))
+
+
+def _agui_assistant_message_from_sdk(
+    sdk_message: Any,
+    message_id: str,
+) -> AguiAssistantMessage | None:
+    """Convert a complete Claude SDK AssistantMessage to AG-UI history."""
+    text = ""
+    tool_calls: list[AguiToolCall] = []
+    for block in getattr(sdk_message, "content", []) or []:
+        block_type = getattr(block, "type", None)
+        block_cls = block.__class__.__name__
+        if block_type == "text" or block_cls == "TextBlock":
+            text += getattr(block, "text", "")
+        elif block_type == "tool_use" or block_cls == "ToolUseBlock":
+            raw_name = getattr(block, "name", "")
+            if _is_agui_state_tool(raw_name):
+                continue
+            tool_id = getattr(block, "id", "")
+            tool_input = getattr(block, "input", {}) or {}
+            tool_calls.append(
+                AguiToolCall(
+                    id=tool_id,
+                    type="function",
+                    function=AguiFunctionCall(
+                        name=_strip_mcp_prefix(raw_name),
+                        arguments=json.dumps(tool_input),
+                    ),
+                )
+            )
+    if not text and not tool_calls:
+        return None
+    return AguiAssistantMessage(
+        id=message_id,
+        role="assistant",
+        content=text or None,
+        tool_calls=tool_calls or None,
+    )
+
+
+def _agui_tool_message(tool_use_id: str, content: Any) -> AguiToolMessage:
+    """Convert a Claude SDK ToolResultBlock to AG-UI tool history."""
+    return AguiToolMessage(
+        id=f"{tool_use_id}-result",
+        role="tool",
+        content=_agui_tool_result_content(content),
+        tool_call_id=tool_use_id,
+    )
 
 
 def _extract_result_text(content: list[Any]) -> str:
@@ -599,46 +921,49 @@ def _build_tool_hooks(
     """
 
     async def _on_pre_tool(
-        input_data: Any,
+        input_data: HookInput,
         tool_use_id: str | None,
         context: HookContext,
     ) -> SyncHookJSONOutput:
+        tool_input = cast(PreToolUseHookInput, input_data)
         await queue.put(
             ToolEvent(
                 kind="start",
-                tool_name=input_data["tool_name"],
-                tool_use_id=input_data["tool_use_id"],
-                tool_input=input_data.get("tool_input"),
+                tool_name=tool_input["tool_name"],
+                tool_use_id=tool_input["tool_use_id"],
+                tool_input=tool_input.get("tool_input"),
             )
         )
         return SyncHookJSONOutput()
 
     async def _on_post_tool(
-        input_data: Any,
+        input_data: HookInput,
         tool_use_id: str | None,
         context: HookContext,
     ) -> SyncHookJSONOutput:
+        tool_input = cast(PostToolUseHookInput, input_data)
         await queue.put(
             ToolEvent(
                 kind="end",
-                tool_name=input_data["tool_name"],
-                tool_use_id=input_data["tool_use_id"],
-                tool_response=str(input_data.get("tool_response", "")),
+                tool_name=tool_input["tool_name"],
+                tool_use_id=tool_input["tool_use_id"],
+                tool_response=str(tool_input.get("tool_response", "")),
             )
         )
         return SyncHookJSONOutput()
 
     async def _on_post_tool_failure(
-        input_data: Any,
+        input_data: HookInput,
         tool_use_id: str | None,
         context: HookContext,
     ) -> SyncHookJSONOutput:
+        tool_input = cast(PostToolUseFailureHookInput, input_data)
         await queue.put(
             ToolEvent(
                 kind="error",
-                tool_name=input_data["tool_name"],
-                tool_use_id=input_data["tool_use_id"],
-                error=str(input_data.get("error", "")),
+                tool_name=tool_input["tool_name"],
+                tool_use_id=tool_input["tool_use_id"],
+                error=str(tool_input.get("error", "")),
             )
         )
         return SyncHookJSONOutput()
@@ -825,6 +1150,64 @@ class ClaudeSession:
             self._base_options.hooks = merged
             return self._base_options
 
+    def _options_for_agui(self, input_data: RunAgentInput) -> ClaudeAgentOptions:
+        """Return per-run Claude options for an AG-UI request.
+
+        This keeps HoloDeck's base options authoritative while adding only the
+        AG-UI-specific runtime surface: partial streaming, state/context prompt
+        addendum, dynamic frontend tools, and the internal state update tool.
+        """
+        options = self._base_options
+        fields = {field.name for field in dataclasses.fields(ClaudeAgentOptions)}
+
+        updates: dict[str, Any] = {"include_partial_messages": True}
+
+        if self._sdk_session_id is not None:
+            updates["resume"] = self._sdk_session_id
+
+        if isinstance(input_data.forwarded_props, dict):
+            for key, value in input_data.forwarded_props.items():
+                if key in _AGUI_FORWARDED_PROPS and key in fields and value is not None:
+                    updates[key] = value
+                elif key not in _AGUI_FORWARDED_PROPS:
+                    logger.warning("Ignoring unsupported AG-UI forwardedProp: %s", key)
+
+        addendum = _agui_state_context_addendum(input_data)
+        if addendum:
+            base_prompt = updates.get("system_prompt", options.system_prompt) or ""
+            updates["system_prompt"] = (
+                f"{base_prompt}\n\n{addendum}" if base_prompt else addendum
+            )
+
+        frontend_tools = [_make_agui_frontend_tool(t) for t in input_data.tools or []]
+        agui_tools = [*frontend_tools, _make_agui_state_tool()]
+
+        allowed_tools = list(options.allowed_tools or [])
+        for name in _agui_tool_names(input_data.tools):
+            full_name = f"mcp__{_AGUI_MCP_SERVER_NAME}__{name}"
+            if full_name not in allowed_tools:
+                allowed_tools.append(full_name)
+        if _AGUI_STATE_TOOL_FULL_NAME not in allowed_tools:
+            allowed_tools.append(_AGUI_STATE_TOOL_FULL_NAME)
+        updates["allowed_tools"] = allowed_tools
+
+        if agui_tools:
+            from claude_agent_sdk import create_sdk_mcp_server
+
+            existing_servers = (
+                dict(options.mcp_servers)
+                if isinstance(options.mcp_servers, dict)
+                else {}
+            )
+            existing_servers[_AGUI_MCP_SERVER_NAME] = create_sdk_mcp_server(
+                _AGUI_MCP_SERVER_NAME,
+                "1.0.0",
+                tools=agui_tools,
+            )
+            updates["mcp_servers"] = existing_servers
+
+        return _clone_options(options, **updates)
+
     async def prepare(self) -> None:
         """No-op under spec 034 P4.
 
@@ -987,6 +1370,449 @@ class ClaudeSession:
                 raise BackendSessionError(
                     f"subprocess terminated unexpectedly: {exc}"
                 ) from exc
+
+    async def send_agui(
+        self,
+        input_data: RunAgentInput,
+        message_override: str | None = None,
+    ) -> AsyncGenerator[BaseEvent, None]:
+        """Send an AG-UI request through this Claude session.
+
+        Yields AG-UI events translated directly from Claude SDK stream messages.
+        """
+        async with self._send_lock:
+            thread_id = input_data.thread_id
+            run_id = input_data.run_id
+            options = self._options_for_agui(input_data)
+            prompt = _agui_prompt_from_input(input_data, message_override)
+            frontend_tool_names = set(_agui_tool_names(input_data.tools))
+            current_state = input_data.state
+            result_data: dict[str, Any] | None = None
+
+            yield RunStartedEvent(
+                type=EventType.RUN_STARTED,
+                thread_id=thread_id,
+                run_id=run_id,
+                parent_run_id=input_data.parent_run_id,
+                input=input_data,
+            )
+            if input_data.state is not None:
+                yield StateSnapshotEvent(
+                    type=EventType.STATE_SNAPSHOT,
+                    snapshot=input_data.state,
+                )
+
+            try:
+                message_stream = claude_agent_sdk.query(
+                    prompt=_streaming_user_envelope(prompt),
+                    options=options,
+                )
+                async for event in self._stream_agui_messages(
+                    message_stream=message_stream,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    input_data=input_data,
+                    frontend_tool_names=frontend_tool_names,
+                    current_state=current_state,
+                ):
+                    if isinstance(event, dict):
+                        current_state = event.get("state", current_state)
+                        if "result" in event:
+                            result_data = event["result"]
+                        continue
+                    yield event
+
+                self._turn_count += 1
+                yield RunFinishedEvent(
+                    type=EventType.RUN_FINISHED,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    result=result_data,
+                )
+            except (ProcessError, CLIConnectionError) as exc:
+                raise BackendSessionError(
+                    f"subprocess terminated unexpectedly: {exc}"
+                ) from exc
+
+    async def _stream_agui_messages(
+        self,
+        *,
+        message_stream: Any,
+        thread_id: str,
+        run_id: str,
+        input_data: RunAgentInput,
+        frontend_tool_names: set[str],
+        current_state: Any,
+    ) -> AsyncGenerator[BaseEvent | dict[str, Any], None]:
+        """Translate Claude SDK message stream to AG-UI events."""
+        current_message_id: str | None = None
+        has_streamed_text = False
+        in_reasoning = False
+        reasoning_message_id: str | None = None
+        accumulated_signature = ""
+        current_tool_call_id: str | None = None
+        current_tool_call_name: str | None = None
+        current_tool_display_name: str | None = None
+        accumulated_tool_json = ""
+        processed_tool_ids: set[str] = set()
+        halt_stream = False
+        run_messages: list[Any] = []
+        pending_msg: dict[str, Any] | None = None
+
+        def upsert_message(message: Any) -> None:
+            msg_id = message.get("id") if isinstance(message, dict) else message.id
+            for idx, existing in enumerate(run_messages):
+                existing_id = (
+                    existing.get("id") if isinstance(existing, dict) else existing.id
+                )
+                if existing_id == msg_id:
+                    run_messages[idx] = message
+                    return
+            run_messages.append(message)
+
+        def flush_pending_msg() -> None:
+            nonlocal pending_msg
+            if pending_msg is None:
+                return
+            has_content = bool(pending_msg.get("content"))
+            has_tools = bool(pending_msg.get("tool_calls"))
+            if has_content or has_tools:
+                upsert_message(
+                    AguiAssistantMessage(
+                        id=pending_msg["id"],
+                        role="assistant",
+                        content=pending_msg["content"] if has_content else None,
+                        tool_calls=pending_msg["tool_calls"] if has_tools else None,
+                    )
+                )
+            pending_msg = None
+
+        async for message in message_stream:
+            if halt_stream:
+                break
+
+            cls_name = message.__class__.__name__
+
+            if cls_name == "StreamEvent":
+                event_data = getattr(message, "event", {}) or {}
+                event_type = event_data.get("type")
+
+                if event_type == "message_start":
+                    current_message_id = str(ULID())
+                    has_streamed_text = False
+                    pending_msg = {
+                        "id": current_message_id,
+                        "content": "",
+                        "tool_calls": [],
+                    }
+
+                elif event_type == "content_block_start":
+                    block_data = event_data.get("content_block", {}) or {}
+                    block_type = block_data.get("type")
+                    if block_type == "thinking":
+                        in_reasoning = True
+                        reasoning_message_id = str(ULID())
+                        yield ReasoningStartEvent(
+                            type=EventType.REASONING_START,
+                            message_id=reasoning_message_id,
+                        )
+                        yield ReasoningMessageStartEvent(
+                            type=EventType.REASONING_MESSAGE_START,
+                            message_id=reasoning_message_id,
+                            role="reasoning",
+                        )
+                    elif block_type == "tool_use":
+                        current_tool_call_id = block_data.get("id")
+                        current_tool_call_name = block_data.get("name", "unknown")
+                        current_tool_display_name = _strip_mcp_prefix(
+                            current_tool_call_name
+                        )
+                        accumulated_tool_json = ""
+                        if current_tool_call_id:
+                            processed_tool_ids.add(current_tool_call_id)
+                            yield ToolCallStartEvent(
+                                type=EventType.TOOL_CALL_START,
+                                tool_call_id=current_tool_call_id,
+                                tool_call_name=current_tool_display_name,
+                                parent_message_id=current_message_id,
+                            )
+
+                elif event_type == "content_block_delta":
+                    delta_data = event_data.get("delta", {}) or {}
+                    delta_type = delta_data.get("type")
+                    if delta_type == "text_delta":
+                        text = _fix_surrogates(delta_data.get("text", ""))
+                        if text and current_message_id:
+                            if not has_streamed_text:
+                                yield TextMessageStartEvent(
+                                    type=EventType.TEXT_MESSAGE_START,
+                                    message_id=current_message_id,
+                                    role="assistant",
+                                )
+                            has_streamed_text = True
+                            if pending_msg is not None:
+                                pending_msg["content"] += text
+                            yield TextMessageContentEvent(
+                                type=EventType.TEXT_MESSAGE_CONTENT,
+                                message_id=current_message_id,
+                                delta=text,
+                            )
+                    elif delta_type == "thinking_delta":
+                        text = _fix_surrogates(delta_data.get("thinking", ""))
+                        if text and reasoning_message_id:
+                            yield ReasoningMessageContentEvent(
+                                type=EventType.REASONING_MESSAGE_CONTENT,
+                                message_id=reasoning_message_id,
+                                delta=text,
+                            )
+                    elif delta_type == "signature_delta":
+                        accumulated_signature += delta_data.get("signature", "")
+                    elif delta_type == "input_json_delta":
+                        partial_json = delta_data.get("partial_json", "")
+                        if partial_json and current_tool_call_id:
+                            accumulated_tool_json += partial_json
+                            yield ToolCallArgsEvent(
+                                type=EventType.TOOL_CALL_ARGS,
+                                tool_call_id=current_tool_call_id,
+                                delta=_fix_surrogates(partial_json),
+                            )
+
+                elif event_type == "content_block_stop":
+                    if in_reasoning and reasoning_message_id:
+                        yield ReasoningMessageEndEvent(
+                            type=EventType.REASONING_MESSAGE_END,
+                            message_id=reasoning_message_id,
+                        )
+                        yield ReasoningEndEvent(
+                            type=EventType.REASONING_END,
+                            message_id=reasoning_message_id,
+                        )
+                        if accumulated_signature and current_message_id:
+                            yield ReasoningEncryptedValueEvent(
+                                type=EventType.REASONING_ENCRYPTED_VALUE,
+                                subtype="message",
+                                entity_id=current_message_id,
+                                encrypted_value=accumulated_signature,
+                            )
+                        in_reasoning = False
+                        reasoning_message_id = None
+                        accumulated_signature = ""
+
+                    if current_tool_call_id:
+                        if _is_agui_state_tool(current_tool_call_name):
+                            try:
+                                parsed = json.loads(
+                                    _fix_surrogates(accumulated_tool_json)
+                                )
+                                updates = parsed.get("state_updates", parsed)
+                                if isinstance(updates, str):
+                                    updates = json.loads(updates)
+                                if isinstance(current_state, dict) and isinstance(
+                                    updates, dict
+                                ):
+                                    current_state = {**current_state, **updates}
+                                else:
+                                    current_state = updates
+                                current_state = _fix_surrogates_deep(current_state)
+                                yield StateSnapshotEvent(
+                                    type=EventType.STATE_SNAPSHOT,
+                                    snapshot=current_state,
+                                )
+                                yield {"state": current_state}
+                            except (json.JSONDecodeError, ValueError, TypeError) as exc:
+                                yield CustomEvent(
+                                    type=EventType.CUSTOM,
+                                    name="state_update_error",
+                                    value={"error": str(exc)},
+                                )
+                        elif pending_msg is not None and current_tool_display_name:
+                            pending_msg["tool_calls"].append(
+                                AguiToolCall(
+                                    id=current_tool_call_id,
+                                    type="function",
+                                    function=AguiFunctionCall(
+                                        name=current_tool_display_name,
+                                        arguments=_fix_surrogates(
+                                            accumulated_tool_json
+                                        ),
+                                    ),
+                                )
+                            )
+
+                        yield ToolCallEndEvent(
+                            type=EventType.TOOL_CALL_END,
+                            tool_call_id=current_tool_call_id,
+                        )
+                        if current_tool_display_name in frontend_tool_names:
+                            flush_pending_msg()
+                            if current_message_id and has_streamed_text:
+                                yield TextMessageEndEvent(
+                                    type=EventType.TEXT_MESSAGE_END,
+                                    message_id=current_message_id,
+                                )
+                                current_message_id = None
+                                has_streamed_text = False
+                            halt_stream = True
+                        current_tool_call_id = None
+                        current_tool_call_name = None
+                        current_tool_display_name = None
+                        accumulated_tool_json = ""
+
+                elif event_type == "message_stop":
+                    flush_pending_msg()
+                    if current_message_id and has_streamed_text:
+                        yield TextMessageEndEvent(
+                            type=EventType.TEXT_MESSAGE_END,
+                            message_id=current_message_id,
+                        )
+                    current_message_id = None
+                continue
+
+            if cls_name == "AssistantMessage":
+                msg_id = current_message_id or str(ULID())
+                agui_message = _agui_assistant_message_from_sdk(message, msg_id)
+                if agui_message is not None:
+                    upsert_message(agui_message)
+
+                for block in getattr(message, "content", []) or []:
+                    if block.__class__.__name__ != "ToolUseBlock":
+                        continue
+                    tool_id = getattr(block, "id", None)
+                    if not tool_id or tool_id in processed_tool_ids:
+                        continue
+                    raw_name = getattr(block, "name", "unknown")
+                    display_name = _strip_mcp_prefix(raw_name)
+                    tool_input = getattr(block, "input", {}) or {}
+                    if _is_agui_state_tool(raw_name):
+                        updates = tool_input.get("state_updates", tool_input)
+                        if isinstance(updates, str):
+                            updates = json.loads(updates)
+                        if isinstance(current_state, dict) and isinstance(
+                            updates, dict
+                        ):
+                            current_state = {**current_state, **updates}
+                        else:
+                            current_state = updates
+                        current_state = _fix_surrogates_deep(current_state)
+                        yield StateSnapshotEvent(
+                            type=EventType.STATE_SNAPSHOT,
+                            snapshot=current_state,
+                        )
+                        yield {"state": current_state}
+                        continue
+                    processed_tool_ids.add(tool_id)
+                    yield ToolCallStartEvent(
+                        type=EventType.TOOL_CALL_START,
+                        tool_call_id=tool_id,
+                        tool_call_name=display_name,
+                        parent_message_id=msg_id,
+                    )
+                    yield ToolCallArgsEvent(
+                        type=EventType.TOOL_CALL_ARGS,
+                        tool_call_id=tool_id,
+                        delta=json.dumps(tool_input),
+                    )
+                    yield ToolCallEndEvent(
+                        type=EventType.TOOL_CALL_END,
+                        tool_call_id=tool_id,
+                    )
+                    if display_name in frontend_tool_names:
+                        halt_stream = True
+                        break
+
+            elif cls_name == "UserMessage":
+                for block in getattr(message, "content", []) or []:
+                    if block.__class__.__name__ != "ToolResultBlock":
+                        continue
+                    tool_use_id = getattr(block, "tool_use_id", None)
+                    if not tool_use_id:
+                        continue
+                    content = getattr(block, "content", None)
+                    upsert_message(_agui_tool_message(tool_use_id, content))
+                    yield ToolCallResultEvent(
+                        type=EventType.TOOL_CALL_RESULT,
+                        message_id=f"{tool_use_id}-result",
+                        tool_call_id=tool_use_id,
+                        content=_agui_tool_result_content(content),
+                        role="tool",
+                    )
+
+            elif cls_name == "SystemMessage":
+                subtype = getattr(message, "subtype", "") or "unknown"
+                yield CustomEvent(
+                    type=EventType.CUSTOM,
+                    name=f"system:{subtype}",
+                    value=getattr(message, "data", {}) or {},
+                )
+
+            elif cls_name == "ResultMessage":
+                result_data = {
+                    "is_error": getattr(message, "is_error", None),
+                    "duration_ms": getattr(message, "duration_ms", None),
+                    "duration_api_ms": getattr(message, "duration_api_ms", None),
+                    "num_turns": getattr(message, "num_turns", None),
+                    "total_cost_usd": getattr(message, "total_cost_usd", None),
+                    "usage": getattr(message, "usage", None),
+                    "structured_output": getattr(message, "structured_output", None),
+                }
+                captured = getattr(message, "session_id", None)
+                if (
+                    self._sdk_session_id is None
+                    and isinstance(captured, str)
+                    and captured
+                ):
+                    self._sdk_session_id = captured
+                result_text = getattr(message, "result", None)
+                if result_text and not has_streamed_text:
+                    result_msg_id = str(ULID())
+                    yield TextMessageStartEvent(
+                        type=EventType.TEXT_MESSAGE_START,
+                        message_id=result_msg_id,
+                        role="assistant",
+                    )
+                    yield TextMessageContentEvent(
+                        type=EventType.TEXT_MESSAGE_CONTENT,
+                        message_id=result_msg_id,
+                        delta=result_text,
+                    )
+                    yield TextMessageEndEvent(
+                        type=EventType.TEXT_MESSAGE_END,
+                        message_id=result_msg_id,
+                    )
+                    upsert_message(
+                        AguiAssistantMessage(
+                            id=result_msg_id,
+                            role="assistant",
+                            content=result_text,
+                        )
+                    )
+                yield {"result": result_data}
+
+        if current_tool_call_id:
+            yield ToolCallEndEvent(
+                type=EventType.TOOL_CALL_END,
+                tool_call_id=current_tool_call_id,
+            )
+        if in_reasoning and reasoning_message_id:
+            yield ReasoningMessageEndEvent(
+                type=EventType.REASONING_MESSAGE_END,
+                message_id=reasoning_message_id,
+            )
+            yield ReasoningEndEvent(
+                type=EventType.REASONING_END,
+                message_id=reasoning_message_id,
+            )
+        if has_streamed_text and current_message_id:
+            yield TextMessageEndEvent(
+                type=EventType.TEXT_MESSAGE_END,
+                message_id=current_message_id,
+            )
+        flush_pending_msg()
+        if run_messages:
+            yield MessagesSnapshotEvent(
+                type=EventType.MESSAGES_SNAPSHOT,
+                messages=[*(input_data.messages or []), *run_messages],
+            )
 
     async def release_transport(self) -> None:
         """No-op under spec 034 P4.

--- a/src/holodeck/lib/backends/claude_backend.py
+++ b/src/holodeck/lib/backends/claude_backend.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy
 import dataclasses
+import inspect
 import json
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterable
 from pathlib import Path
 from typing import Any, cast
 
@@ -67,6 +69,7 @@ from claude_agent_sdk import (
     ClaudeAgentOptions,
     HookMatcher,
     ProcessError,
+    tool,
 )
 from claude_agent_sdk._errors import CLIConnectionError, MessageParseError
 from claude_agent_sdk.types import (
@@ -137,6 +140,49 @@ _AGUI_FORWARDED_PROPS: frozenset[str] = frozenset(
         "output_format",
     }
 )
+_AGUI_STATE_TOOL_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "state_updates": {
+            "type": "object",
+            "additionalProperties": True,
+        }
+    },
+    "required": ["state_updates"],
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class _AguiStreamStateUpdate:
+    """Internal stream item carrying updated AG-UI state to the caller."""
+
+    state: Any
+
+
+@dataclasses.dataclass(frozen=True)
+class _AguiStreamResult:
+    """Internal stream item carrying Claude result metadata to the caller."""
+
+    result: dict[str, Any]
+
+
+@dataclasses.dataclass(frozen=True)
+class _AguiSdkToolUseBlock:
+    """Normalized SDK tool-use block for AG-UI conversion."""
+
+    tool_id: str
+    raw_name: str
+    display_name: str
+    tool_input: dict[str, Any]
+
+
+@dataclasses.dataclass(frozen=True)
+class _AguiSdkToolResultBlock:
+    """Normalized SDK tool-result block for AG-UI conversion."""
+
+    tool_use_id: str
+    content: Any
+
 
 # ---------------------------------------------------------------------------
 # Private helpers
@@ -353,7 +399,6 @@ def _agui_state_context_addendum(input_data: RunAgentInput) -> str:
 
 def _make_agui_frontend_tool(tool_def: AguiTool) -> Any:
     """Convert an AG-UI Tool definition to a Claude SDK MCP proxy tool."""
-    from claude_agent_sdk import tool
 
     @tool(tool_def.name, tool_def.description, tool_def.parameters or {})
     async def frontend_tool_stub(args: dict[str, Any]) -> dict[str, Any]:
@@ -366,12 +411,11 @@ def _make_agui_frontend_tool(tool_def: AguiTool) -> Any:
 
 def _make_agui_state_tool() -> Any:
     """Create the internal AG-UI state update tool."""
-    from claude_agent_sdk import tool
 
     @tool(
         _AGUI_STATE_TOOL_NAME,
         "Update the shared application state visible to the AG-UI frontend.",
-        {"state_updates": dict},
+        _AGUI_STATE_TOOL_SCHEMA,
     )
     async def update_state_tool(args: dict[str, Any]) -> dict[str, Any]:
         return {"content": [{"type": "text", "text": "State updated"}]}
@@ -382,11 +426,14 @@ def _make_agui_state_tool() -> Any:
 def _clone_options(options: ClaudeAgentOptions, **updates: Any) -> ClaudeAgentOptions:
     """Clone ``ClaudeAgentOptions`` without mutating the session base options."""
     try:
-        return dataclasses.replace(options, **updates)
+        dataclasses.fields(options)
     except TypeError:
+        cloned = copy.copy(options)
         for key, value in updates.items():
-            setattr(options, key, value)
-        return options
+            setattr(cloned, key, value)
+        return cloned
+    else:
+        return dataclasses.replace(options, **updates)
 
 
 def _agui_tool_result_content(content: Any) -> str:
@@ -406,6 +453,76 @@ def _agui_tool_result_content(content: Any) -> str:
         return _fix_surrogates(json.dumps(content))
     except (TypeError, ValueError):
         return _fix_surrogates(str(content))
+
+
+def _sdk_content_blocks(sdk_message: object) -> list[Any]:
+    """Return Claude SDK content blocks while containing dynamic SDK access.
+
+    The Claude SDK content block classes are not stable public typing surfaces,
+    and unit tests use lightweight SDK-shaped doubles. Keep the ``getattr``
+    boundary here so stream translation stays typed after normalization.
+    """
+    content = getattr(sdk_message, "content", None)
+    if content is None:
+        return []
+    if isinstance(content, list):
+        return content
+    try:
+        return list(cast(Any, content))
+    except TypeError:
+        return []
+
+
+def _agui_sdk_tool_use_blocks(sdk_message: object) -> list[_AguiSdkToolUseBlock]:
+    """Normalize Claude SDK tool-use blocks for AG-UI stream handling."""
+    tool_blocks: list[_AguiSdkToolUseBlock] = []
+    for block in _sdk_content_blocks(sdk_message):
+        if block.__class__.__name__ != "ToolUseBlock":
+            continue
+        tool_id = getattr(block, "id", None)
+        if not tool_id:
+            continue
+        raw_name = str(getattr(block, "name", "unknown") or "unknown")
+        tool_input = getattr(block, "input", {}) or {}
+        if not isinstance(tool_input, dict):
+            tool_input = {"value": tool_input}
+        tool_blocks.append(
+            _AguiSdkToolUseBlock(
+                tool_id=str(tool_id),
+                raw_name=raw_name,
+                display_name=_strip_mcp_prefix(raw_name),
+                tool_input=tool_input,
+            )
+        )
+    return tool_blocks
+
+
+def _agui_sdk_tool_result_blocks(sdk_message: object) -> list[_AguiSdkToolResultBlock]:
+    """Normalize Claude SDK tool-result blocks for AG-UI stream handling."""
+    result_blocks: list[_AguiSdkToolResultBlock] = []
+    for block in _sdk_content_blocks(sdk_message):
+        if block.__class__.__name__ != "ToolResultBlock":
+            continue
+        tool_use_id = getattr(block, "tool_use_id", None)
+        if not tool_use_id:
+            continue
+        result_blocks.append(
+            _AguiSdkToolResultBlock(
+                tool_use_id=str(tool_use_id),
+                content=getattr(block, "content", None),
+            )
+        )
+    return result_blocks
+
+
+async def _close_message_stream(message_stream: object) -> None:
+    """Close an SDK async stream immediately when AG-UI must halt."""
+    aclose = getattr(message_stream, "aclose", None)
+    if aclose is None:
+        return
+    close_result = aclose()
+    if inspect.isawaitable(close_result):
+        await close_result
 
 
 def _agui_assistant_message_from_sdk(
@@ -1415,10 +1532,11 @@ class ClaudeSession:
                     frontend_tool_names=frontend_tool_names,
                     current_state=current_state,
                 ):
-                    if isinstance(event, dict):
-                        current_state = event.get("state", current_state)
-                        if "result" in event:
-                            result_data = event["result"]
+                    if isinstance(event, _AguiStreamStateUpdate):
+                        current_state = event.state
+                        continue
+                    if isinstance(event, _AguiStreamResult):
+                        result_data = event.result
                         continue
                     yield event
 
@@ -1437,13 +1555,13 @@ class ClaudeSession:
     async def _stream_agui_messages(
         self,
         *,
-        message_stream: Any,
+        message_stream: AsyncIterable[object],
         thread_id: str,
         run_id: str,
         input_data: RunAgentInput,
         frontend_tool_names: set[str],
         current_state: Any,
-    ) -> AsyncGenerator[BaseEvent | dict[str, Any], None]:
+    ) -> AsyncGenerator[BaseEvent | _AguiStreamStateUpdate | _AguiStreamResult, None]:
         """Translate Claude SDK message stream to AG-UI events."""
         current_message_id: str | None = None
         has_streamed_text = False
@@ -1456,16 +1574,13 @@ class ClaudeSession:
         accumulated_tool_json = ""
         processed_tool_ids: set[str] = set()
         halt_stream = False
-        run_messages: list[Any] = []
+        run_messages: list[AguiAssistantMessage | AguiToolMessage] = []
         pending_msg: dict[str, Any] | None = None
 
-        def upsert_message(message: Any) -> None:
-            msg_id = message.get("id") if isinstance(message, dict) else message.id
+        def upsert_message(message: AguiAssistantMessage | AguiToolMessage) -> None:
+            msg_id = message.id
             for idx, existing in enumerate(run_messages):
-                existing_id = (
-                    existing.get("id") if isinstance(existing, dict) else existing.id
-                )
-                if existing_id == msg_id:
+                if existing.id == msg_id:
                     run_messages[idx] = message
                     return
             run_messages.append(message)
@@ -1489,6 +1604,7 @@ class ClaudeSession:
 
         async for message in message_stream:
             if halt_stream:
+                await _close_message_stream(message_stream)
                 break
 
             cls_name = message.__class__.__name__
@@ -1618,7 +1734,7 @@ class ClaudeSession:
                                     type=EventType.STATE_SNAPSHOT,
                                     snapshot=current_state,
                                 )
-                                yield {"state": current_state}
+                                yield _AguiStreamStateUpdate(state=current_state)
                             except (json.JSONDecodeError, ValueError, TypeError) as exc:
                                 yield CustomEvent(
                                     type=EventType.CUSTOM,
@@ -1666,6 +1782,9 @@ class ClaudeSession:
                             message_id=current_message_id,
                         )
                     current_message_id = None
+                if halt_stream:
+                    await _close_message_stream(message_stream)
+                    break
                 continue
 
             if cls_name == "AssistantMessage":
@@ -1674,17 +1793,13 @@ class ClaudeSession:
                 if agui_message is not None:
                     upsert_message(agui_message)
 
-                for block in getattr(message, "content", []) or []:
-                    if block.__class__.__name__ != "ToolUseBlock":
+                for tool_block in _agui_sdk_tool_use_blocks(message):
+                    if tool_block.tool_id in processed_tool_ids:
                         continue
-                    tool_id = getattr(block, "id", None)
-                    if not tool_id or tool_id in processed_tool_ids:
-                        continue
-                    raw_name = getattr(block, "name", "unknown")
-                    display_name = _strip_mcp_prefix(raw_name)
-                    tool_input = getattr(block, "input", {}) or {}
-                    if _is_agui_state_tool(raw_name):
-                        updates = tool_input.get("state_updates", tool_input)
+                    if _is_agui_state_tool(tool_block.raw_name):
+                        updates = tool_block.tool_input.get(
+                            "state_updates", tool_block.tool_input
+                        )
                         if isinstance(updates, str):
                             updates = json.loads(updates)
                         if isinstance(current_state, dict) and isinstance(
@@ -1698,42 +1813,41 @@ class ClaudeSession:
                             type=EventType.STATE_SNAPSHOT,
                             snapshot=current_state,
                         )
-                        yield {"state": current_state}
+                        yield _AguiStreamStateUpdate(state=current_state)
                         continue
-                    processed_tool_ids.add(tool_id)
+                    processed_tool_ids.add(tool_block.tool_id)
                     yield ToolCallStartEvent(
                         type=EventType.TOOL_CALL_START,
-                        tool_call_id=tool_id,
-                        tool_call_name=display_name,
+                        tool_call_id=tool_block.tool_id,
+                        tool_call_name=tool_block.display_name,
                         parent_message_id=msg_id,
                     )
                     yield ToolCallArgsEvent(
                         type=EventType.TOOL_CALL_ARGS,
-                        tool_call_id=tool_id,
-                        delta=json.dumps(tool_input),
+                        tool_call_id=tool_block.tool_id,
+                        delta=json.dumps(tool_block.tool_input),
                     )
                     yield ToolCallEndEvent(
                         type=EventType.TOOL_CALL_END,
-                        tool_call_id=tool_id,
+                        tool_call_id=tool_block.tool_id,
                     )
-                    if display_name in frontend_tool_names:
+                    if tool_block.display_name in frontend_tool_names:
                         halt_stream = True
                         break
 
             elif cls_name == "UserMessage":
-                for block in getattr(message, "content", []) or []:
-                    if block.__class__.__name__ != "ToolResultBlock":
-                        continue
-                    tool_use_id = getattr(block, "tool_use_id", None)
-                    if not tool_use_id:
-                        continue
-                    content = getattr(block, "content", None)
-                    upsert_message(_agui_tool_message(tool_use_id, content))
+                for tool_result in _agui_sdk_tool_result_blocks(message):
+                    upsert_message(
+                        _agui_tool_message(
+                            tool_result.tool_use_id,
+                            tool_result.content,
+                        )
+                    )
                     yield ToolCallResultEvent(
                         type=EventType.TOOL_CALL_RESULT,
-                        message_id=f"{tool_use_id}-result",
-                        tool_call_id=tool_use_id,
-                        content=_agui_tool_result_content(content),
+                        message_id=f"{tool_result.tool_use_id}-result",
+                        tool_call_id=tool_result.tool_use_id,
+                        content=_agui_tool_result_content(tool_result.content),
                         role="tool",
                     )
 
@@ -1786,7 +1900,11 @@ class ClaudeSession:
                             content=result_text,
                         )
                     )
-                yield {"result": result_data}
+                yield _AguiStreamResult(result=result_data)
+
+            if halt_stream:
+                await _close_message_stream(message_stream)
+                break
 
         if current_tool_call_id:
             yield ToolCallEndEvent(

--- a/src/holodeck/serve/protocols/agui.py
+++ b/src/holodeck/serve/protocols/agui.py
@@ -39,6 +39,7 @@ from ulid import ULID
 from holodeck.lib.backends import BackendSessionError
 from holodeck.lib.backends.base import ToolEvent
 from holodeck.lib.logging_config import get_logger
+from holodeck.models.llm import ProviderEnum
 from holodeck.models.test_case import FileInput
 from holodeck.serve.file_utils import (
     cleanup_temp_files,
@@ -212,6 +213,15 @@ def extract_message_from_input(input_data: RunAgentInput) -> str:
                 return " ".join(text_parts)
 
     raise ValueError("No user messages found in input")
+
+
+def latest_message_role(input_data: RunAgentInput) -> str:
+    """Return the role for the latest AG-UI message, if present."""
+    messages = input_data.messages or []
+    if not messages:
+        return ""
+    message = messages[-1]
+    return str(message.role)
 
 
 def map_session_id(thread_id: str) -> str:
@@ -679,11 +689,11 @@ class AGUIProtocol(Protocol):
         Returns:
             MIME type string for response Content-Type header.
         """
-        return "text/event-stream"
+        return AGUIEventStream(accept_header=self._accept_header).content_type
 
     async def handle_request(
         self,
-        request: Any,
+        request: RunAgentInput,
         session: ServerSession,
     ) -> AsyncGenerator[bytes, None]:
         """Handle AG-UI request and generate event stream.
@@ -699,7 +709,7 @@ class AGUIProtocol(Protocol):
             Encoded AG-UI events as bytes.
         """
         # Extract components from RunAgentInput
-        input_data: RunAgentInput = request
+        input_data = request
         thread_id = input_data.thread_id
         run_id = input_data.run_id
 
@@ -766,13 +776,30 @@ class AGUIProtocol(Protocol):
             else:
                 full_message = text_message
 
+            executor = session.agent_executor
+            provider = executor.agent_config.model.provider
+            if provider in (ProviderEnum.ANTHROPIC, ProviderEnum.ANTHROPIC.value):
+                # Claude AG-UI resumes after frontend tool execution with a
+                # latest ``tool`` message. Do not override that with the prior
+                # user message, or the model can repeatedly call the same
+                # frontend tool.
+                claude_message_override = (
+                    full_message if latest_message_role(input_data) == "user" else None
+                )
+                async for agui_evt in executor.execute_turn_agui(
+                    input_data,
+                    claude_message_override,
+                ):
+                    yield encoder.encode(agui_evt)
+                logger.debug("Completed Claude AG-UI request for run %s", run_id)
+                return
+
             # 1. Emit RunStartedEvent
             yield encoder.encode(create_run_started_event(thread_id, run_id))
 
             # 2. Eagerly initialize backend so tool_event_queue is available
             #    before execution starts. Gracefully degrade if the executor
             #    does not expose this method (e.g. in tests with mocks).
-            executor = session.agent_executor
             logger.debug(
                 "[trace] agui.handle_request: session=%s, executor_id=%s, "
                 "session_attached=%s",

--- a/tests/unit/agent/test_executor_coverage.py
+++ b/tests/unit/agent/test_executor_coverage.py
@@ -12,7 +12,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from holodeck.chat.executor import AgentExecutor, AgentResponse, _TaskBoundSession
+from holodeck.chat.executor import (
+    AgentExecutor,
+    AgentResponse,
+    _require_agui_session,
+    _TaskBoundSession,
+)
 from holodeck.lib.backends.base import (
     AgentSession,
     BackendInitError,
@@ -128,6 +133,82 @@ class TestExecuteTurnErrors:
 
         with pytest.raises(RuntimeError, match="Direct runtime error"):
             await executor.execute_turn("Hello")
+
+
+class TestExecuteTurnAgui:
+    """Test AgentExecutor.execute_turn_agui()."""
+
+    @pytest.mark.asyncio
+    async def test_execute_turn_agui_streams_backend_events(self, make_agent) -> None:
+        """execute_turn_agui() delegates to an AG-UI-capable session."""
+        from ag_ui.core import EventType, RunAgentInput, RunStartedEvent, UserMessage
+
+        class AguiSession:
+            async def prepare(self) -> None:
+                return None
+
+            async def send(self, message: str) -> ExecutionResult:
+                return ExecutionResult(response="unused")
+
+            async def send_streaming(self, message: str):
+                yield "unused"
+
+            async def send_agui(
+                self,
+                input_data: RunAgentInput,
+                message_override: str | None = None,
+            ):
+                assert message_override == "override"
+                yield RunStartedEvent(
+                    type=EventType.RUN_STARTED,
+                    thread_id=input_data.thread_id,
+                    run_id=input_data.run_id,
+                    input=input_data,
+                )
+
+            async def close(self) -> None:
+                return None
+
+        mock_backend = AsyncMock()
+        mock_backend.create_session = AsyncMock(return_value=AguiSession())
+        input_data = RunAgentInput(
+            thread_id="thread-1",
+            run_id="run-1",
+            messages=[UserMessage(id="msg-1", role="user", content="hi")],
+            tools=[],
+            context=[],
+            state=None,
+            forwarded_props=None,
+        )
+
+        executor = AgentExecutor(make_agent(), backend=mock_backend)
+        events = [
+            event async for event in executor.execute_turn_agui(input_data, "override")
+        ]
+
+        assert [event.type for event in events] == [EventType.RUN_STARTED]
+
+    @pytest.mark.asyncio
+    async def test_execute_turn_agui_wraps_backend_init_error(self, make_agent) -> None:
+        """BackendInitError is wrapped with AG-UI-specific context."""
+        from ag_ui.core import RunAgentInput, UserMessage
+
+        mock_backend = AsyncMock()
+        mock_backend.create_session.side_effect = BackendInitError("init failed")
+        input_data = RunAgentInput(
+            thread_id="thread-1",
+            run_id="run-1",
+            messages=[UserMessage(id="msg-1", role="user", content="hi")],
+            tools=[],
+            context=[],
+            state=None,
+            forwarded_props=None,
+        )
+
+        executor = AgentExecutor(make_agent(), backend=mock_backend)
+        with pytest.raises(RuntimeError, match="Agent AG-UI execution failed"):
+            async for _ in executor.execute_turn_agui(input_data):
+                pass
 
     @pytest.mark.asyncio
     async def test_backend_session_error_propagates(
@@ -318,6 +399,56 @@ class TestGetHistoryCopy:
 
 class TestTaskBoundSession:
     """Test the _TaskBoundSession actor wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_send_agui_delegates_to_inner_session(self) -> None:
+        """send_agui() yields events from an AG-UI-capable inner session."""
+        from ag_ui.core import EventType, RunAgentInput, RunStartedEvent, UserMessage
+
+        class AguiCapableSession:
+            async def prepare(self) -> None:
+                return None
+
+            async def send(self, message: str) -> ExecutionResult:
+                return ExecutionResult(response="unused")
+
+            async def send_streaming(self, message: str):
+                yield "unused"
+
+            async def send_agui(
+                self,
+                input_data: RunAgentInput,
+                message_override: str | None = None,
+            ):
+                yield RunStartedEvent(
+                    type=EventType.RUN_STARTED,
+                    thread_id=input_data.thread_id,
+                    run_id=input_data.run_id,
+                    input=input_data,
+                )
+
+            async def close(self) -> None:
+                return None
+
+        input_data = RunAgentInput(
+            thread_id="thread-1",
+            run_id="run-1",
+            messages=[UserMessage(id="msg-1", role="user", content="hi")],
+            tools=[],
+            context=[],
+            state=None,
+            forwarded_props=None,
+        )
+
+        actor = _TaskBoundSession(AguiCapableSession())
+        events = [event async for event in actor.send_agui(input_data)]
+
+        assert [event.type for event in events] == [EventType.RUN_STARTED]
+
+    def test_require_agui_session_rejects_missing_capability(self) -> None:
+        """A non-AG-UI session fails with a clear AttributeError."""
+        with pytest.raises(AttributeError, match="does not support AG-UI"):
+            _require_agui_session(None)
 
     @pytest.mark.asyncio
     async def test_send_delegates_to_inner_session(self) -> None:

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -15,7 +15,7 @@ import json
 import logging
 import sys
 from pathlib import Path  # noqa: F401  (used by P4 task 5)
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -177,6 +177,26 @@ class StreamEvent:
 
     def __init__(self, event: dict[str, Any]) -> None:
         self.event = event
+
+
+class ClosableAsyncStream:
+    """Async iterator that records explicit AG-UI stream closure."""
+
+    def __init__(self, items: list[Any]) -> None:
+        self._items = iter(items)
+        self.closed = False
+
+    def __aiter__(self) -> ClosableAsyncStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._items)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
 # ---------------------------------------------------------------------------
@@ -1509,6 +1529,16 @@ class TestClaudeSessionAGUI:
         assert frontend_tool.input_schema == {"type": "object"}
         state_tool = _make_agui_state_tool()
         assert state_tool.name == "ag_ui_update_state"
+        assert state_tool.input_schema == {
+            "type": "object",
+            "properties": {
+                "state_updates": {
+                    "type": "object",
+                    "additionalProperties": True,
+                }
+            },
+            "required": ["state_updates"],
+        }
 
         assert _agui_tool_result_content(None) == ""
         assert _agui_tool_result_content([{"type": "text", "text": '{"a": 1}'}]) == (
@@ -1556,9 +1586,18 @@ class TestClaudeSessionAGUI:
 
         cloned = _clone_options(ClaudeAgentOptions(), max_turns=2)
         assert cloned.max_turns == 2
-        fallback_options = MagicMock()
-        assert _clone_options(fallback_options, custom_value=3) is fallback_options
-        assert fallback_options.custom_value == 3
+
+        class FallbackOptions:
+            pass
+
+        fallback_options = FallbackOptions()
+        cloned_fallback = _clone_options(
+            cast(ClaudeAgentOptions, fallback_options),
+            custom_value=3,
+        )
+        assert cloned_fallback is not fallback_options
+        assert cast(Any, cloned_fallback).custom_value == 3
+        assert not hasattr(fallback_options, "custom_value")
 
         # Keep EventType imported in this test so coverage includes the public
         # event enum path used by the helpers above.
@@ -1612,34 +1651,37 @@ class TestClaudeSessionAGUI:
     async def test_send_agui_frontend_tool_halts_before_later_text(self) -> None:
         from ag_ui.core import EventType, Tool
 
-        async def fake_query(prompt, options):
-            yield StreamEvent({"type": "message_start"})
-            yield StreamEvent(
-                {
-                    "type": "content_block_start",
-                    "content_block": {
-                        "type": "tool_use",
-                        "id": "toolu_front",
-                        "name": "mcp__ag_ui__ask_user",
-                    },
-                }
-            )
-            yield StreamEvent(
-                {
-                    "type": "content_block_delta",
-                    "delta": {
-                        "type": "input_json_delta",
-                        "partial_json": '{"question":"ok?"}',
-                    },
-                }
-            )
-            yield StreamEvent({"type": "content_block_stop"})
-            yield StreamEvent(
-                {
-                    "type": "content_block_delta",
-                    "delta": {"type": "text_delta", "text": "late"},
-                }
-            )
+        stream = ClosableAsyncStream(
+            [
+                StreamEvent({"type": "message_start"}),
+                StreamEvent(
+                    {
+                        "type": "content_block_start",
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": "toolu_front",
+                            "name": "mcp__ag_ui__ask_user",
+                        },
+                    }
+                ),
+                StreamEvent(
+                    {
+                        "type": "content_block_delta",
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": '{"question":"ok?"}',
+                        },
+                    }
+                ),
+                StreamEvent({"type": "content_block_stop"}),
+                StreamEvent(
+                    {
+                        "type": "content_block_delta",
+                        "delta": {"type": "text_delta", "text": "late"},
+                    }
+                ),
+            ]
+        )
 
         input_data = self._run_input(
             tools=[
@@ -1656,10 +1698,11 @@ class TestClaudeSessionAGUI:
         session = ClaudeSession(options=ClaudeAgentOptions())
         with patch(
             "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
-            side_effect=fake_query,
+            return_value=stream,
         ):
             events = [event async for event in session.send_agui(input_data)]
 
+        assert stream.closed is True
         assert [e.type for e in events if hasattr(e, "tool_call_id")] == [
             EventType.TOOL_CALL_START,
             EventType.TOOL_CALL_ARGS,
@@ -1671,6 +1714,82 @@ class TestClaudeSessionAGUI:
             e.type == EventType.TEXT_MESSAGE_CONTENT and e.delta == "late"
             for e in events
         )
+        assert events[-1].type == EventType.RUN_FINISHED
+
+    @pytest.mark.asyncio
+    async def test_send_agui_complete_frontend_tool_closes_stream(self) -> None:
+        from ag_ui.core import EventType, Tool
+
+        stream = ClosableAsyncStream(
+            [
+                _make_assistant_message(
+                    [
+                        _make_tool_use_block(
+                            tool_id="toolu_front",
+                            name="mcp__ag_ui__ask_user",
+                            inp={"question": "ok?"},
+                        )
+                    ]
+                ),
+                _make_assistant_message([_make_text_block("late")]),
+            ]
+        )
+
+        input_data = self._run_input(
+            tools=[
+                Tool(
+                    name="ask_user",
+                    description="Ask user",
+                    parameters={
+                        "type": "object",
+                        "properties": {"question": {"type": "string"}},
+                    },
+                )
+            ]
+        )
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            return_value=stream,
+        ):
+            events = [event async for event in session.send_agui(input_data)]
+
+        assert stream.closed is True
+        assert any(e.type == EventType.TOOL_CALL_START for e in events)
+        assert not any(
+            e.type == EventType.TEXT_MESSAGE_CONTENT and e.delta == "late"
+            for e in events
+        )
+        assert events[-1].type == EventType.RUN_FINISHED
+
+    @pytest.mark.asyncio
+    async def test_send_agui_backend_tool_keeps_stream_open(self) -> None:
+        from ag_ui.core import EventType
+
+        stream = ClosableAsyncStream(
+            [
+                _make_assistant_message(
+                    [
+                        _make_tool_use_block(
+                            tool_id="toolu_backend",
+                            name="mcp__backend__lookup",
+                            inp={"q": "msft"},
+                        )
+                    ]
+                ),
+                _make_result_message(session_id="sdk-backend"),
+            ]
+        )
+
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            return_value=stream,
+        ):
+            events = [event async for event in session.send_agui(self._run_input())]
+
+        assert stream.closed is False
+        assert any(e.type == EventType.TOOL_CALL_START for e in events)
         assert events[-1].type == EventType.RUN_FINISHED
 
     @pytest.mark.asyncio

--- a/tests/unit/lib/backends/test_claude_backend.py
+++ b/tests/unit/lib/backends/test_claude_backend.py
@@ -33,12 +33,25 @@ from holodeck.lib.backends.base import (
 from holodeck.lib.backends.claude_backend import (
     ClaudeBackend,
     ClaudeSession,
+    _agui_assistant_message_from_sdk,
+    _agui_message_content,
+    _agui_prompt_from_input,
+    _agui_state_context_addendum,
+    _agui_tool_message,
+    _agui_tool_names,
+    _agui_tool_result_content,
     _build_output_format,
     _build_permission_mode,
+    _clone_options,
     _enrich_tool_results,
     _extract_result_text,
+    _fix_surrogates,
+    _fix_surrogates_deep,
+    _make_agui_frontend_tool,
+    _make_agui_state_tool,
     _maybe_emit_thinking_blocks,
     _process_message,
+    _strip_mcp_prefix,
     _wrap_prompt,
     build_options,
 )
@@ -148,6 +161,7 @@ def _make_result_message(
     msg.session_id = session_id
     msg.usage = usage or {"input_tokens": 10, "output_tokens": 5}
     msg.structured_output = structured_output
+    msg.result = None
     msg.__class__.__name__ = "ResultMessage"
     return msg
 
@@ -156,6 +170,13 @@ async def _async_iter(items: list[Any]):
     """Create an async iterator from a list."""
     for item in items:
         yield item
+
+
+class StreamEvent:
+    """Small stand-in for claude_agent_sdk.types.StreamEvent."""
+
+    def __init__(self, event: dict[str, Any]) -> None:
+        self.event = event
 
 
 # ---------------------------------------------------------------------------
@@ -1391,6 +1412,534 @@ class TestClaudeSessionStreaming:
         assert captured_resume[0] is None
         assert captured_resume[1] == "sdk-stream-XYZ"
         assert session._sdk_session_id == "sdk-stream-XYZ"
+
+
+@pytest.mark.unit
+class TestClaudeSessionAGUI:
+    """ClaudeSession.send_agui() translates Claude SDK streams to AG-UI."""
+
+    def _run_input(self, **overrides: Any) -> Any:
+        from ag_ui.core import RunAgentInput, UserMessage
+
+        data = {
+            "thread_id": "thread-1",
+            "run_id": "run-1",
+            "messages": [UserMessage(id="user-1", role="user", content="Hello")],
+            "state": None,
+            "tools": [],
+            "context": [],
+            "forwarded_props": None,
+        }
+        data.update(overrides)
+        return RunAgentInput(**data)
+
+    def test_agui_helper_normalization_paths(self) -> None:
+        """AG-UI helper functions handle typed messages and JSON-ish content."""
+        from ag_ui.core import (
+            AssistantMessage,
+            Context,
+            EventType,
+            SystemMessage,
+            TextInputContent,
+            Tool,
+            ToolMessage,
+            UserMessage,
+        )
+
+        assert _fix_surrogates("\ud83d") == "?"
+        assert _fix_surrogates_deep({"bad\ud83d": ["ok", "\ud83d"]}) == {
+            "bad?": ["ok", "?"]
+        }
+        assert _strip_mcp_prefix("mcp__ag_ui__show_panel") == "show_panel"
+        assert _strip_mcp_prefix("plain") == "plain"
+        assert _agui_tool_names(
+            [Tool(name="show_panel", description="Show", parameters=None)]
+        ) == ["show_panel"]
+        assert (
+            _agui_message_content(
+                AssistantMessage(id="a", role="assistant", content=None)
+            )
+            == ""
+        )
+        assert (
+            _agui_message_content(
+                ToolMessage(id="t", role="tool", content="done", tool_call_id="toolu")
+            )
+            == "done"
+        )
+        assert (
+            _agui_message_content(
+                UserMessage(
+                    id="u",
+                    role="user",
+                    content=[
+                        TextInputContent(type="text", text="hello"),
+                    ],
+                )
+            )
+            == "hello"
+        )
+        assert (
+            _agui_message_content(
+                SystemMessage(id="s", role="system", content="system note")
+            )
+            == "system note"
+        )
+        assert _agui_prompt_from_input(self._run_input(), "override") == "override"
+        assert _agui_prompt_from_input(self._run_input(messages=[])) == ""
+
+        addendum = _agui_state_context_addendum(
+            self._run_input(
+                state={"bad": object()},
+                context=[Context(description="Ticker", value="MSFT")],
+            )
+        )
+        assert "Context from the application" in addendum
+        assert "Ticker: MSFT" in addendum
+        assert "Current Shared State" in addendum
+
+        frontend_tool = _make_agui_frontend_tool(
+            Tool(
+                name="show_panel",
+                description="Show panel",
+                parameters={"type": "object"},
+            )
+        )
+        assert frontend_tool.name == "show_panel"
+        assert frontend_tool.input_schema == {"type": "object"}
+        state_tool = _make_agui_state_tool()
+        assert state_tool.name == "ag_ui_update_state"
+
+        assert _agui_tool_result_content(None) == ""
+        assert _agui_tool_result_content([{"type": "text", "text": '{"a": 1}'}]) == (
+            '{"a": 1}'
+        )
+        assert _agui_tool_result_content([{"type": "text", "text": "plain"}]) == (
+            "plain"
+        )
+        assert _agui_tool_result_content([{"type": "image", "url": "x"}]) == (
+            '[{"type": "image", "url": "x"}]'
+        )
+        assert "object" in _agui_tool_result_content(object())
+
+        msg = _agui_tool_message("toolu", [{"type": "text", "text": "ok"}])
+        assert msg.tool_call_id == "toolu"
+        assert msg.content == "ok"
+
+        empty_sdk_message = MagicMock()
+        empty_sdk_message.__class__.__name__ = "AssistantMessage"
+        empty_sdk_message.content = []
+        empty = _agui_assistant_message_from_sdk(empty_sdk_message, "m")
+        assert empty is None
+        converted = _agui_assistant_message_from_sdk(
+            _make_assistant_message(
+                [
+                    _make_text_block("hi"),
+                    _make_tool_use_block(
+                        tool_id="toolu_state",
+                        name="mcp__ag_ui__ag_ui_update_state",
+                    ),
+                    _make_tool_use_block(
+                        tool_id="toolu_backend",
+                        name="mcp__backend__lookup",
+                        inp={"q": "msft"},
+                    ),
+                ]
+            ),
+            "assistant-1",
+        )
+        assert converted is not None
+        assert converted.content == "hi"
+        assert converted.tool_calls is not None
+        assert converted.tool_calls[0].function.name == "lookup"
+        assert converted.tool_calls[0].function.arguments == '{"q": "msft"}'
+
+        cloned = _clone_options(ClaudeAgentOptions(), max_turns=2)
+        assert cloned.max_turns == 2
+        fallback_options = MagicMock()
+        assert _clone_options(fallback_options, custom_value=3) is fallback_options
+        assert fallback_options.custom_value == 3
+
+        # Keep EventType imported in this test so coverage includes the public
+        # event enum path used by the helpers above.
+        assert EventType.RUN_STARTED.value == "RUN_STARTED"
+
+    @pytest.mark.asyncio
+    async def test_send_agui_streams_text_chunks(self) -> None:
+        from ag_ui.core import EventType
+
+        captured_options: list[ClaudeAgentOptions] = []
+
+        async def fake_query(prompt, options):
+            captured_options.append(options)
+            yield StreamEvent({"type": "message_start"})
+            yield StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "Hel"},
+                }
+            )
+            yield StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "lo"},
+                }
+            )
+            yield StreamEvent({"type": "message_stop"})
+            yield _make_result_message(session_id="sdk-agui-1")
+
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
+        ):
+            events = [event async for event in session.send_agui(self._run_input())]
+
+        assert captured_options[0].include_partial_messages is True
+        assert "mcp__ag_ui__ag_ui_update_state" in captured_options[0].allowed_tools
+        assert "ag_ui" in captured_options[0].mcp_servers
+        assert [
+            e.delta for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT
+        ] == [
+            "Hel",
+            "lo",
+        ]
+        assert any(e.type == EventType.MESSAGES_SNAPSHOT for e in events)
+        assert events[-1].type == EventType.RUN_FINISHED
+        assert session._sdk_session_id == "sdk-agui-1"
+
+    @pytest.mark.asyncio
+    async def test_send_agui_frontend_tool_halts_before_later_text(self) -> None:
+        from ag_ui.core import EventType, Tool
+
+        async def fake_query(prompt, options):
+            yield StreamEvent({"type": "message_start"})
+            yield StreamEvent(
+                {
+                    "type": "content_block_start",
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": "toolu_front",
+                        "name": "mcp__ag_ui__ask_user",
+                    },
+                }
+            )
+            yield StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": '{"question":"ok?"}',
+                    },
+                }
+            )
+            yield StreamEvent({"type": "content_block_stop"})
+            yield StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "late"},
+                }
+            )
+
+        input_data = self._run_input(
+            tools=[
+                Tool(
+                    name="ask_user",
+                    description="Ask user",
+                    parameters={
+                        "type": "object",
+                        "properties": {"question": {"type": "string"}},
+                    },
+                )
+            ]
+        )
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
+        ):
+            events = [event async for event in session.send_agui(input_data)]
+
+        assert [e.type for e in events if hasattr(e, "tool_call_id")] == [
+            EventType.TOOL_CALL_START,
+            EventType.TOOL_CALL_ARGS,
+            EventType.TOOL_CALL_END,
+        ]
+        start = next(e for e in events if e.type == EventType.TOOL_CALL_START)
+        assert start.tool_call_name == "ask_user"
+        assert not any(
+            e.type == EventType.TEXT_MESSAGE_CONTENT and e.delta == "late"
+            for e in events
+        )
+        assert events[-1].type == EventType.RUN_FINISHED
+
+    @pytest.mark.asyncio
+    async def test_send_agui_state_update_emits_snapshot(self) -> None:
+        from ag_ui.core import EventType
+
+        async def fake_query(prompt, options):
+            yield StreamEvent({"type": "message_start"})
+            yield StreamEvent(
+                {
+                    "type": "content_block_start",
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": "toolu_state",
+                        "name": "mcp__ag_ui__ag_ui_update_state",
+                    },
+                }
+            )
+            yield StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": '{"state_updates":{"status":"done"}}',
+                    },
+                }
+            )
+            yield StreamEvent({"type": "content_block_stop"})
+            yield _make_result_message(session_id="sdk-state")
+
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
+        ):
+            events = [
+                event
+                async for event in session.send_agui(
+                    self._run_input(state={"status": "new"})
+                )
+            ]
+
+        snapshots = [e.snapshot for e in events if e.type == EventType.STATE_SNAPSHOT]
+        assert snapshots[0] == {"status": "new"}
+        assert snapshots[-1] == {"status": "done"}
+
+    @pytest.mark.asyncio
+    async def test_send_agui_streams_reasoning_and_signature(self) -> None:
+        """Thinking deltas map to AG-UI reasoning events."""
+        from ag_ui.core import EventType
+
+        async def fake_query(prompt, options):
+            yield StreamEvent({"type": "message_start"})
+            yield StreamEvent(
+                {
+                    "type": "content_block_start",
+                    "content_block": {"type": "thinking"},
+                }
+            )
+            yield StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "thinking_delta", "thinking": "plan"},
+                }
+            )
+            yield StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "signature_delta", "signature": "sig"},
+                }
+            )
+            yield StreamEvent({"type": "content_block_stop"})
+            yield _make_result_message(session_id="sdk-reasoning")
+
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
+        ):
+            events = [event async for event in session.send_agui(self._run_input())]
+
+        event_types = [event.type for event in events]
+        assert EventType.REASONING_START in event_types
+        assert EventType.REASONING_MESSAGE_START in event_types
+        assert EventType.REASONING_MESSAGE_CONTENT in event_types
+        assert EventType.REASONING_MESSAGE_END in event_types
+        assert EventType.REASONING_END in event_types
+        assert EventType.REASONING_ENCRYPTED_VALUE in event_types
+
+    @pytest.mark.asyncio
+    async def test_send_agui_invalid_state_update_emits_custom_error(self) -> None:
+        """Malformed state update JSON becomes a custom error event."""
+        from ag_ui.core import EventType
+
+        async def fake_query(prompt, options):
+            yield StreamEvent({"type": "message_start"})
+            yield StreamEvent(
+                {
+                    "type": "content_block_start",
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": "toolu_state",
+                        "name": "mcp__ag_ui__ag_ui_update_state",
+                    },
+                }
+            )
+            yield StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "input_json_delta", "partial_json": "{"},
+                }
+            )
+            yield StreamEvent({"type": "content_block_stop"})
+            yield _make_result_message(session_id="sdk-state-error")
+
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
+        ):
+            events = [event async for event in session.send_agui(self._run_input())]
+
+        errors = [
+            event
+            for event in events
+            if event.type == EventType.CUSTOM and event.name == "state_update_error"
+        ]
+        assert errors
+
+    @pytest.mark.asyncio
+    async def test_send_agui_complete_sdk_messages_emit_tool_events(self) -> None:
+        """Complete Assistant/User/Result messages cover non-StreamEvent paths."""
+        from ag_ui.core import EventType
+
+        tool_result = MagicMock()
+        tool_result.__class__.__name__ = "ToolResultBlock"
+        tool_result.tool_use_id = "toolu_backend"
+        tool_result.content = [{"type": "text", "text": "result text"}]
+        user_msg = MagicMock()
+        user_msg.__class__.__name__ = "UserMessage"
+        user_msg.content = [tool_result]
+
+        result_msg = _make_result_message(session_id="sdk-complete")
+        result_msg.result = "final text"
+
+        async def fake_query(prompt, options):
+            yield _make_assistant_message(
+                [
+                    _make_tool_use_block(
+                        tool_id="toolu_backend",
+                        name="mcp__backend__lookup",
+                        inp={"q": "msft"},
+                    )
+                ]
+            )
+            yield user_msg
+            yield result_msg
+
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
+        ):
+            events = [event async for event in session.send_agui(self._run_input())]
+
+        event_types = [event.type for event in events]
+        assert EventType.TOOL_CALL_START in event_types
+        assert EventType.TOOL_CALL_ARGS in event_types
+        assert EventType.TOOL_CALL_END in event_types
+        assert EventType.TOOL_CALL_RESULT in event_types
+        assert EventType.TEXT_MESSAGE_CONTENT in event_types
+        start = next(
+            event for event in events if event.type == EventType.TOOL_CALL_START
+        )
+        assert start.tool_call_name == "lookup"
+        result = next(
+            event for event in events if event.type == EventType.TOOL_CALL_RESULT
+        )
+        assert result.content == "result text"
+
+    @pytest.mark.asyncio
+    async def test_send_agui_translates_process_error(self) -> None:
+        """SDK process errors are translated for AG-UI execution too."""
+
+        async def fake_query(prompt, options):
+            raise ProcessError("boom")
+            yield  # pragma: no cover
+
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with (
+            patch(
+                "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+                side_effect=fake_query,
+            ),
+            pytest.raises(BackendSessionError, match="subprocess terminated"),
+        ):
+            async for _ in session.send_agui(self._run_input()):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_send_agui_tool_result_resume_uses_transcript_prompt(self) -> None:
+        from ag_ui.core import (
+            AssistantMessage,
+            EventType,
+            FunctionCall,
+            ToolCall,
+            ToolMessage,
+            UserMessage,
+        )
+
+        captured_prompts: list[str] = []
+
+        async def fake_query(prompt, options):
+            chunks: list[str] = []
+            async for item in prompt:
+                chunks.append(item["message"]["content"])
+            captured_prompts.extend(chunks)
+            yield StreamEvent({"type": "message_start"})
+            yield StreamEvent(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "Done."},
+                }
+            )
+            yield StreamEvent({"type": "message_stop"})
+            yield _make_result_message(session_id="sdk-resume")
+
+        input_data = self._run_input(
+            messages=[
+                UserMessage(id="user-1", role="user", content="Show MSFT."),
+                AssistantMessage(
+                    id="assistant-1",
+                    role="assistant",
+                    tool_calls=[
+                        ToolCall(
+                            id="toolu_front",
+                            type="function",
+                            function=FunctionCall(
+                                name="showPortfolioPanel",
+                                arguments='{"ticker":"MSFT"}',
+                            ),
+                        )
+                    ],
+                ),
+                ToolMessage(
+                    id="tool-result-1",
+                    role="tool",
+                    tool_call_id="toolu_front",
+                    content='{"ok":true}',
+                ),
+            ]
+        )
+        session = ClaudeSession(options=ClaudeAgentOptions())
+        with patch(
+            "holodeck.lib.backends.claude_backend.claude_agent_sdk.query",
+            side_effect=fake_query,
+        ):
+            events = [event async for event in session.send_agui(input_data)]
+
+        assert (
+            "latest frontend tool result has already been executed"
+            in captured_prompts[0]
+        )
+        assert "user: Show MSFT." in captured_prompts[0]
+        assert "name=showPortfolioPanel" in captured_prompts[0]
+        assert 'tool_result id=toolu_front: {"ok":true}' in captured_prompts[0]
+        assert [
+            e.delta for e in events if e.type == EventType.TEXT_MESSAGE_CONTENT
+        ] == ["Done."]
 
 
 @pytest.mark.unit

--- a/tests/unit/serve/test_protocols_agui.py
+++ b/tests/unit/serve/test_protocols_agui.py
@@ -671,6 +671,24 @@ class TestAGUIEventStreamBinaryFormat:
 class TestAGUIProtocolHandleRequest:
     """Tests for AGUIProtocol.handle_request method."""
 
+    def test_latest_message_role_empty_messages(self) -> None:
+        """latest_message_role returns empty string when no messages exist."""
+        from ag_ui.core.events import RunAgentInput
+
+        from holodeck.serve.protocols.agui import latest_message_role
+
+        input_data = RunAgentInput(
+            thread_id="thread-123",
+            run_id="run-456",
+            messages=[],
+            state=None,
+            tools=[],
+            context=[],
+            forwarded_props=None,
+        )
+
+        assert latest_message_role(input_data) == ""
+
     @pytest.mark.asyncio
     async def test_handle_request_success(self) -> None:
         """Test handle_request returns proper event sequence on success."""
@@ -859,6 +877,177 @@ class TestAGUIProtocolHandleRequest:
             events.append(event_bytes)
 
         assert len(events) > 0
+
+    @pytest.mark.asyncio
+    async def test_handle_request_uses_claude_agui_path(self) -> None:
+        """Anthropic executors delegate to the backend-owned AG-UI stream."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ag_ui.core.events import RunAgentInput
+        from ag_ui.core.types import UserMessage
+
+        from holodeck.serve.protocols.agui import (
+            AGUIProtocol,
+            create_run_finished_event,
+            create_run_started_event,
+        )
+
+        input_data = RunAgentInput(
+            thread_id="thread-123",
+            run_id="run-456",
+            messages=[UserMessage(id="msg-1", role="user", content="Hello")],
+            state=None,
+            tools=[],
+            context=[],
+            forwarded_props=None,
+        )
+
+        calls: list[tuple[RunAgentInput, str | None]] = []
+
+        async def execute_turn_agui(
+            input_arg: RunAgentInput,
+            message_override: str | None = None,
+        ):
+            calls.append((input_arg, message_override))
+            yield create_run_started_event("thread-123", "run-456")
+            yield create_run_finished_event("thread-123", "run-456")
+
+        mock_executor = MagicMock()
+        mock_executor.agent_config.model.provider = "anthropic"
+        mock_executor.execute_turn_agui = execute_turn_agui
+        mock_executor.execute_turn = AsyncMock()
+
+        mock_session = MagicMock()
+        mock_session.session_id = "session-123"
+        mock_session.agent_executor = mock_executor
+
+        protocol = AGUIProtocol()
+        events = [
+            event_bytes
+            async for event_bytes in protocol.handle_request(input_data, mock_session)
+        ]
+
+        assert calls == [(input_data, "Hello")]
+        mock_executor.execute_turn.assert_not_called()
+        all_content = b"".join(events).decode("utf-8")
+        assert "RUN_STARTED" in all_content
+        assert "RUN_FINISHED" in all_content
+
+    @pytest.mark.asyncio
+    async def test_handle_request_claude_tool_resume_does_not_reuse_user_prompt(
+        self,
+    ) -> None:
+        """Claude frontend-tool resumes preserve the latest tool message."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ag_ui.core.events import RunAgentInput
+        from ag_ui.core.types import ToolMessage, UserMessage
+
+        from holodeck.serve.protocols.agui import (
+            AGUIProtocol,
+            create_run_finished_event,
+            create_run_started_event,
+        )
+
+        input_data = RunAgentInput(
+            thread_id="thread-123",
+            run_id="run-456",
+            messages=[
+                UserMessage(id="msg-1", role="user", content="Show MSFT"),
+                ToolMessage(
+                    id="tool-result-1",
+                    role="tool",
+                    tool_call_id="toolu_front",
+                    content='{"ok":true}',
+                ),
+            ],
+            state=None,
+            tools=[],
+            context=[],
+            forwarded_props=None,
+        )
+
+        calls: list[tuple[RunAgentInput, str | None]] = []
+
+        async def execute_turn_agui(
+            input_arg: RunAgentInput,
+            message_override: str | None = None,
+        ):
+            calls.append((input_arg, message_override))
+            yield create_run_started_event("thread-123", "run-456")
+            yield create_run_finished_event("thread-123", "run-456")
+
+        mock_executor = MagicMock()
+        mock_executor.agent_config.model.provider = "anthropic"
+        mock_executor.execute_turn_agui = execute_turn_agui
+        mock_executor.execute_turn = AsyncMock()
+
+        mock_session = MagicMock()
+        mock_session.session_id = "session-123"
+        mock_session.agent_executor = mock_executor
+
+        protocol = AGUIProtocol()
+        events = [
+            event_bytes
+            async for event_bytes in protocol.handle_request(input_data, mock_session)
+        ]
+
+        assert calls == [(input_data, None)]
+        mock_executor.execute_turn.assert_not_called()
+        all_content = b"".join(events).decode("utf-8")
+        assert "RUN_STARTED" in all_content
+        assert "RUN_FINISHED" in all_content
+
+    @pytest.mark.asyncio
+    async def test_handle_request_non_claude_keeps_generic_path(self) -> None:
+        """Non-Claude executors keep the existing generic AG-UI fallback."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from ag_ui.core.events import RunAgentInput
+        from ag_ui.core.types import UserMessage
+
+        from holodeck.serve.protocols.agui import AGUIProtocol
+
+        input_data = RunAgentInput(
+            thread_id="thread-123",
+            run_id="run-456",
+            messages=[UserMessage(id="msg-1", role="user", content="Hello")],
+            state=None,
+            tools=[],
+            context=[],
+            forwarded_props=None,
+        )
+
+        async def execute_turn_agui(
+            input_arg: RunAgentInput,
+            message_override: str | None = None,
+        ):
+            msg = "non-Claude path should not call execute_turn_agui"
+            raise AssertionError(msg)
+            yield  # pragma: no cover
+
+        mock_response = MagicMock()
+        mock_response.content = "Hello from SK"
+        mock_response.tool_executions = []
+
+        mock_executor = MagicMock()
+        mock_executor.agent_config.model.provider = "openai"
+        mock_executor.execute_turn_agui = execute_turn_agui
+        mock_executor.execute_turn = AsyncMock(return_value=mock_response)
+
+        mock_session = MagicMock()
+        mock_session.session_id = "session-123"
+        mock_session.agent_executor = mock_executor
+
+        protocol = AGUIProtocol()
+        events = [
+            event_bytes
+            async for event_bytes in protocol.handle_request(input_data, mock_session)
+        ]
+
+        mock_executor.execute_turn.assert_awaited_once_with("Hello")
+        all_content = b"".join(events).decode("utf-8")
+        assert "Hello from SK" in all_content
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add a Claude-specific AG-UI execution path through the existing `AgentExecutor` and `ClaudeSession` flow.
- Translate Claude SDK partial stream events into AG-UI text, reasoning, tool-call, state, result, and message snapshot events.
- Register request-scoped AG-UI frontend tools as an internal Claude SDK MCP server and halt after frontend tool calls so the client can execute and resume.
- Fix frontend-tool resume handling so tool-result requests do not resend the stale user prompt and repeatedly call the same frontend tool.
- Keep non-Claude `/awp` requests on the existing generic AG-UI path and use `EventEncoder` for response content type.

## Validation

- `uv run pytest tests/unit/serve/test_protocols_agui.py tests/unit/serve/test_agui_tool_events.py -n auto -q`
- `uv run pytest tests/unit/lib/backends/test_claude_backend.py tests/unit/lib/backends/test_tool_hooks.py -n auto -q`
- `uv run pytest tests/integration/serve -n auto -q`
- `uv run ruff check src/holodeck/lib/backends/claude_backend.py src/holodeck/chat/executor.py src/holodeck/serve/protocols/agui.py tests/unit/lib/backends/test_claude_backend.py tests/unit/serve/test_protocols_agui.py`
- `git diff --check`
- pre-commit on commit, including staged-file mypy

## Notes

The local copied `samples/financial-assistant` directory was intentionally not included in this PR because it contains local runtime artifacts and ignored environment files.