### PR TITLE
fix(deps): cap mcp below 2.0 for claude-agent-sdk compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,11 @@ dependencies = [
     "deepeval>=3.7.9,<3.8.0",
     "python-ulid>=3.1.0,<4.0.0",
     "ml-dtypes>=0.4.0,<0.5.0",
-    "mcp>=1.23",
+    # Cap below 2.0: claude-agent-sdk 0.2.x still uses the MCP 1.x low-level
+    # Server API (@server.list_tools()), which the 2.0 line removed. Without the
+    # cap, a prerelease-enabled install resolves mcp 2.0.0a1 and the Claude
+    # backend fails at init with "'Server' object has no attribute 'list_tools'".
+    "mcp>=1.23,<2",
     "inquirerpy>=0.3.4,<0.4.0",
     "fastapi>=0.115.0,<1.0.0",
     # PYSEC-2026-161: pin starlette transitive (via fastapi/mcp) to the patched

--- a/uv.lock
+++ b/uv.lock
@@ -2416,7 +2416,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.0.0,<5.0.0" },
     { name = "litellm", specifier = ">=1.80.0,<1.89.0" },
     { name = "markitdown", extras = ["all"], specifier = ">=0.1.4,<0.2.0" },
-    { name = "mcp", specifier = ">=1.23" },
+    { name = "mcp", specifier = ">=1.23,<2" },
     { name = "mkdocs-llmstxt", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "mkdocs-material", specifier = ">=9.6.22,<10.0.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.25.0" },


### PR DESCRIPTION
## What

Pin the `mcp` dependency to `>=1.23,<2` (was `>=1.23`, no upper bound).

## Why

`claude-agent-sdk` 0.2.x still uses the MCP **1.x** low-level `Server` API (`@server.list_tools()`), which the MCP **2.0** line removed. Because our `mcp` requirement had no upper bound, a prerelease-enabled install resolves the latest pre-release — currently **`mcp 2.0.0a1`** — and the Claude backend dies at init:

```
BackendInitError: Claude backend initialization failed:
'Server' object has no attribute 'list_tools'
```

Reproduced via `uv tool install "holodeck-ai[claude-otel,qdrant]"` with `--prerelease allow`, which is how the tool gets installed in some environments. `holodeck test` then fails before running any case.

## Change

- `pyproject.toml`: `mcp>=1.23` → `mcp>=1.23,<2` (+ explanatory comment).
- `uv.lock`: constraint metadata updated to match. **Resolved version is unchanged** — `mcp` stays at `1.26.0`. This only closes the upper bound; no transitive resolution changes.

## Risk

Minimal. No code changes, no version bumps to installed packages. Lifting the cap can be revisited once `claude-agent-sdk` adds MCP 2.x support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)