### PR TITLE
chore(cli): default GRPC_VERBOSITY=ERROR to silence gRPC fork-FD log noise

### DIFF
--- a/src/holodeck/cli/main.py
+++ b/src/holodeck/cli/main.py
@@ -8,14 +8,21 @@ import os
 from pathlib import Path
 
 # =============================================================================
-# CRITICAL: Set telemetry env vars BEFORE any library imports.
+# CRITICAL: Set telemetry/library env vars BEFORE any library imports.
 # - DEEPEVAL_TELEMETRY_OPT_OUT: Prevents deepeval from setting a TracerProvider
 # - SK env var: Enables Semantic Kernel telemetry
+# - GRPC_VERBOSITY: Silence gRPC C-core INFO logs — notably the
+#   "FD from fork parent still in poll list" lines grpcio prints straight to
+#   stderr after a fork (multiprocessing / pytest-xdist) when a channel exists
+#   (OTLP gRPC exporter, qdrant gRPC, deepeval). These bypass Python logging,
+#   so the C-core verbosity knob is the only way to quiet them. setdefault
+#   preserves an explicit operator override (e.g. GRPC_VERBOSITY=DEBUG).
 # =============================================================================
 os.environ.setdefault("DEEPEVAL_TELEMETRY_OPT_OUT", "YES")
 os.environ.setdefault(
     "SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS", "true"
 )
+os.environ.setdefault("GRPC_VERBOSITY", "ERROR")
 
 from importlib.metadata import PackageNotFoundError, version
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,0 +1,16 @@
+"""Unit tests for the CLI root module (``holodeck.cli.main``)."""
+
+import os
+
+
+def test_grpc_verbosity_defaulted_to_error() -> None:
+    """Importing the CLI entrypoint defaults gRPC's C-core to ERROR verbosity.
+
+    This silences the INFO ``FD from fork parent still in poll list`` lines that
+    grpcio prints straight to stderr after a fork (multiprocessing / pytest-xdist)
+    when a gRPC channel exists. The default is applied at import time via
+    ``os.environ.setdefault`` in ``holodeck.cli.main``.
+    """
+    import holodeck.cli.main  # noqa: F401  (import triggers the env defaults)
+
+    assert os.environ.get("GRPC_VERBOSITY") == "ERROR"


### PR DESCRIPTION
## Summary

gRPC's C-core prints INFO lines straight to **stderr** after a `fork()` when a gRPC channel exists, e.g.:

```
I0620 12:55:51.360344 6389987 ev_poll_posix.cc:593] FD from fork parent still in poll list: fd(13, generation: 1)
```

These come from grpcio's poll-based event engine noticing file descriptors inherited across a fork (`multiprocessing` / `pytest-xdist`). In HoloDeck a gRPC channel is created by the **OTLP gRPC exporter** (base dep), **qdrant-client** (gRPC mode), or **deepeval**. The lines **bypass Python logging**, so `-q`/`-v` and the logging config can't quiet them — only gRPC's own verbosity knob can.

## Change

Default `GRPC_VERBOSITY=ERROR` in the CLI entrypoint's pre-import env block (alongside the existing `DEEPEVAL_TELEMETRY_OPT_OUT` / Semantic Kernel defaults). `setdefault` preserves an explicit operator override (e.g. `GRPC_VERBOSITY=DEBUG` when debugging gRPC).

- `ERROR` keeps genuine gRPC errors; only the INFO/fork noise is suppressed.
- Set before library imports so it's in place before any gRPC channel initializes.

## Testing

- `tests/unit/cli/test_main.py` — asserts the default is applied on import.
- Verified the override is preserved (`GRPC_VERBOSITY=DEBUG` stays `DEBUG`).
- `tests/unit/cli` (443) green; `make format`/`lint`/`type-check` clean.

## Notes

- Independent of #345 (optimizer progress stream); branched off `main`.
- Relevant context: the gRPC fork noise was one of the motivating examples in `specs/038-optimizer-progress-stream/spec.md` for why scraping stdout is brittle. These lines are on stderr, so they never polluted the `--progress json` stdout stream — this just cleans up the stderr/log side.